### PR TITLE
[SNOW:DINC0374643] Adding a check for sdm roles while renaming attachments

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -7,7 +7,7 @@ public class SDMConstants {
     // Doesn't do anything
   }
 
-  public static final String REPOSITORY_ID = "e7d35bdc-772b-4d88-83c5-d70a7ffc2dd8";
+  public static final String REPOSITORY_ID = System.getenv("REPOSITORY_ID");
   public static final String BEARER_TOKEN = "Bearer ";
   public static final int TIMEOUT = 900;
 

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -7,7 +7,7 @@ public class SDMConstants {
     // Doesn't do anything
   }
 
-  public static final String REPOSITORY_ID = System.getenv("REPOSITORY_ID");
+  public static final String REPOSITORY_ID = "e7d35bdc-772b-4d88-83c5-d70a7ffc2dd8";
   public static final String BEARER_TOKEN = "Bearer ";
   public static final int TIMEOUT = 900;
 
@@ -27,6 +27,8 @@ public class SDMConstants {
   public static final String NOT_FOUND_ERROR = "Failed to read document.";
   public static final String NAME_CONSTRAINT_WARNING_MESSAGE =
       "Enter a valid file name for %s. The following characters are not supported: /, \\";
+  public static final String SDM_MISSING_ROLES_EXCEPTION_MSG =
+      "You do not have the required permissions to rename attachments. Kindly contact the admin";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -29,6 +29,8 @@ public class SDMConstants {
       "Enter a valid file name for %s. The following characters are not supported: /, \\";
   public static final String SDM_MISSING_ROLES_EXCEPTION_MSG =
       "You do not have the required permissions to rename attachments. Kindly contact the admin";
+  public static final String SDM_ROLES_ERROR_MESSAGE =
+      "Unable to rename the file due to an error at the server";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
@@ -7,6 +7,7 @@ import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.utilities.SDMUtils;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.authentication.AuthenticationInfo;
 import com.sap.cds.services.authentication.JwtTokenAuthenticationInfo;
 import com.sap.cds.services.cds.ApplicationService;
@@ -98,6 +99,10 @@ public class SDMCreateAttachmentsHandler implements EventHandler {
         cmisDocument.setFileName(filenameInRequest);
         cmisDocument.setObjectId(objectId);
         int responseCode = sdmService.renameAttachments(jwtToken, sdmCredentials, cmisDocument);
+        if (responseCode == 403) {
+          // SDM Roles for user are missing
+          throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
+        }
         if (responseCode == 409) {
           duplicateFileNameList.add(filenameInRequest);
           attachment.replace("fileName", fileNameInSDM);

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
@@ -99,13 +99,23 @@ public class SDMCreateAttachmentsHandler implements EventHandler {
         cmisDocument.setFileName(filenameInRequest);
         cmisDocument.setObjectId(objectId);
         int responseCode = sdmService.renameAttachments(jwtToken, sdmCredentials, cmisDocument);
-        if (responseCode == 403) {
-          // SDM Roles for user are missing
-          throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
-        }
-        if (responseCode == 409) {
-          duplicateFileNameList.add(filenameInRequest);
-          attachment.replace("fileName", fileNameInSDM);
+        switch (responseCode) {
+          case 403:
+            // SDM Roles for user are missing
+            throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
+
+          case 409:
+            duplicateFileNameList.add(filenameInRequest);
+            attachment.replace("fileName", fileNameInSDM);
+            break;
+
+          case 200:
+          case 201:
+            // Success cases, do nothing
+            break;
+
+          default:
+            throw new ServiceException(SDMConstants.SDM_ROLES_ERROR_MESSAGE, null);
         }
       }
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
@@ -11,6 +11,7 @@ import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.utilities.SDMUtils;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.authentication.AuthenticationInfo;
 import com.sap.cds.services.authentication.JwtTokenAuthenticationInfo;
 import com.sap.cds.services.cds.ApplicationService;
@@ -126,6 +127,10 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
               context.getAuthenticationInfo().as(JwtTokenAuthenticationInfo.class).getToken(),
               TokenHandler.getSDMCredentials(),
               cmisDocument);
+      if (responseCode == 403) {
+        // SDM Roles for user are missing
+        throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
+      }
       if (responseCode == 409) {
         duplicateFileNameList.add(filenameInRequest);
         attachment.replace("fileName", fileNameInSDM);

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
@@ -148,7 +148,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
     }
   }
 
-  public String getFileNameInSDM(
+  private String getFileNameInSDM(
       CdsUpdateEventContext context, String fileNameInDB, String objectId) throws IOException {
     AuthenticationInfo authInfo = context.getAuthenticationInfo();
     JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
@@ -100,7 +100,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
     }
   }
 
-  private void processAttachment(
+  public void processAttachment(
       Optional<CdsEntity> attachmentEntity,
       CdsUpdateEventContext context,
       Map<String, Object> attachment,
@@ -127,18 +127,28 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
               context.getAuthenticationInfo().as(JwtTokenAuthenticationInfo.class).getToken(),
               TokenHandler.getSDMCredentials(),
               cmisDocument);
-      if (responseCode == 403) {
-        // SDM Roles for user are missing
-        throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
-      }
-      if (responseCode == 409) {
-        duplicateFileNameList.add(filenameInRequest);
-        attachment.replace("fileName", fileNameInSDM);
+      switch (responseCode) {
+        case 403:
+          // SDM Roles for user are missing
+          throw new ServiceException(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, null);
+
+        case 409:
+          duplicateFileNameList.add(filenameInRequest);
+          attachment.replace("fileName", fileNameInSDM);
+          break;
+
+        case 200:
+        case 201:
+          // Success cases, do nothing
+          break;
+
+        default:
+          throw new ServiceException(SDMConstants.SDM_ROLES_ERROR_MESSAGE, null);
       }
     }
   }
 
-  private String getFileNameInSDM(
+  public String getFileNameInSDM(
       CdsUpdateEventContext context, String fileNameInDB, String objectId) throws IOException {
     AuthenticationInfo authInfo = context.getAuthenticationInfo();
     JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
@@ -1,479 +1,493 @@
-package integration.com.sap.cds.sdm;
+// package integration.com.sap.cds.sdm;
 
-import static org.junit.jupiter.api.Assertions.*;
+// import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import okhttp3.*;
-import org.junit.jupiter.api.*;
+// import com.fasterxml.jackson.databind.JsonNode;
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import java.io.File;
+// import java.io.IOException;
+// import java.nio.charset.StandardCharsets;
+// import java.util.*;
+// import okhttp3.*;
+// import org.junit.jupiter.api.*;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class AttachmentsSDMTest {
-  private static String token;
-  private static String entityID;
-  private static String entityID2;
-  private static String appUrl;
-  private static String authUrl;
-  private static String username;
-  private static String password;
-  private static String serviceName = "AdminService";
-  private static String entityName = "Books";
-  private static String srvpath = "AdminService";
-  private static Api api;
-  private static String attachmentID1 = "";
-  private static String attachmentID2 = "";
-  private static String attachmentID3 = "";
-  private static String attachmentID4 = "";
+// @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+// public class AttachmentsSDMTest {
+//   private static String token;
+//   private static String entityID;
+//   private static String entityID2;
+//   private static String appUrl;
+//   private static String authUrl;
+//   private static String username;
+//   private static String password;
+//   private static String serviceName = "AdminService";
+//   private static String entityName = "Books";
+//   private static String srvpath = "AdminService";
+//   private static Api api;
+//   private static String attachmentID1 = "";
+//   private static String attachmentID2 = "";
+//   private static String attachmentID3 = "";
+//   private static String attachmentID4 = "";
 
-  @BeforeAll
-  public static void setup() throws IOException {
-    // Define your clientId and clientSecret
-    Properties credentialsProperties = Credentials.getCredentials();
-    String clientId = credentialsProperties.getProperty("clientID");
-    String clientSecret = credentialsProperties.getProperty("clientSecret");
-    appUrl = credentialsProperties.getProperty("appUrl");
-    authUrl = credentialsProperties.getProperty("authUrl");
-    username = credentialsProperties.getProperty("username");
-    password = credentialsProperties.getProperty("password");
+//   @BeforeAll
+//   public static void setup() throws IOException {
+//     // Define your clientId and clientSecret
+//     Properties credentialsProperties = Credentials.getCredentials();
+//     String clientId = credentialsProperties.getProperty("clientID");
+//     String clientSecret = credentialsProperties.getProperty("clientSecret");
+//     appUrl = credentialsProperties.getProperty("appUrl");
+//     authUrl = credentialsProperties.getProperty("authUrl");
+//     username = credentialsProperties.getProperty("username");
+//     password = credentialsProperties.getProperty("password");
 
-    // Encode clientId:clientSecret to Base64
-    String credentials = clientId + ":" + clientSecret;
-    String basicAuth =
-        "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+//     // Encode clientId:clientSecret to Base64
+//     String credentials = clientId + ":" + clientSecret;
+//     String basicAuth =
+//         "Basic " +
+// Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-    OkHttpClient client = new OkHttpClient().newBuilder().build();
-    MediaType mediaType = MediaType.parse("text/plain");
-    RequestBody body = RequestBody.create(mediaType, "");
-    Request request =
-        new Request.Builder()
-            .url(
-                authUrl
-                    + "/oauth/token?grant_type=password&username="
-                    + username
-                    + "&password="
-                    + password)
-            .method("POST", body)
-            .addHeader("Authorization", basicAuth)
-            .build();
-    Response response = client.newCall(request).execute();
-    if (response.code() != 200) {
-      System.out.println("Token generation failed. Response code: " + response.code());
-      String errorBody = response.body().string();
-      System.out.println("Error body: " + errorBody);
-    }
-    token = new ObjectMapper().readTree(response.body().string()).get("access_token").asText();
-    response.close();
-    Map<String, String> config = new HashMap<>();
-    config.put("Authorization", "Bearer " + token);
-    api = new Api(config);
-  }
+//     OkHttpClient client = new OkHttpClient().newBuilder().build();
+//     MediaType mediaType = MediaType.parse("text/plain");
+//     RequestBody body = RequestBody.create(mediaType, "");
+//     Request request =
+//         new Request.Builder()
+//             .url(
+//                 authUrl
+//                     + "/oauth/token?grant_type=password&username="
+//                     + username
+//                     + "&password="
+//                     + password)
+//             .method("POST", body)
+//             .addHeader("Authorization", basicAuth)
+//             .build();
+//     Response response = client.newCall(request).execute();
+//     if (response.code() != 200) {
+//       System.out.println("Token generation failed. Response code: " + response.code());
+//       String errorBody = response.body().string();
+//       System.out.println("Error body: " + errorBody);
+//     }
+//     token = new ObjectMapper().readTree(response.body().string()).get("access_token").asText();
+//     response.close();
+//     Map<String, String> config = new HashMap<>();
+//     config.put("Authorization", "Bearer " + token);
+//     api = new Api(config);
+//   }
 
-  @Test
-  @Order(1)
-  public void testCreateEntityAndCheck() throws IOException {
-    System.out.println("Test (1) : Create entity and check if it exists");
-    Boolean testStatus = false;
-    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
-    if (response != "Could not create entity") {
-      entityID = response;
-      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-      if (response == "Saved") {
-        response = api.checkEntity(appUrl, serviceName, entityName, entityID);
-        if (response.equals("Entity exists")) {
-          testStatus = true;
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not create entity");
-    }
-  }
+//   @Test
+//   @Order(1)
+//   public void testCreateEntityAndCheck() throws IOException {
+//     System.out.println("Test (1) : Create entity and check if it exists");
+//     Boolean testStatus = false;
+//     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+//     if (response != "Could not create entity") {
+//       entityID = response;
+//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//       if (response == "Saved") {
+//         response = api.checkEntity(appUrl, serviceName, entityName, entityID);
+//         if (response.equals("Entity exists")) {
+//           testStatus = true;
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not create entity");
+//     }
+//   }
 
-  @Test
-  @Order(2)
-  public void testUpdateEmptyEntity() throws IOException {
-    System.out.println("Test (2) : Update an existing entity");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-      if (response == "Saved") {
-        response = api.checkEntity(appUrl, serviceName, entityName, entityID);
-        if (response.equals("Entity exists")) {
-          testStatus = true;
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not update entity");
-    }
-  }
+//   @Test
+//   @Order(2)
+//   public void testUpdateEmptyEntity() throws IOException {
+//     System.out.println("Test (2) : Update an existing entity");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//       if (response == "Saved") {
+//         response = api.checkEntity(appUrl, serviceName, entityName, entityID);
+//         if (response.equals("Entity exists")) {
+//           testStatus = true;
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not update entity");
+//     }
+//   }
 
-  @Test
-  @Order(3)
-  public void testUploadSingleAttachmentPDF() throws IOException {
-    System.out.println("Test (3) : Upload pdf");
-    Boolean testStatus = false;
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample.pdf").getFile());
+//   @Test
+//   @Order(3)
+//   public void testUploadSingleAttachmentPDF() throws IOException {
+//     System.out.println("Test (3) : Upload pdf");
+//     Boolean testStatus = false;
+//     ClassLoader classLoader = getClass().getClassLoader();
+//     File file = new File(classLoader.getResource("sample.pdf").getFile());
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID);
-    postData.put("mimeType", "application/pdf");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+//     Map<String, Object> postData = new HashMap<>();
+//     postData.put("up__ID", entityID);
+//     postData.put("mimeType", "application/pdf");
+//     postData.put("createdAt", new Date().toString());
+//     postData.put("createdBy", "test@test.com");
+//     postData.put("modifiedBy", "test@test.com");
 
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      List<String> createResponse =
-          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
-      String check = createResponse.get(0);
-      if (check.equals("Attachment created")) {
-        attachmentID1 = createResponse.get(1);
-        response =
-            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID1);
-        if (response.equals("OK")) {
-          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-          if (response.equals("Saved")) {
-            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID1);
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       List<String> createResponse =
+//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
+// file);
+//       String check = createResponse.get(0);
+//       if (check.equals("Attachment created")) {
+//         attachmentID1 = createResponse.get(1);
+//         response =
+//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID1);
+//         if (response.equals("OK")) {
+//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//           if (response.equals("Saved")) {
+//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID1);
 
-            if (response.equals("OK")) {
-              testStatus = true;
-            }
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not upload sample.pdf " + response);
-    }
-  }
+//             if (response.equals("OK")) {
+//               testStatus = true;
+//             }
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not upload sample.pdf " + response);
+//     }
+//   }
 
-  @Test
-  @Order(4)
-  public void testUploadSingleAttachmentTXT() throws IOException {
-    System.out.println("Test (4) : Upload txt");
-    Boolean testStatus = false;
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample.txt").getFile());
+//   @Test
+//   @Order(4)
+//   public void testUploadSingleAttachmentTXT() throws IOException {
+//     System.out.println("Test (4) : Upload txt");
+//     Boolean testStatus = false;
+//     ClassLoader classLoader = getClass().getClassLoader();
+//     File file = new File(classLoader.getResource("sample.txt").getFile());
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID);
-    postData.put("mimeType", "application/txt");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+//     Map<String, Object> postData = new HashMap<>();
+//     postData.put("up__ID", entityID);
+//     postData.put("mimeType", "application/txt");
+//     postData.put("createdAt", new Date().toString());
+//     postData.put("createdBy", "test@test.com");
+//     postData.put("modifiedBy", "test@test.com");
 
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      List<String> createResponse =
-          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
-      String check = createResponse.get(0);
-      if (check.equals("Attachment created")) {
-        attachmentID2 = createResponse.get(1);
-        response =
-            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID2);
-        if (response.equals("OK")) {
-          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-          if (response.equals("Saved")) {
-            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID2);
-            if (response.equals("OK")) {
-              testStatus = true;
-            }
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not upload sample.txt");
-    }
-  }
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       List<String> createResponse =
+//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
+// file);
+//       String check = createResponse.get(0);
+//       if (check.equals("Attachment created")) {
+//         attachmentID2 = createResponse.get(1);
+//         response =
+//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID2);
+//         if (response.equals("OK")) {
+//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//           if (response.equals("Saved")) {
+//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID2);
+//             if (response.equals("OK")) {
+//               testStatus = true;
+//             }
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not upload sample.txt");
+//     }
+//   }
 
-  @Test
-  @Order(5)
-  public void testUploadSingleAttachmentEXE() throws IOException {
-    System.out.println("Test (5) : Upload exe");
-    Boolean testStatus = false;
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample.exe").getFile());
+//   @Test
+//   @Order(5)
+//   public void testUploadSingleAttachmentEXE() throws IOException {
+//     System.out.println("Test (5) : Upload exe");
+//     Boolean testStatus = false;
+//     ClassLoader classLoader = getClass().getClassLoader();
+//     File file = new File(classLoader.getResource("sample.exe").getFile());
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID);
-    postData.put("mimeType", "application/exe");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+//     Map<String, Object> postData = new HashMap<>();
+//     postData.put("up__ID", entityID);
+//     postData.put("mimeType", "application/exe");
+//     postData.put("createdAt", new Date().toString());
+//     postData.put("createdBy", "test@test.com");
+//     postData.put("modifiedBy", "test@test.com");
 
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      List<String> createResponse =
-          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
-      String check = createResponse.get(0);
-      if (check.equals("Attachment created")) {
-        attachmentID3 = createResponse.get(1);
-        response =
-            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID3);
-        if (response.equals("OK")) {
-          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-          if (response.equals("Saved")) {
-            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID3);
-            if (response.equals("OK")) {
-              testStatus = true;
-            }
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not create sample.exe");
-    }
-  }
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       List<String> createResponse =
+//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
+// file);
+//       String check = createResponse.get(0);
+//       if (check.equals("Attachment created")) {
+//         attachmentID3 = createResponse.get(1);
+//         response =
+//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID3);
+//         if (response.equals("OK")) {
+//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//           if (response.equals("Saved")) {
+//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID3);
+//             if (response.equals("OK")) {
+//               testStatus = true;
+//             }
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not create sample.exe");
+//     }
+//   }
 
-  @Test
-  @Order(6)
-  public void testUploadSingleAttachmentPDFDuplicate() throws IOException {
-    System.out.println("Test (6) : Upload duplicate pdf");
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample.pdf").getFile());
-    Boolean testStatus = false;
+//   @Test
+//   @Order(6)
+//   public void testUploadSingleAttachmentPDFDuplicate() throws IOException {
+//     System.out.println("Test (6) : Upload duplicate pdf");
+//     ClassLoader classLoader = getClass().getClassLoader();
+//     File file = new File(classLoader.getResource("sample.pdf").getFile());
+//     Boolean testStatus = false;
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID);
-    postData.put("mimeType", "application/pdf");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+//     Map<String, Object> postData = new HashMap<>();
+//     postData.put("up__ID", entityID);
+//     postData.put("mimeType", "application/pdf");
+//     postData.put("createdAt", new Date().toString());
+//     postData.put("createdBy", "test@test.com");
+//     postData.put("modifiedBy", "test@test.com");
 
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      List<String> createResponse =
-          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
-      String check = createResponse.get(0);
-      if (check.equals("Attachment created")) {
-        testStatus = false;
-      } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        if (response.equals("Saved")) {
-          String expectedJson =
-              "{\"error\":{\"code\":\"500\",\"message\":\"sample.pdf already exists.\"}}";
-          ObjectMapper objectMapper = new ObjectMapper();
-          JsonNode actualJsonNode = objectMapper.readTree(check);
-          JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
-          if (expectedJsonNode.equals(actualJsonNode)) {
-            testStatus = true;
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Attachment was created");
-    }
-  }
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       List<String> createResponse =
+//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
+// file);
+//       String check = createResponse.get(0);
+//       if (check.equals("Attachment created")) {
+//         testStatus = false;
+//       } else {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         if (response.equals("Saved")) {
+//           String expectedJson =
+//               "{\"error\":{\"code\":\"500\",\"message\":\"sample.pdf already exists.\"}}";
+//           ObjectMapper objectMapper = new ObjectMapper();
+//           JsonNode actualJsonNode = objectMapper.readTree(check);
+//           JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
+//           if (expectedJsonNode.equals(actualJsonNode)) {
+//             testStatus = true;
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Attachment was created");
+//     }
+//   }
 
-  @Test
-  @Order(7)
-  public void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
-    System.out.println("Test (7) : Upload duplicate pdf in different entity");
-    Boolean testStatus = false;
-    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
-    if (response != "Could not create entity") {
-      entityID2 = response;
-      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-      if (response == "Saved") {
-        response = api.checkEntity(appUrl, serviceName, entityName, entityID2);
-        if (response.equals("Entity exists")) {
-          testStatus = true;
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not create entity");
-    }
+//   @Test
+//   @Order(7)
+//   public void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
+//     System.out.println("Test (7) : Upload duplicate pdf in different entity");
+//     Boolean testStatus = false;
+//     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+//     if (response != "Could not create entity") {
+//       entityID2 = response;
+//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+//       if (response == "Saved") {
+//         response = api.checkEntity(appUrl, serviceName, entityName, entityID2);
+//         if (response.equals("Entity exists")) {
+//           testStatus = true;
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not create entity");
+//     }
 
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample.pdf").getFile());
+//     ClassLoader classLoader = getClass().getClassLoader();
+//     File file = new File(classLoader.getResource("sample.pdf").getFile());
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID2);
-    postData.put("mimeType", "application/pdf");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+//     Map<String, Object> postData = new HashMap<>();
+//     postData.put("up__ID", entityID2);
+//     postData.put("mimeType", "application/pdf");
+//     postData.put("createdAt", new Date().toString());
+//     postData.put("createdBy", "test@test.com");
+//     postData.put("modifiedBy", "test@test.com");
 
-    response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-    if (response == "Entity in draft mode") {
-      List<String> createResponse =
-          api.createAttachment(appUrl, serviceName, entityName, entityID2, srvpath, postData, file);
-      String check = createResponse.get(0);
-      if (check.equals("Attachment created")) {
-        attachmentID4 = createResponse.get(1);
-        response =
-            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID2, attachmentID4);
-        if (response.equals("OK")) {
-          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-          if (response.equals("Saved")) {
-            response =
-                api.readAttachment(appUrl, serviceName, entityName, entityID2, attachmentID4);
+//     response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+//     if (response == "Entity in draft mode") {
+//       List<String> createResponse =
+//           api.createAttachment(appUrl, serviceName, entityName, entityID2, srvpath, postData,
+// file);
+//       String check = createResponse.get(0);
+//       if (check.equals("Attachment created")) {
+//         attachmentID4 = createResponse.get(1);
+//         response =
+//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID2, attachmentID4);
+//         if (response.equals("OK")) {
+//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+//           if (response.equals("Saved")) {
+//             response =
+//                 api.readAttachment(appUrl, serviceName, entityName, entityID2, attachmentID4);
 
-            if (response.equals("OK")) {
-              testStatus = true;
-            }
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not upload sample.pdf " + response);
-    }
-  }
+//             if (response.equals("OK")) {
+//               testStatus = true;
+//             }
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not upload sample.pdf " + response);
+//     }
+//   }
 
-  @Test
-  @Order(8)
-  public void testRenameSingleAttachment() throws IOException {
-    System.out.println("Test (8) : Rename single attachment");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    String name = "sample123";
-    if (response == "Entity in draft mode") {
-      response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID1, name);
-      if (response.equals("Renamed")) {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        if (response.equals("Saved")) {
-          testStatus = true;
-        }
-      } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-      }
-    }
-    if (!testStatus) {
-      fail("Attachment was not renamed");
-    }
-  }
+//   @Test
+//   @Order(8)
+//   public void testRenameSingleAttachment() throws IOException {
+//     System.out.println("Test (8) : Rename single attachment");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     String name = "sample123";
+//     if (response == "Entity in draft mode") {
+//       response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID1, name);
+//       if (response.equals("Renamed")) {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         if (response.equals("Saved")) {
+//           testStatus = true;
+//         }
+//       } else {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Attachment was not renamed");
+//     }
+//   }
 
-  @Test
-  @Order(9)
-  public void testRenameMultipleAttachments() throws IOException {
-    System.out.println("Test (9) : Rename multiple attachments");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    String name1 = "sample1234";
-    String name2 = "sample12345";
-    if (response == "Entity in draft mode") {
-      String response1 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID2, name1);
-      String response2 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
-      if (response1.equals("Renamed") && response2.equals("Renamed")) {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        if (response.equals("Saved")) {
-          testStatus = true;
-        }
-      } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-      }
-    }
-    if (!testStatus) {
-      fail("Attachment was not renamed");
-    }
-  }
+//   @Test
+//   @Order(9)
+//   public void testRenameMultipleAttachments() throws IOException {
+//     System.out.println("Test (9) : Rename multiple attachments");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     String name1 = "sample1234";
+//     String name2 = "sample12345";
+//     if (response == "Entity in draft mode") {
+//       String response1 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID2,
+// name1);
+//       String response2 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3,
+// name2);
+//       if (response1.equals("Renamed") && response2.equals("Renamed")) {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         if (response.equals("Saved")) {
+//           testStatus = true;
+//         }
+//       } else {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Attachment was not renamed");
+//     }
+//   }
 
-  @Test
-  @Order(10)
-  public void testRenameSingleAttachmentDuplicate() throws IOException {
-    System.out.println("Test (10) : Rename single attachment duplicate");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    String name = "sample123";
-    String name2 = "sample123456";
-    if (response == "Entity in draft mode") {
-      response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name);
-      if (response.equals("Renamed")) {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        String expected =
-            "{\"error\":{\"code\":\"400\",\"message\":\"The file(s) sample123 have been added "
-                + "multiple times. Please rename and try again.\"}}";
-        if (response.equals(expected)) {
-          response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
-          if (response.equals("Renamed")) {
-            response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-            if (response.equals("Saved")) {
-              testStatus = true;
-            }
-          }
-        }
-      } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-      }
-    }
-    if (!testStatus) {
-      fail("Attachment was renamed");
-    }
-  }
+//   @Test
+//   @Order(10)
+//   public void testRenameSingleAttachmentDuplicate() throws IOException {
+//     System.out.println("Test (10) : Rename single attachment duplicate");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     String name = "sample123";
+//     String name2 = "sample123456";
+//     if (response == "Entity in draft mode") {
+//       response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name);
+//       if (response.equals("Renamed")) {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         String expected =
+//             "{\"error\":{\"code\":\"400\",\"message\":\"The file(s) sample123 have been added "
+//                 + "multiple times. Please rename and try again.\"}}";
+//         if (response.equals(expected)) {
+//           response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
+//           if (response.equals("Renamed")) {
+//             response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//             if (response.equals("Saved")) {
+//               testStatus = true;
+//             }
+//           }
+//         }
+//       } else {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Attachment was renamed");
+//     }
+//   }
 
-  @Test
-  @Order(11)
-  public void testDeleteSingleAttachment() throws IOException {
-    System.out.println("Test (11) : Delete single attachment");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      response = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID1);
-      if (response == "Deleted") {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        if (response == "Saved") {
-          response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID1);
-          if (response.equals("Could not read attachment")) {
-            testStatus = true;
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not delete attachment");
-    }
-  }
+//   @Test
+//   @Order(11)
+//   public void testDeleteSingleAttachment() throws IOException {
+//     System.out.println("Test (11) : Delete single attachment");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       response = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID1);
+//       if (response == "Deleted") {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         if (response == "Saved") {
+//           response = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID1);
+//           if (response.equals("Could not read attachment")) {
+//             testStatus = true;
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not delete attachment");
+//     }
+//   }
 
-  @Test
-  @Order(12)
-  public void testDeleteMultipleAttachments() throws IOException {
-    System.out.println("Test (12) : Delete multiple attachments");
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-    if (response == "Entity in draft mode") {
-      String response1 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID2);
-      String response2 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID3);
-      if (response1 == "Deleted" && response2 == "Deleted") {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-        if (response == "Saved") {
-          response1 = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID2);
-          response2 = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID3);
-          if (response1.equals("Could not read attachment")
-              && response2.equals("Could not read attachment")) {
-            testStatus = true;
-          }
-        }
-      }
-    }
-    if (!testStatus) {
-      fail("Could not delete attachment");
-    }
-  }
+//   @Test
+//   @Order(12)
+//   public void testDeleteMultipleAttachments() throws IOException {
+//     System.out.println("Test (12) : Delete multiple attachments");
+//     Boolean testStatus = false;
+//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//     if (response == "Entity in draft mode") {
+//       String response1 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID2);
+//       String response2 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID3);
+//       if (response1 == "Deleted" && response2 == "Deleted") {
+//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+//         if (response == "Saved") {
+//           response1 = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID2);
+//           response2 = api.readAttachment(appUrl, serviceName, entityName, entityID,
+// attachmentID3);
+//           if (response1.equals("Could not read attachment")
+//               && response2.equals("Could not read attachment")) {
+//             testStatus = true;
+//           }
+//         }
+//       }
+//     }
+//     if (!testStatus) {
+//       fail("Could not delete attachment");
+//     }
+//   }
 
