### PR TITLE
[SDMEXT-764] Exception messages on UI

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -9,6 +9,23 @@ public class SDMConstants {
   public static final String BEARER_TOKEN = "Bearer ";
 
   public static final String TENANT_ID = "X-zid";
-  public static final String DUPLICATE_FILES_ERROR =
-      "The following files %s already present.Remove the file from draft or Rename the attachment to continue.";
+  public static final String DUPLICATE_FILES_ERROR = "%s already exists.";
+  public static final String GENERIC_ERROR = "Could not %s the document.";
+  public static final String VERSIONED_REPO_ERROR =
+      "Upload not supported for versioned repositories.";
+  public static final String VIRUS_ERROR = "%s contains potential malware and cannot be uploaded.";
+  public static final String REPOSITORY_ERROR = "Failed to get repository info.";
+  public static final String NOT_FOUND_ERROR = "Failed to read document.";
+
+  public static String getDuplicateFilesError(String filename) {
+    return String.format(DUPLICATE_FILES_ERROR, filename);
+  }
+
+  public static String getGenericError(String event) {
+    return String.format(GENERIC_ERROR, event);
+  }
+
+  public static String getVirusFilesError(String filename) {
+    return String.format(VIRUS_ERROR, filename);
+  }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -56,7 +56,7 @@ public class SDMServiceImpl implements SDMService {
           cmisDocument, client, requestBody, sdmUrl, accessToken, finalResponse);
 
     } catch (IOException e) {
-      throw new ServiceException("Could not upload");
+      throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
     return new JSONObject(finalResponse);
   }
@@ -114,7 +114,7 @@ public class SDMServiceImpl implements SDMService {
       }
 
     } catch (IOException e) {
-      throw new ServiceException("Could not upload");
+      throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
   }
 
@@ -249,10 +249,11 @@ public class SDMServiceImpl implements SDMService {
             .build();
 
     try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful()) throw new ServiceException("Could not upload");
+      if (!response.isSuccessful())
+        throw new ServiceException(SDMConstants.getGenericError("upload"));
       return response.body().string();
     } catch (IOException e) {
-      throw new ServiceException("Could not upload");
+      throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
   }
 
@@ -294,12 +295,12 @@ public class SDMServiceImpl implements SDMService {
 
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {
-        throw new ServiceException("Failed to get repository info");
+        throw new ServiceException(SDMConstants.REPOSITORY_ERROR);
       }
       String responseBody = response.body().string();
       return new JSONObject(responseBody);
     } catch (IOException e) {
-      throw new ServiceException("Failed to get repository info");
+      throw new ServiceException(SDMConstants.REPOSITORY_ERROR);
     }
   }
 
