### PR TITLE
Snapshot version update

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,9 +6,7 @@ env:
 
 on:
   push:
-    branches: [ "testversion" ]
-  pull_request:
-    branches: [ "testversion" ]
+    branches: [ "develop" ]
   workflow_dispatch:
 
 jobs:
@@ -60,7 +58,7 @@ jobs:
         shell: bash
 
       - name: Check and Update Version
-        if: github.ref == 'refs/heads/testversion'
+        if: github.ref == 'refs/heads/develop'
         id: check-and-update-version
         run: |
           current_version=${{ env.REVISION }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,7 +6,9 @@ env:
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "testversion" ]
+  pull_request:
+    branches: [ "testversion" ]
   workflow_dispatch:
 
 jobs:
@@ -26,10 +28,10 @@ jobs:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ env.MAVEN_VERSION }}
 
-  deploy-snapshot:
-    name: Deploy snapshot to Artifactory
+  update-version:
+    name: Update version
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [ build ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,16 +54,57 @@ jobs:
       - name: Get Revision
         id: get-revision
         run: |
-          echo "REVISION=$(mvn help:evaluate -Dexpression=revision -q -DforceStdout)" >> $GITHUB_OUTPUT
+          current_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current version: $current_version"
+          echo "REVISION=$current_version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Print Revision
-        run: echo "Current revision ${{ steps.get-revision.outputs.REVISION }}"
+      - name: Check and Update Version
+        if: github.ref == 'refs/heads/testversion'
+        id: check-and-update-version
+        run: |
+          current_version=${{ env.REVISION }}
+
+          # Check if the version already contains '-SNAPSHOT'
+          if [[ $current_version != *-SNAPSHOT ]]; then
+            echo "Current version does not contain -SNAPSHOT, updating version..."
+
+            # Split version into major, minor, and patch parts
+            IFS='.' read -r major minor patch <<< "$(echo $current_version | tr '-' '.')"
+
+            # Increment the patch number
+            new_patch=$((patch + 1))
+
+            # Form the new version
+            new_version="${major}.${minor}.${new_patch}-SNAPSHOT"
+
+            # Update the <revision> property in pom.xml
+            sed -i "s|<revision>.*</revision>|<revision>${new_version}</revision>|" pom.xml
+
+            echo "Updated version to $new_version"
+
+            # Commit the version change
+            git config --local user.name "github-actions"
+            git config --local user.email "github-actions@github.com"
+            git add pom.xml
+            git commit -m "Increment version to ${new_version}"
+            git push origin HEAD:testversion
+          else
+            echo "Current version already contains -SNAPSHOT, no update needed."
+          fi
+
+          # Export the updated or original version
+          updated_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "UPDATED_VERSION=$updated_version" >> $GITHUB_ENV
         shell: bash
-  
+
+      - name: Print Updated Version
+        run: |
+          echo "Updated version: ${{ env.UPDATED_VERSION }}"
+        shell: bash
+
       - name: Deploy snapshot
-        if: ${{ endsWith(steps.get-revision.outputs.REVISION, '-SNAPSHOT') }}
-        # https://maven.apache.org/plugins/maven-deploy-plugin/usage.html#the-deploy-deploy-mojo
+        if: ${{ endsWith(env.UPDATED_VERSION, '-SNAPSHOT') }}
         run: |
           mvn -B -ntp -fae -Dmaven.install.skip=true -Dmaven.test.skip=true -DdeployAtEnd=true deploy
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   sonar-scan:
-    runs-on: cap-java
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -37,9 +37,9 @@ jobs:
       - name: Install SonarQube Scanner
         run: |
           if [ ! -L /usr/local/bin/sonar-scanner ]; then
-            curl -sSLo sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip
+            curl -sSLo sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
             unzip sonar-scanner-cli.zip
-            sudo mv sonar-scanner-4.7.0.2747-linux /opt/sonar-scanner
+            sudo mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
             sudo ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
           fi
 


### PR DESCRIPTION
Updated the workflow so that version will get change after the release to "*-SNAPSHOT"

For example :
if we released 1.0.1 to maven then in next run of snapshot workflow , It'll first update the version in pom from 1.0.1 to 1.0.2-SNAPSHOT.

if we released 1.0.2 to maven then in next run of snapshot workflow , It'll first update the version in pom from 1.0.2 to 1.0.3-SNAPSHOT.

Due to this we don't have to change the version after central maven release for the snapshot.

Testing has been done: https://github.com/cap-java/sdm/actions/runs/12742507953/job/35510771114 