-  @Test
-  @Order(13)
-  public void testDeleteEntity() throws IOException {
-    System.out.println("Test (13) : Delete entity");
-    Boolean testStatus = false;
-    String response = api.deleteEntity(appUrl, serviceName, entityName, entityID);
-    String response2 = api.deleteEntity(appUrl, serviceName, entityName, entityID2);
-    if (response == "Entity Deleted" && response2 == "Entity Deleted") {
-      testStatus = true;
-    }
-    if (!testStatus) {
-      fail("Could not delete entity");
-    }
-  }
-}
+//   @Test
+//   @Order(13)
+//   public void testDeleteEntity() throws IOException {
+//     System.out.println("Test (13) : Delete entity");
+//     Boolean testStatus = false;
+//     String response = api.deleteEntity(appUrl, serviceName, entityName, entityID);
+//     String response2 = api.deleteEntity(appUrl, serviceName, entityName, entityID2);
+//     if (response == "Entity Deleted" && response2 == "Entity Deleted") {
+//       testStatus = true;
+//     }
+//     if (!testStatus) {
+//       fail("Could not delete entity");
+//     }
+//   }
+// }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
@@ -1,493 +1,479 @@
-// package integration.com.sap.cds.sdm;
+package integration.com.sap.cds.sdm;
 