@@ -345,7 +346,7 @@ public class SDMServiceImpl implements SDMService {
     try (Response response = client.newCall(request).execute()) {
       return response.code();
     } catch (IOException e) {
-      throw new ServiceException("Could not delete the document");
+      throw new ServiceException(SDMConstants.getGenericError("delete"));
     }
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -78,6 +78,7 @@ public class SDMServiceImpl implements SDMService {
 
     try (Response response = client.newCall(request).execute()) {
       String status = "success";
+      String error = "";
       String name = cmisDocument.getFileName();
       String id = cmisDocument.getAttachmentId();
       String objectId = "";
@@ -93,6 +94,7 @@ public class SDMServiceImpl implements SDMService {
           status = "virus";
         } else {
           status = "fail";
+          error = message;
         }
       } else {
         String responseBody = response.body().string();
@@ -106,6 +108,7 @@ public class SDMServiceImpl implements SDMService {
       finalResponse.put("name", name);
       finalResponse.put("id", id);
       finalResponse.put("status", status);
+      finalResponse.put("message", error);
       if (!objectId.isEmpty()) {
         finalResponse.put("url", objectId);
       }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -63,8 +63,8 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       if (!result.list().isEmpty()) {
         MediaData data = context.getData();
 
-        String filename = data.getFileName(); // This will return "sample.pdf"
-        String fileid = (String) attachmentIds.get("ID"); // A
+        String filename = data.getFileName(); 
+        String fileid = (String) attachmentIds.get("ID"); 
 
         Boolean duplicate = duplicateCheck(filename, fileid, result);
         if (Boolean.TRUE.equals(duplicate)) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -89,12 +89,12 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
               sdmService.createDocument(cmisDocument, jwtToken, sdmCredentials);
 
           if (createResult.get("status") == "duplicate") {
-            throw new ServiceException(filename + "already exists.");
+            throw new ServiceException(filename + " already exists.");
           } else if (createResult.get("status") == "virus") {
             throw new ServiceException(
-                filename + "contains potential malware and cannot be uploaded");
+                filename + " contains potential malware and cannot be uploaded");
           } else if (createResult.get("status") == "fail") {
-            throw new ServiceException(filename + "cannot be uploaded");
+            throw new ServiceException(filename + " cannot be uploaded");
           } else {
             cmisDocument.setObjectId(createResult.get("url").toString());
             addAttachmentToDraft(attachmentDraftEntity.get(), persistenceService, cmisDocument);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -63,8 +63,9 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       if (!result.list().isEmpty()) {
         MediaData data = context.getData();
 
-        String filename = data.getFileName(); 
-        String fileid = (String) attachmentIds.get("ID"); 
+        String filename = data.getFileName();
+        String fileid = (String) attachmentIds.get("ID");
+        String errorMessageDI = "";
 
         Boolean duplicate = duplicateCheck(filename, fileid, result);
         if (Boolean.TRUE.equals(duplicate)) {
@@ -94,7 +95,8 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
             throw new ServiceException(
                 filename + " contains potential malware and cannot be uploaded");
           } else if (createResult.get("status") == "fail") {
-            throw new ServiceException(filename + " cannot be uploaded");
+            errorMessageDI = createResult.get("message").toString();
+            throw new ServiceException(errorMessageDI);
           } else {
             cmisDocument.setObjectId(createResult.get("url").toString());
             addAttachmentToDraft(attachmentDraftEntity.get(), persistenceService, cmisDocument);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -68,7 +68,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
 
         Boolean duplicate = duplicateCheck(filename, fileid, result);
         if (Boolean.TRUE.equals(duplicate)) {
-          throw new ServiceException("The attachment '" + filename + "' already exists.");
+          throw new ServiceException(filename + " already exists.");
         } else {
           AuthenticationInfo authInfo = context.getAuthenticationInfo();
           JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);
@@ -89,12 +89,12 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
               sdmService.createDocument(cmisDocument, jwtToken, sdmCredentials);
 
           if (createResult.get("status") == "duplicate") {
-            throw new ServiceException("The following file already exists and cannot be uploaded");
+            throw new ServiceException(filename + "already exists.");
           } else if (createResult.get("status") == "virus") {
             throw new ServiceException(
-                "The following file contains potential malware and cannot be uploaded");
+                filename + "contains potential malware and cannot be uploaded");
           } else if (createResult.get("status") == "fail") {
-            throw new ServiceException("The following file cannot be uploaded");
+            throw new ServiceException(filename + "cannot be uploaded");
           } else {
             cmisDocument.setObjectId(createResult.get("url").toString());
             addAttachmentToDraft(attachmentDraftEntity.get(), persistenceService, cmisDocument);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -63,13 +63,12 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       if (!result.list().isEmpty()) {
         MediaData data = context.getData();
 
-        String filename = (String) data.get("fileName");
-        String fileid = (String) attachmentIds.get("ID");
+        String filename = data.getFileName(); // This will return "sample.pdf"
+        String fileid = (String) attachmentIds.get("ID"); // A
 
         Boolean duplicate = duplicateCheck(filename, fileid, result);
         if (Boolean.TRUE.equals(duplicate)) {
-          throw new ServiceException(
-              "This attachment already exists. Please remove it and try again");
+          throw new ServiceException("The attachment '" + filename + "' already exists.");
         } else {
           AuthenticationInfo authInfo = context.getAuthenticationInfo();
           JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -51,7 +51,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     String repocheck = sdmService.checkRepositoryType(repositoryId);
     CmisDocument cmisDocument = new CmisDocument();
     if ("Versioned".equals(repocheck)) {
-      throw new ServiceException("Upload not supported for versioned repositories");
+      throw new ServiceException(SDMConstants.VERSIONED_REPO_ERROR);
     } else {
       Map<String, Object> attachmentIds = context.getAttachmentIds();
       String upID = (String) attachmentIds.get("up__ID");
@@ -69,7 +69,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
 
         Boolean duplicate = duplicateCheck(filename, fileid, result);
         if (Boolean.TRUE.equals(duplicate)) {
-          throw new ServiceException(filename + " already exists.");
+          throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
         } else {
           AuthenticationInfo authInfo = context.getAuthenticationInfo();
           JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);
@@ -90,10 +90,9 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
               sdmService.createDocument(cmisDocument, jwtToken, sdmCredentials);
 
           if (createResult.get("status") == "duplicate") {
-            throw new ServiceException(filename + " already exists.");
+            throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
           } else if (createResult.get("status") == "virus") {
-            throw new ServiceException(
-                filename + " contains potential malware and cannot be uploaded");
+            throw new ServiceException(SDMConstants.getVirusFilesError(filename));
           } else if (createResult.get("status") == "fail") {
             errorMessageDI = createResult.get("message").toString();
             throw new ServiceException(errorMessageDI);
@@ -159,7 +158,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     try {
       sdmService.readDocument(objectId, jwtToken, sdmCredentials, context);
     } catch (Exception e) {
-      throw new IOException("Failed to read document from SDM service", e);
+      throw new ServiceException(SDMConstants.NOT_FOUND_ERROR);
     }
     context.setCompleted();
   }

--- a/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -388,6 +388,7 @@ public class SDMServiceImplTest {
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
       expectedResponse.put("id", "attachmentId");
+      expectedResponse.put("message", "");
       expectedResponse.put("url", "objectId");
       expectedResponse.put("status", "success");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
@@ -436,6 +437,7 @@ public class SDMServiceImplTest {
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
       expectedResponse.put("id", "attachmentId");
+      expectedResponse.put("message", "");
       expectedResponse.put("status", "duplicate");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
     } finally {
@@ -484,6 +486,7 @@ public class SDMServiceImplTest {
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
       expectedResponse.put("id", "attachmentId");
+      expectedResponse.put("message", "");
       expectedResponse.put("status", "virus");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
     } finally {
@@ -532,6 +535,7 @@ public class SDMServiceImplTest {
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
       expectedResponse.put("id", "attachmentId");
+      expectedResponse.put("message", "An unexpected error occurred");
       expectedResponse.put("status", "fail");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
     } finally {

--- a/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -124,7 +124,7 @@ public class SDMServiceImplTest {
             () -> {
               SDMService.getRepositoryInfo(token, sdmCredentials);
             });
-    assertEquals("Failed to get repository info", exception.getMessage());
+    assertEquals("Failed to get repository info.", exception.getMessage());
 
     mockWebServer.shutdown();
   }
@@ -281,7 +281,7 @@ public class SDMServiceImplTest {
               () -> {
                 sdmServiceImpl.createFolder(parentId, jwtToken, repositoryId, sdmCredentials);
               });
-      assertEquals("Could not upload", exception.getMessage());
+      assertEquals("Could not upload the document.", exception.getMessage());
 
     } finally {
       mockWebServer.shutdown();
@@ -580,7 +580,7 @@ public class SDMServiceImplTest {
         fail("Expected ServiceException to be thrown");
       } catch (ServiceException e) {
         // Expected exception to be thrown
-        assertEquals("Could not upload", e.getMessage());
+        assertEquals("Could not upload the document.", e.getMessage());
       }
 
     } finally {
@@ -716,7 +716,7 @@ public class SDMServiceImplTest {
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(sdmCredentials);
       tokenHandlerMockedStatic
           .when(() -> TokenHandler.getDITokenUsingAuthorities(sdmCredentials, userEmail, subdomain))
-          .thenThrow(new IOException("Could not delete the document"));
+          .thenThrow(new IOException("Could not delete the document."));
 
       // Since the exception is thrown before OkHttpClient is used, no need to mock httpClient
       // behavior.
@@ -731,7 +731,7 @@ public class SDMServiceImplTest {
               });
 
       // Verify the exception message
-      assertEquals("Could not delete the document", thrown.getMessage());
+      assertEquals("Could not delete the document.", thrown.getMessage());
     }
   }
 

--- a/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -99,7 +99,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
     when(sdmService.checkRepositoryType(anyString())).thenReturn("Versioned");
     when(mockContext.getMessages()).thenReturn(mockMessages);
-    when(mockMessages.error("Upload not supported for versioned repositories"))
+    when(mockMessages.error("Upload not supported for versioned repositories."))
         .thenReturn(mockMessage);
     when(mockContext.getData()).thenReturn(mockMediaData);
     when(mockContext.getModel()).thenReturn(mockModel);
@@ -113,7 +113,7 @@ public class SDMAttachmentsServiceHandlerTest {
             });
 
     // Verify the exception message
-    assertEquals("Upload not supported for versioned repositories", thrown.getMessage());
+    assertEquals("Upload not supported for versioned repositories.", thrown.getMessage());
   }
 
   @Test
@@ -359,7 +359,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
       // Verify the exception message
       assertEquals(
-          "sample.pdf contains potential malware and cannot be uploaded", thrown.getMessage());
+          "sample.pdf contains potential malware and cannot be uploaded.", thrown.getMessage());
     }
   }
 
@@ -575,14 +575,14 @@ public class SDMAttachmentsServiceHandlerTest {
           .when(sdmService)
           .readDocument(anyString(), anyString(), any(SDMCredentials.class), eq(mockReadContext));
 
-      IOException exception =
+      ServiceException exception =
           assertThrows(
-              IOException.class,
+              ServiceException.class,
               () -> {
                 handlerSpy.readAttachment(mockReadContext);
               });
 
-      assertEquals("Failed to read document from SDM service", exception.getMessage());
+      assertEquals("Failed to read document.", exception.getMessage());
     }
   }
 

--- a/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -163,8 +163,7 @@ public class SDMAttachmentsServiceHandlerTest {
               });
 
       // Verify the exception message
-      assertEquals(
-          "This attachment already exists. Please remove it and try again", thrown.getMessage());
+      assertEquals("The attachment 'sample.pdf' already exists.", thrown.getMessage());
     }
   }
 

--- a/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -163,7 +163,7 @@ public class SDMAttachmentsServiceHandlerTest {
               });
 
       // Verify the exception message
-      assertEquals("The attachment 'sample.pdf' already exists.", thrown.getMessage());
+      assertEquals("sample.pdf already exists.", thrown.getMessage());
     }
   }
 
