### PR TITLE
FixVirusError

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -88,10 +88,11 @@ public class SDMServiceImpl implements SDMService {
         JSONObject jsonResponse = new JSONObject(responseBody);
         String message = jsonResponse.getString("message");
 
-        if (response.code() == 409) {
-          status = "duplicate";
-        } else if ("Malware Service Exception: Virus found in the file!".equals(message)) {
+        if (response.code() == 409
+            && "Malware Service Exception: Virus found in the file!".equals(message)) {
           status = "virus";
+        } else if (response.code() == 409) {
+          status = "duplicate";
         } else {
           status = "fail";
           error = message;

--- a/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -456,7 +456,7 @@ public class SDMServiceImplTest {
       mockWebServer.enqueue(
           new MockResponse()
               .setBody(mockResponseBody)
-              .setResponseCode(400) // Assuming 400 Bad Request or a similar client error code
+              .setResponseCode(409)
               .addHeader("Content-Type", "application/json"));
 
       CmisDocument cmisDocument = new CmisDocument();


### PR DESCRIPTION
Earlier we had a check for status code == 409 for dupliacte in if and then second check else-if for virus message. Although DI throws same error-code 409 in both duplicate & virus. So even when we were uploading virus-file we were getting 409 and if block was getting executing resulting in duplicate message on UI. So added an additional check of status code as well as message in case of virus files.