-// import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-// import com.fasterxml.jackson.databind.JsonNode;
-// import com.fasterxml.jackson.databind.ObjectMapper;
-// import java.io.File;
-// import java.io.IOException;
-// import java.nio.charset.StandardCharsets;
-// import java.util.*;
-// import okhttp3.*;
-// import org.junit.jupiter.api.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import okhttp3.*;
+import org.junit.jupiter.api.*;
 
-// @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-// public class AttachmentsSDMTest {
-//   private static String token;
-//   private static String entityID;
-//   private static String entityID2;
-//   private static String appUrl;
-//   private static String authUrl;
-//   private static String username;
-//   private static String password;
-//   private static String serviceName = "AdminService";
-//   private static String entityName = "Books";
-//   private static String srvpath = "AdminService";
-//   private static Api api;
-//   private static String attachmentID1 = "";
-//   private static String attachmentID2 = "";
-//   private static String attachmentID3 = "";
-//   private static String attachmentID4 = "";
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AttachmentsSDMTest {
+  private static String token;
+  private static String entityID;
+  private static String entityID2;
+  private static String appUrl;
+  private static String authUrl;
+  private static String username;
+  private static String password;
+  private static String serviceName = "AdminService";
+  private static String entityName = "Books";
+  private static String srvpath = "AdminService";
+  private static Api api;
+  private static String attachmentID1 = "";
+  private static String attachmentID2 = "";
+  private static String attachmentID3 = "";
+  private static String attachmentID4 = "";
 
-//   @BeforeAll
-//   public static void setup() throws IOException {
-//     // Define your clientId and clientSecret
-//     Properties credentialsProperties = Credentials.getCredentials();
-//     String clientId = credentialsProperties.getProperty("clientID");
-//     String clientSecret = credentialsProperties.getProperty("clientSecret");
-//     appUrl = credentialsProperties.getProperty("appUrl");
-//     authUrl = credentialsProperties.getProperty("authUrl");
-//     username = credentialsProperties.getProperty("username");
-//     password = credentialsProperties.getProperty("password");
+  @BeforeAll
+  public static void setup() throws IOException {
+    // Define your clientId and clientSecret
+    Properties credentialsProperties = Credentials.getCredentials();
+    String clientId = credentialsProperties.getProperty("clientID");
+    String clientSecret = credentialsProperties.getProperty("clientSecret");
+    appUrl = credentialsProperties.getProperty("appUrl");
+    authUrl = credentialsProperties.getProperty("authUrl");
+    username = credentialsProperties.getProperty("username");
+    password = credentialsProperties.getProperty("password");
 
-//     // Encode clientId:clientSecret to Base64
-//     String credentials = clientId + ":" + clientSecret;
-//     String basicAuth =
-//         "Basic " +
-// Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    // Encode clientId:clientSecret to Base64
+    String credentials = clientId + ":" + clientSecret;
+    String basicAuth =
+        "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-//     OkHttpClient client = new OkHttpClient().newBuilder().build();
-//     MediaType mediaType = MediaType.parse("text/plain");
-//     RequestBody body = RequestBody.create(mediaType, "");
-//     Request request =
-//         new Request.Builder()
-//             .url(
-//                 authUrl
-//                     + "/oauth/token?grant_type=password&username="
-//                     + username
-//                     + "&password="
-//                     + password)
-//             .method("POST", body)
-//             .addHeader("Authorization", basicAuth)
-//             .build();
-//     Response response = client.newCall(request).execute();
-//     if (response.code() != 200) {
-//       System.out.println("Token generation failed. Response code: " + response.code());
-//       String errorBody = response.body().string();
-//       System.out.println("Error body: " + errorBody);
-//     }
-//     token = new ObjectMapper().readTree(response.body().string()).get("access_token").asText();
-//     response.close();
-//     Map<String, String> config = new HashMap<>();
-//     config.put("Authorization", "Bearer " + token);
-//     api = new Api(config);
-//   }
+    OkHttpClient client = new OkHttpClient().newBuilder().build();
+    MediaType mediaType = MediaType.parse("text/plain");
+    RequestBody body = RequestBody.create(mediaType, "");
+    Request request =
+        new Request.Builder()
+            .url(
+                authUrl
+                    + "/oauth/token?grant_type=password&username="
+                    + username
+                    + "&password="
+                    + password)
+            .method("POST", body)
+            .addHeader("Authorization", basicAuth)
+            .build();
+    Response response = client.newCall(request).execute();
+    if (response.code() != 200) {
+      System.out.println("Token generation failed. Response code: " + response.code());
+      String errorBody = response.body().string();
+      System.out.println("Error body: " + errorBody);
+    }
+    token = new ObjectMapper().readTree(response.body().string()).get("access_token").asText();
+    response.close();
+    Map<String, String> config = new HashMap<>();
+    config.put("Authorization", "Bearer " + token);
+    api = new Api(config);
+  }
 
-//   @Test
-//   @Order(1)
-//   public void testCreateEntityAndCheck() throws IOException {
-//     System.out.println("Test (1) : Create entity and check if it exists");
-//     Boolean testStatus = false;
-//     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
-//     if (response != "Could not create entity") {
-//       entityID = response;
-//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//       if (response == "Saved") {
-//         response = api.checkEntity(appUrl, serviceName, entityName, entityID);
-//         if (response.equals("Entity exists")) {
-//           testStatus = true;
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not create entity");
-//     }
-//   }
+  @Test
+  @Order(1)
+  public void testCreateEntityAndCheck() throws IOException {
+    System.out.println("Test (1) : Create entity and check if it exists");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID = response;
+      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+      if (response == "Saved") {
+        response = api.checkEntity(appUrl, serviceName, entityName, entityID);
+        if (response.equals("Entity exists")) {
+          testStatus = true;
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not create entity");
+    }
+  }
 
-//   @Test
-//   @Order(2)
-//   public void testUpdateEmptyEntity() throws IOException {
-//     System.out.println("Test (2) : Update an existing entity");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//       if (response == "Saved") {
-//         response = api.checkEntity(appUrl, serviceName, entityName, entityID);
-//         if (response.equals("Entity exists")) {
-//           testStatus = true;
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not update entity");
-//     }
-//   }
+  @Test
+  @Order(2)
+  public void testUpdateEmptyEntity() throws IOException {
+    System.out.println("Test (2) : Update an existing entity");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+      if (response == "Saved") {
+        response = api.checkEntity(appUrl, serviceName, entityName, entityID);
+        if (response.equals("Entity exists")) {
+          testStatus = true;
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update entity");
+    }
+  }
 
-//   @Test
-//   @Order(3)
-//   public void testUploadSingleAttachmentPDF() throws IOException {
-//     System.out.println("Test (3) : Upload pdf");
-//     Boolean testStatus = false;
-//     ClassLoader classLoader = getClass().getClassLoader();
-//     File file = new File(classLoader.getResource("sample.pdf").getFile());
+  @Test
+  @Order(3)
+  public void testUploadSingleAttachmentPDF() throws IOException {
+    System.out.println("Test (3) : Upload pdf");
+    Boolean testStatus = false;
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
 
-//     Map<String, Object> postData = new HashMap<>();
-//     postData.put("up__ID", entityID);
-//     postData.put("mimeType", "application/pdf");
-//     postData.put("createdAt", new Date().toString());
-//     postData.put("createdBy", "test@test.com");
-//     postData.put("modifiedBy", "test@test.com");
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
 
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       List<String> createResponse =
-//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
-// file);
-//       String check = createResponse.get(0);
-//       if (check.equals("Attachment created")) {
-//         attachmentID1 = createResponse.get(1);
-//         response =
-//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID1);
-//         if (response.equals("OK")) {
-//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//           if (response.equals("Saved")) {
-//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID1);
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID1 = createResponse.get(1);
+        response =
+            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID1);
+        if (response.equals("OK")) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+          if (response.equals("Saved")) {
+            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID1);
 
-//             if (response.equals("OK")) {
-//               testStatus = true;
-//             }
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not upload sample.pdf " + response);
-//     }
-//   }
+            if (response.equals("OK")) {
+              testStatus = true;
+            }
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not upload sample.pdf " + response);
+    }
+  }
 
-//   @Test
-//   @Order(4)
-//   public void testUploadSingleAttachmentTXT() throws IOException {
-//     System.out.println("Test (4) : Upload txt");
-//     Boolean testStatus = false;
-//     ClassLoader classLoader = getClass().getClassLoader();
-//     File file = new File(classLoader.getResource("sample.txt").getFile());
+  @Test
+  @Order(4)
+  public void testUploadSingleAttachmentTXT() throws IOException {
+    System.out.println("Test (4) : Upload txt");
+    Boolean testStatus = false;
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.txt").getFile());
 
-//     Map<String, Object> postData = new HashMap<>();
-//     postData.put("up__ID", entityID);
-//     postData.put("mimeType", "application/txt");
-//     postData.put("createdAt", new Date().toString());
-//     postData.put("createdBy", "test@test.com");
-//     postData.put("modifiedBy", "test@test.com");
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID);
+    postData.put("mimeType", "application/txt");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
 
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       List<String> createResponse =
-//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
-// file);
-//       String check = createResponse.get(0);
-//       if (check.equals("Attachment created")) {
-//         attachmentID2 = createResponse.get(1);
-//         response =
-//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID2);
-//         if (response.equals("OK")) {
-//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//           if (response.equals("Saved")) {
-//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID2);
-//             if (response.equals("OK")) {
-//               testStatus = true;
-//             }
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not upload sample.txt");
-//     }
-//   }
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID2 = createResponse.get(1);
+        response =
+            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID2);
+        if (response.equals("OK")) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+          if (response.equals("Saved")) {
+            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID2);
+            if (response.equals("OK")) {
+              testStatus = true;
+            }
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not upload sample.txt");
+    }
+  }
 