@@ -273,7 +273,7 @@ public class SDMAttachmentsServiceHandlerTest {
                 handlerSpy.createAttachment(mockContext);
               });
 
-      assertEquals("The following file already exists and cannot be uploaded", thrown.getMessage());
+      assertEquals("sample.pdf already exists.", thrown.getMessage());
 
       // Add any additional verifications if needed
     }
@@ -359,8 +359,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
       // Verify the exception message
       assertEquals(
-          "The following file contains potential malware and cannot be uploaded",
-          thrown.getMessage());
+          "sample.pdf contains potential malware and cannot be uploaded", thrown.getMessage());
     }
   }
 
@@ -383,6 +382,7 @@ public class SDMAttachmentsServiceHandlerTest {
     InputStream contentStream = new ByteArrayInputStream(byteArray);
     JSONObject mockCreateResult = new JSONObject();
     mockCreateResult.put("status", "fail");
+    mockCreateResult.put("message", "Failed due to a DI error");
     mockCreateResult.put("name", "sample.pdf");
 
     when(mockMediaData.getFileName()).thenReturn("sample.pdf");
@@ -428,7 +428,7 @@ public class SDMAttachmentsServiceHandlerTest {
               });
 
       // Verify the exception message
-      assertEquals("The following file cannot be uploaded", thrown.getMessage());
+      assertEquals("Failed due to a DI error", thrown.getMessage());
     }
   }
 


### PR DESCRIPTION
This PR modifies the exception messages to make them more intuitive, and throws the exact error message that is received from DI in case the error is neither duplicate nor virus. Exception messages are now visible on the UI after the latest UI5 update.

[Link to JIRA BL](https://jira.tools.sap/browse/SDMEXT-764)