-//   @Test
-//   @Order(5)
-//   public void testUploadSingleAttachmentEXE() throws IOException {
-//     System.out.println("Test (5) : Upload exe");
-//     Boolean testStatus = false;
-//     ClassLoader classLoader = getClass().getClassLoader();
-//     File file = new File(classLoader.getResource("sample.exe").getFile());
+  @Test
+  @Order(5)
+  public void testUploadSingleAttachmentEXE() throws IOException {
+    System.out.println("Test (5) : Upload exe");
+    Boolean testStatus = false;
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.exe").getFile());
 
-//     Map<String, Object> postData = new HashMap<>();
-//     postData.put("up__ID", entityID);
-//     postData.put("mimeType", "application/exe");
-//     postData.put("createdAt", new Date().toString());
-//     postData.put("createdBy", "test@test.com");
-//     postData.put("modifiedBy", "test@test.com");
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID);
+    postData.put("mimeType", "application/exe");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
 
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       List<String> createResponse =
-//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
-// file);
-//       String check = createResponse.get(0);
-//       if (check.equals("Attachment created")) {
-//         attachmentID3 = createResponse.get(1);
-//         response =
-//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID3);
-//         if (response.equals("OK")) {
-//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//           if (response.equals("Saved")) {
-//             response = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID3);
-//             if (response.equals("OK")) {
-//               testStatus = true;
-//             }
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not create sample.exe");
-//     }
-//   }
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID3 = createResponse.get(1);
+        response =
+            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID, attachmentID3);
+        if (response.equals("OK")) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+          if (response.equals("Saved")) {
+            response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID3);
+            if (response.equals("OK")) {
+              testStatus = true;
+            }
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not create sample.exe");
+    }
+  }
 
-//   @Test
-//   @Order(6)
-//   public void testUploadSingleAttachmentPDFDuplicate() throws IOException {
-//     System.out.println("Test (6) : Upload duplicate pdf");
-//     ClassLoader classLoader = getClass().getClassLoader();
-//     File file = new File(classLoader.getResource("sample.pdf").getFile());
-//     Boolean testStatus = false;
+  @Test
+  @Order(6)
+  public void testUploadSingleAttachmentPDFDuplicate() throws IOException {
+    System.out.println("Test (6) : Upload duplicate pdf");
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
+    Boolean testStatus = false;
 
-//     Map<String, Object> postData = new HashMap<>();
-//     postData.put("up__ID", entityID);
-//     postData.put("mimeType", "application/pdf");
-//     postData.put("createdAt", new Date().toString());
-//     postData.put("createdBy", "test@test.com");
-//     postData.put("modifiedBy", "test@test.com");
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
 
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       List<String> createResponse =
-//           api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData,
-// file);
-//       String check = createResponse.get(0);
-//       if (check.equals("Attachment created")) {
-//         testStatus = false;
-//       } else {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         if (response.equals("Saved")) {
-//           String expectedJson =
-//               "{\"error\":{\"code\":\"500\",\"message\":\"sample.pdf already exists.\"}}";
-//           ObjectMapper objectMapper = new ObjectMapper();
-//           JsonNode actualJsonNode = objectMapper.readTree(check);
-//           JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
-//           if (expectedJsonNode.equals(actualJsonNode)) {
-//             testStatus = true;
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Attachment was created");
-//     }
-//   }
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        testStatus = false;
+      } else {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        if (response.equals("Saved")) {
+          String expectedJson =
+              "{\"error\":{\"code\":\"500\",\"message\":\"sample.pdf already exists.\"}}";
+          ObjectMapper objectMapper = new ObjectMapper();
+          JsonNode actualJsonNode = objectMapper.readTree(check);
+          JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
+          if (expectedJsonNode.equals(actualJsonNode)) {
+            testStatus = true;
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment was created");
+    }
+  }
 
-//   @Test
-//   @Order(7)
-//   public void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
-//     System.out.println("Test (7) : Upload duplicate pdf in different entity");
-//     Boolean testStatus = false;
-//     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
-//     if (response != "Could not create entity") {
-//       entityID2 = response;
-//       response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-//       if (response == "Saved") {
-//         response = api.checkEntity(appUrl, serviceName, entityName, entityID2);
-//         if (response.equals("Entity exists")) {
-//           testStatus = true;
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not create entity");
-//     }
+  @Test
+  @Order(7)
+  public void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
+    System.out.println("Test (7) : Upload duplicate pdf in different entity");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID2 = response;
+      response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+      if (response == "Saved") {
+        response = api.checkEntity(appUrl, serviceName, entityName, entityID2);
+        if (response.equals("Entity exists")) {
+          testStatus = true;
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not create entity");
+    }
 
-//     ClassLoader classLoader = getClass().getClassLoader();
-//     File file = new File(classLoader.getResource("sample.pdf").getFile());
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
 
-//     Map<String, Object> postData = new HashMap<>();
-//     postData.put("up__ID", entityID2);
-//     postData.put("mimeType", "application/pdf");
-//     postData.put("createdAt", new Date().toString());
-//     postData.put("createdBy", "test@test.com");
-//     postData.put("modifiedBy", "test@test.com");
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID2);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
 
-//     response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-//     if (response == "Entity in draft mode") {
-//       List<String> createResponse =
-//           api.createAttachment(appUrl, serviceName, entityName, entityID2, srvpath, postData,
-// file);
-//       String check = createResponse.get(0);
-//       if (check.equals("Attachment created")) {
-//         attachmentID4 = createResponse.get(1);
-//         response =
-//             api.readAttachmentDraft(appUrl, serviceName, entityName, entityID2, attachmentID4);
-//         if (response.equals("OK")) {
-//           response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
-//           if (response.equals("Saved")) {
-//             response =
-//                 api.readAttachment(appUrl, serviceName, entityName, entityID2, attachmentID4);
+    response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+    if (response == "Entity in draft mode") {
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID2, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID4 = createResponse.get(1);
+        response =
+            api.readAttachmentDraft(appUrl, serviceName, entityName, entityID2, attachmentID4);
+        if (response.equals("OK")) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID2);
+          if (response.equals("Saved")) {
+            response =
+                api.readAttachment(appUrl, serviceName, entityName, entityID2, attachmentID4);
 
-//             if (response.equals("OK")) {
-//               testStatus = true;
-//             }
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not upload sample.pdf " + response);
-//     }
-//   }
+            if (response.equals("OK")) {
+              testStatus = true;
+            }
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not upload sample.pdf " + response);
+    }
+  }
 
-//   @Test
-//   @Order(8)
-//   public void testRenameSingleAttachment() throws IOException {
-//     System.out.println("Test (8) : Rename single attachment");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     String name = "sample123";
-//     if (response == "Entity in draft mode") {
-//       response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID1, name);
-//       if (response.equals("Renamed")) {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         if (response.equals("Saved")) {
-//           testStatus = true;
-//         }
-//       } else {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Attachment was not renamed");
-//     }
-//   }
+  @Test
+  @Order(8)
+  public void testRenameSingleAttachment() throws IOException {
+    System.out.println("Test (8) : Rename single attachment");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    String name = "sample123";
+    if (response == "Entity in draft mode") {
+      response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID1, name);
+      if (response.equals("Renamed")) {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        if (response.equals("Saved")) {
+          testStatus = true;
+        }
+      } else {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment was not renamed");
+    }
+  }
 
-//   @Test
-//   @Order(9)
-//   public void testRenameMultipleAttachments() throws IOException {
-//     System.out.println("Test (9) : Rename multiple attachments");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     String name1 = "sample1234";
-//     String name2 = "sample12345";
-//     if (response == "Entity in draft mode") {
-//       String response1 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID2,
-// name1);
-//       String response2 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3,
-// name2);
-//       if (response1.equals("Renamed") && response2.equals("Renamed")) {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         if (response.equals("Saved")) {
-//           testStatus = true;
-//         }
-//       } else {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Attachment was not renamed");
-//     }
-//   }
+  @Test
+  @Order(9)
+  public void testRenameMultipleAttachments() throws IOException {
+    System.out.println("Test (9) : Rename multiple attachments");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    String name1 = "sample1234";
+    String name2 = "sample12345";
+    if (response == "Entity in draft mode") {
+      String response1 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID2, name1);
+      String response2 = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
+      if (response1.equals("Renamed") && response2.equals("Renamed")) {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        if (response.equals("Saved")) {
+          testStatus = true;
+        }
+      } else {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment was not renamed");
+    }
+  }
 
-//   @Test
-//   @Order(10)
-//   public void testRenameSingleAttachmentDuplicate() throws IOException {
-//     System.out.println("Test (10) : Rename single attachment duplicate");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     String name = "sample123";
-//     String name2 = "sample123456";
-//     if (response == "Entity in draft mode") {
-//       response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name);
-//       if (response.equals("Renamed")) {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         String expected =
-//             "{\"error\":{\"code\":\"400\",\"message\":\"The file(s) sample123 have been added "
-//                 + "multiple times. Please rename and try again.\"}}";
-//         if (response.equals(expected)) {
-//           response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
-//           if (response.equals("Renamed")) {
-//             response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//             if (response.equals("Saved")) {
-//               testStatus = true;
-//             }
-//           }
-//         }
-//       } else {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Attachment was renamed");
-//     }
-//   }
+  @Test
+  @Order(10)
+  public void testRenameSingleAttachmentDuplicate() throws IOException {
+    System.out.println("Test (10) : Rename single attachment duplicate");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    String name = "sample123";
+    String name2 = "sample123456";
+    if (response == "Entity in draft mode") {
+      response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name);
+      if (response.equals("Renamed")) {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        String expected =
+            "{\"error\":{\"code\":\"400\",\"message\":\"The file(s) sample123 have been added "
+                + "multiple times. Please rename and try again.\"}}";
+        if (response.equals(expected)) {
+          response = api.renameAttachment(appUrl, serviceName, entityID, attachmentID3, name2);
+          if (response.equals("Renamed")) {
+            response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+            if (response.equals("Saved")) {
+              testStatus = true;
+            }
+          }
+        }
+      } else {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment was renamed");
+    }
+  }
 
-//   @Test
-//   @Order(11)
-//   public void testDeleteSingleAttachment() throws IOException {
-//     System.out.println("Test (11) : Delete single attachment");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       response = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID1);
-//       if (response == "Deleted") {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         if (response == "Saved") {
-//           response = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID1);
-//           if (response.equals("Could not read attachment")) {
-//             testStatus = true;
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not delete attachment");
-//     }
-//   }
+  @Test
+  @Order(11)
+  public void testDeleteSingleAttachment() throws IOException {
+    System.out.println("Test (11) : Delete single attachment");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      response = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID1);
+      if (response == "Deleted") {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        if (response == "Saved") {
+          response = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID1);
+          if (response.equals("Could not read attachment")) {
+            testStatus = true;
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not delete attachment");
+    }
+  }
 
-//   @Test
-//   @Order(12)
-//   public void testDeleteMultipleAttachments() throws IOException {
-//     System.out.println("Test (12) : Delete multiple attachments");
-//     Boolean testStatus = false;
-//     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//     if (response == "Entity in draft mode") {
-//       String response1 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID2);
-//       String response2 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID3);
-//       if (response1 == "Deleted" && response2 == "Deleted") {
-//         response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
-//         if (response == "Saved") {
-//           response1 = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID2);
-//           response2 = api.readAttachment(appUrl, serviceName, entityName, entityID,
-// attachmentID3);
-//           if (response1.equals("Could not read attachment")
-//               && response2.equals("Could not read attachment")) {
-//             testStatus = true;
-//           }
-//         }
-//       }
-//     }
-//     if (!testStatus) {
-//       fail("Could not delete attachment");
-//     }
-//   }
+  @Test
+  @Order(12)
+  public void testDeleteMultipleAttachments() throws IOException {
+    System.out.println("Test (12) : Delete multiple attachments");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+    if (response == "Entity in draft mode") {
+      String response1 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID2);
+      String response2 = api.deleteAttachment(appUrl, serviceName, entityID, attachmentID3);
+      if (response1 == "Deleted" && response2 == "Deleted") {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        if (response == "Saved") {
+          response1 = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID2);
+          response2 = api.readAttachment(appUrl, serviceName, entityName, entityID, attachmentID3);
+          if (response1.equals("Could not read attachment")
+              && response2.equals("Could not read attachment")) {
+            testStatus = true;
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not delete attachment");
+    }
+  }
 
-//   @Test
-//   @Order(13)
-//   public void testDeleteEntity() throws IOException {
-//     System.out.println("Test (13) : Delete entity");
-//     Boolean testStatus = false;
-//     String response = api.deleteEntity(appUrl, serviceName, entityName, entityID);
-//     String response2 = api.deleteEntity(appUrl, serviceName, entityName, entityID2);
-//     if (response == "Entity Deleted" && response2 == "Entity Deleted") {
-//       testStatus = true;
-//     }
-//     if (!testStatus) {
-//       fail("Could not delete entity");
-//     }
-//   }
-// }
+  @Test
+  @Order(13)
+  public void testDeleteEntity() throws IOException {
+    System.out.println("Test (13) : Delete entity");
+    Boolean testStatus = false;
+    String response = api.deleteEntity(appUrl, serviceName, entityName, entityID);
+    String response2 = api.deleteEntity(appUrl, serviceName, entityName, entityID2);
+    if (response == "Entity Deleted" && response2 == "Entity Deleted") {
+      testStatus = true;
+    }
+    if (!testStatus) {
+      fail("Could not delete entity");
+    }
+  }
+}

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
@@ -1,6 +1,8 @@
 package unit.com.sap.cds.sdm.handler.applicationservice;
 
 import static com.sap.cds.sdm.utilities.SDMUtils.isFileNameDuplicateInDrafts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,6 +18,7 @@ import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.service.SDMServiceImpl;
 import com.sap.cds.sdm.utilities.SDMUtils;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.authentication.AuthenticationInfo;
 import com.sap.cds.services.authentication.JwtTokenAuthenticationInfo;
 import com.sap.cds.services.cds.CdsCreateEventContext;
@@ -216,6 +219,51 @@ public class SDMCreateAttachmentsHandlerTest {
     // Verify that a warning message was added to the context
     verify(messages, times(1))
         .warn("The following files could not be renamed as they already exist:\nfile1.txt\n");
+  }
+
+  @Test
+  public void testCreateAttachmentWithNoSDMRoles() throws IOException {
+    // Mock the data structure to simulate the attachments
+    List<CdsData> data = new ArrayList<>();
+    Map<String, Object> entity = new HashMap<>();
+    List<Map<String, Object>> attachments = new ArrayList<>();
+    Map<String, Object> attachment = spy(new HashMap<>());
+    attachment.put("fileName", "file1.txt");
+    attachment.put("url", "objectId");
+    attachment.put("ID", "test-id"); // assuming there's an ID field
+    attachments.add(attachment);
+    entity.put("attachments", attachments);
+    CdsData mockCdsData = mock(CdsData.class);
+    when(mockCdsData.get("attachments")).thenReturn(attachments);
+    data.add(mockCdsData);
+
+    // Mock the authentication context
+    when(context.getAuthenticationInfo()).thenReturn(authInfo);
+    when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
+    when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
+
+    // Mock the static TokenHandler
+    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
+
+    // Mock the SDM service responses
+    when(sdmService.getObject(any(), any(), any()))
+        .thenReturn("file-sdm.txt"); // Mock a different file name in SDM to trigger renaming
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(403); // Mock conflict response code
+
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(403); // Mock conflict response code
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              handler.updateName(context, data);
+            });
+
+    assertEquals(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, exception.getMessage());
   }
 
   @Test

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
@@ -267,6 +267,46 @@ public class SDMCreateAttachmentsHandlerTest {
   }
 
   @Test
+  public void testCreateAttachmentWith500Error() throws IOException {
+    // Mock the data structure to simulate the attachments
+    List<CdsData> data = new ArrayList<>();
+    Map<String, Object> entity = new HashMap<>();
+    List<Map<String, Object>> attachments = new ArrayList<>();
+    Map<String, Object> attachment = spy(new HashMap<>());
+    attachment.put("fileName", "file1.txt");
+    attachment.put("url", "objectId");
+    attachment.put("ID", "test-id"); // assuming there's an ID field
+    attachments.add(attachment);
+    entity.put("attachments", attachments);
+    CdsData mockCdsData = mock(CdsData.class);
+    when(mockCdsData.get("attachments")).thenReturn(attachments);
+    data.add(mockCdsData);
+
+    // Mock the authentication context
+    when(context.getAuthenticationInfo()).thenReturn(authInfo);
+    when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
+    when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
+
+    // Mock the static TokenHandler
+    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
+
+    // Mock the SDM service responses
+    when(sdmService.getObject(any(), any(), any()))
+        .thenReturn("file-sdm.txt"); // Mock a different file name in SDM to trigger renaming
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(500); // Mock conflict response code
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              handler.updateName(context, data);
+            });
+
+    assertEquals(SDMConstants.SDM_ROLES_ERROR_MESSAGE, exception.getMessage());
+  }
+
+  @Test
   public void testRenameWith200ResponseCode() throws IOException {
     // Mock the data structure to simulate the attachments
     System.out.println("testRenameWithConflictResponseCode");
@@ -319,21 +359,35 @@ public class SDMCreateAttachmentsHandlerTest {
     fileNameWithRestrictedChars.add("file/2.txt");
     fileNameWithRestrictedChars.add("file\\3.txt");
 
+    // Mock the CdsEntity and setup context
     CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
     when(context.getTarget()).thenReturn(attachmentDraftEntity);
     when(context.getAuthenticationInfo()).thenReturn(authInfo);
     when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
     when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
-
     when(context.getMessages()).thenReturn(messages);
 
-    sdmUtilsMockedStatic = mockStatic(SDMUtils.class);
+    // Mock SDMUtils to simulate restricted characters
+    MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class);
     sdmUtilsMockedStatic
         .when(() -> SDMUtils.isRestrictedCharactersInName(anyString()))
-        .thenCallRealMethod();
+        .thenAnswer(
+            invocation -> {
+              String filename = invocation.getArgument(0);
+              return filename.contains("/") || filename.contains("\\");
+            });
+
+    // Mock the SDM service object retrieval
     when(sdmService.getObject(anyString(), anyString(), any())).thenReturn("file-in-sdm");
 
+    // Ensure renameAttachments behaves as expected
+    when(sdmService.renameAttachments(anyString(), any(), any(CmisDocument.class)))
+        .thenReturn(200); // or a desired response code
+
+    // Act
     handler.updateName(context, data);
+
+    // Verify warning message about restricted characters
     verify(messages, times(1))
         .warn(SDMConstants.nameConstraintMessage(fileNameWithRestrictedChars, "Rename"));
 
@@ -344,40 +398,61 @@ public class SDMCreateAttachmentsHandlerTest {
       for (Map<String, Object> attachment : attachments) {
         String filename = (String) attachment.get("fileName");
         if (filename.equals("file/2.txt") || filename.equals("file\\3.txt")) {
+          // Ensure the filename is replaced
           verify(attachment).replace("fileName", "file-in-sdm");
         }
       }
     }
+
+    // Close the mocked static method
+    sdmUtilsMockedStatic.close();
   }
 
   @Test
   public void testWarnOnRestrictedCharacters() throws IOException {
+    // Prepare the sample data with restricted characters
     List<CdsData> data = prepareMockAttachmentData("file1.txt", "file/2.txt", "file3\\abc.txt");
-    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
     List<String> fileNameWithRestrictedChars = new ArrayList<>();
     fileNameWithRestrictedChars.add("file/2.txt");
     fileNameWithRestrictedChars.add("file3\\abc.txt");
+
+    // Mock context and related authentication methods
+    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
     when(context.getTarget()).thenReturn(attachmentDraftEntity);
     when(context.getAuthenticationInfo()).thenReturn(authInfo);
     when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
     when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
-    // Mock the static TokenHandler
-    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
 
-    // Mock the SDM service responses
+    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
     when(sdmService.getObject(anyString(), anyString(), any())).thenReturn("file-in-sdm");
 
+    // Mock message handling
     when(context.getMessages()).thenReturn(messages);
 
-    // No duplicate filenames, simulate restricted characters only.
-    handler.updateName(context, data);
+    // Mock SDMUtils restricted character check
+    try (MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class)) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.isRestrictedCharactersInName(anyString()))
+          .thenAnswer(
+              invocation -> {
+                String filename = invocation.getArgument(0);
+                return filename.contains("/") || filename.contains("\\");
+              });
 
-    // Verify the warning message for restricted filenames
-    verify(messages, times(1))
-        .warn(SDMConstants.nameConstraintMessage(fileNameWithRestrictedChars, "Rename"));
+      // Mock renameAttachments implementation to avoid ServiceExceptions for testing
+      when(sdmService.renameAttachments(any(String.class), any(), any(CmisDocument.class)))
+          .thenReturn(200); // assuming successful rename
 
-    // Verify no error message is issued
-    verify(messages, never()).error(anyString());
+      // Act by invoking the handler updateName method with the context and data
+      handler.updateName(context, data);
+
+      // Verify the warning for restricted filenames is correctly handled
+      verify(messages, times(1))
+          .warn(SDMConstants.nameConstraintMessage(fileNameWithRestrictedChars, "Rename"));
+
+      // Ensure no error messages are appearing unexpectedly
+      verify(messages, never()).error(anyString());
+    }
   }
 
   private List<CdsData> prepareMockAttachmentData(String... fileNames) {

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
@@ -243,6 +243,60 @@ public class SDMUpdateAttachmentsHandlerTest {
   }
 
   @Test
+  public void testRenameWith500Error() throws IOException {
+    // Mock the data structure to simulate the attachments
+    List<CdsData> data = new ArrayList<>();
+    Map<String, Object> entity = new HashMap<>();
+    List<Map<String, Object>> attachments = new ArrayList<>();
+    Map<String, Object> attachment = spy(new HashMap<>());
+    attachment.put("fileName", "file1.txt");
+    attachment.put("url", "objectId");
+    attachment.put("ID", "test-id"); // assuming there's an ID field
+    attachments.add(attachment);
+    entity.put("attachments", attachments);
+    CdsData mockCdsData = mock(CdsData.class);
+    when(mockCdsData.get("attachments")).thenReturn(attachments);
+    data.add(mockCdsData);
+
+    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
+    when(context.getTarget()).thenReturn(attachmentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(attachmentDraftEntity.getQualifiedName()).thenReturn("some.qualified.Name");
+    when(model.findEntity("some.qualified.Name.attachments"))
+        .thenReturn(Optional.of(attachmentDraftEntity));
+
+    // Mock the authentication context
+    when(context.getAuthenticationInfo()).thenReturn(authInfo);
+    when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
+    when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
+
+    // Mock the static TokenHandler
+    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
+
+    // Mock the SDM service responses
+    dbQueryMockedStatic = mockStatic(DBQuery.class);
+    dbQueryMockedStatic
+        .when(
+            () ->
+                getAttachmentForID(
+                    any(CdsEntity.class), any(PersistenceService.class), anyString()))
+        .thenReturn("file123.txt"); // Mock a different file name in SDM to trigger renaming
+
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(500); // Mock conflict response code
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              handler.updateName(context, data);
+            });
+
+    assertEquals(SDMConstants.SDM_ROLES_ERROR_MESSAGE, exception.getMessage());
+  }
+
+  @Test
   public void testRenameWith200ResponseCode() throws IOException {
     // Mock the data structure to simulate the attachments
     System.out.println("testRenameWithConflictResponseCode");
@@ -371,6 +425,10 @@ public class SDMUpdateAttachmentsHandlerTest {
               String filename = invocation.getArgument(0);
               return filename.contains("/") || filename.contains("\\");
             });
+
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(409); // Mock conflict response code
 
     dbQueryMockedStatic = mockStatic(DBQuery.class);
     dbQueryMockedStatic

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
@@ -2,6 +2,8 @@ package unit.com.sap.cds.sdm.handler.applicationservice;
 
 import static com.sap.cds.sdm.persistence.DBQuery.getAttachmentForID;
 import static com.sap.cds.sdm.utilities.SDMUtils.isFileNameDuplicateInDrafts;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -20,6 +22,7 @@ import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.service.SDMServiceImpl;
 import com.sap.cds.sdm.utilities.SDMUtils;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.authentication.AuthenticationInfo;
 import com.sap.cds.services.authentication.JwtTokenAuthenticationInfo;
 import com.sap.cds.services.cds.CdsUpdateEventContext;
@@ -183,6 +186,60 @@ public class SDMUpdateAttachmentsHandlerTest {
     // Verify that a warning message was added to the context
     verify(messages, times(1))
         .warn("The following files could not be renamed as they already exist:\nfile1.txt\n");
+  }
+
+  @Test
+  public void testRenameWithNoSDMRoles() throws IOException {
+    // Mock the data structure to simulate the attachments
+    List<CdsData> data = new ArrayList<>();
+    Map<String, Object> entity = new HashMap<>();
+    List<Map<String, Object>> attachments = new ArrayList<>();
+    Map<String, Object> attachment = spy(new HashMap<>());
+    attachment.put("fileName", "file1.txt");
+    attachment.put("url", "objectId");
+    attachment.put("ID", "test-id"); // assuming there's an ID field
+    attachments.add(attachment);
+    entity.put("attachments", attachments);
+    CdsData mockCdsData = mock(CdsData.class);
+    when(mockCdsData.get("attachments")).thenReturn(attachments);
+    data.add(mockCdsData);
+
+    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
+    when(context.getTarget()).thenReturn(attachmentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(attachmentDraftEntity.getQualifiedName()).thenReturn("some.qualified.Name");
+    when(model.findEntity("some.qualified.Name.attachments"))
+        .thenReturn(Optional.of(attachmentDraftEntity));
+
+    // Mock the authentication context
+    when(context.getAuthenticationInfo()).thenReturn(authInfo);
+    when(authInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(jwtTokenInfo);
+    when(jwtTokenInfo.getToken()).thenReturn("jwtToken");
+
+    // Mock the static TokenHandler
+    when(TokenHandler.getSDMCredentials()).thenReturn(mockCredentials);
+
+    // Mock the SDM service responses
+    dbQueryMockedStatic = mockStatic(DBQuery.class);
+    dbQueryMockedStatic
+        .when(
+            () ->
+                getAttachmentForID(
+                    any(CdsEntity.class), any(PersistenceService.class), anyString()))
+        .thenReturn("file123.txt"); // Mock a different file name in SDM to trigger renaming
+
+    when(sdmService.renameAttachments(
+            anyString(), any(SDMCredentials.class), any(CmisDocument.class)))
+        .thenReturn(403); // Mock conflict response code
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              handler.updateName(context, data);
+            });
+
+    assertEquals(SDMConstants.SDM_MISSING_ROLES_EXCEPTION_MSG, exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Currently a user is able to rename a file even if they do not have SDM roles. 

Bug Link: https://itsm.services.sap/nav_to.do?uri=x_sapda_devinc_development_incident.do?sys_id=0c9d1540834f5e54e85fc230feaad3f4%26sysparm_view=Development_Incident

This PR is intended to resolve this issue and throw an error suggesting the user does not have sufficient permissions. 

![image](https://github.com/user-attachments/assets/823f9c8f-6209-4351-97e0-bb64048bb31f)
