### PR TITLE
[DINC0374658]:Error message fix when a user with No SDM Roles uploads an attachment

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -27,6 +27,8 @@ public class SDMConstants {
   public static final String NOT_FOUND_ERROR = "Failed to read document.";
   public static final String NAME_CONSTRAINT_WARNING_MESSAGE =
       "Enter a valid file name for %s. The following characters are not supported: /, \\";
+  public static final String USER_NOT_AUTHORISED_ERROR =
+      "You do not have the required permissions to upload attachments. Please contact your administrator for access.";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -295,6 +295,9 @@ public class SDMServiceImpl implements SDMService {
 
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {
+        if (response.code() == 403) {
+          throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
+        }
         return null;
       } else {
         String responseBody = response.body().string();
@@ -333,8 +336,12 @@ public class SDMServiceImpl implements SDMService {
             .build();
 
     try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful())
+      if (!response.isSuccessful()) {
+        if (response.code() == 403) {
+          throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
+        }
         throw new ServiceException(SDMConstants.getGenericError("upload"));
+      }
       return response.body().string();
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("upload"));

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -11,11 +11,11 @@ import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentReadEventContext;
 import com.sap.cds.sdm.caching.CacheConfig;
 import com.sap.cds.sdm.caching.RepoKey;
+import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.service.*;
-import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.ByteArrayInputStream;
@@ -318,6 +318,39 @@ public class SDMServiceImplTest {
   }
 
   @Test
+  public void testCreateFolderFailResponseCode403() throws IOException {
+    MockWebServer mockWebServer = new MockWebServer();
+    mockWebServer.start();
+    try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+        Mockito.mockStatic(TokenHandler.class)) {
+      mockWebServer.enqueue(
+          new MockResponse()
+              .setResponseCode(403) // Set HTTP status code to 403
+              .setBody("{\"error\":" + SDMConstants.USER_NOT_AUTHORISED_ERROR + "\"}")
+              .addHeader("Content-Type", "application/json"));
+      String parentId = "123";
+      String jwtToken = "jwt_token";
+      String repositoryId = "repository_id";
+      String mockUrl = mockWebServer.url("/").toString();
+      SDMCredentials sdmCredentials = new SDMCredentials();
+      sdmCredentials.setUrl(mockUrl);
+      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+
+      ServiceException exception =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                sdmServiceImpl.createFolder(parentId, jwtToken, repositoryId, sdmCredentials);
+              });
+      assertEquals(SDMConstants.USER_NOT_AUTHORISED_ERROR, exception.getMessage());
+
+    } finally {
+      mockWebServer.shutdown();
+    }
+  }
+
+  @Test
   public void testGetFolderIdByPath() throws IOException {
     MockWebServer mockWebServer = new MockWebServer();
     mockWebServer.start();
@@ -384,6 +417,40 @@ public class SDMServiceImplTest {
       String folderId =
           sdmServiceImpl.getFolderIdByPath(parentId, jwtToken, repositoryId, sdmCredentials);
       assertNull(folderId, "Expected folderId to be null");
+
+    } finally {
+      mockWebServer.shutdown();
+    }
+  }
+
+  @Test
+  public void testGetFolderIdByPathFailResponseCode403() throws IOException {
+    MockWebServer mockWebServer = new MockWebServer();
+    mockWebServer.start();
+    try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+        Mockito.mockStatic(TokenHandler.class)) {
+      mockWebServer.enqueue(
+          new MockResponse()
+              .setResponseCode(403) // Set HTTP status code to 403 for an internal server error
+              .setBody("{\"error\":" + SDMConstants.USER_NOT_AUTHORISED_ERROR + "\"}")
+              // the body
+              .addHeader("Content-Type", "application/json"));
+      String parentId = "123";
+      String jwtToken = "jwt_token";
+      String repositoryId = "repository_id";
+      String mockUrl = mockWebServer.url("/").toString();
+      SDMCredentials sdmCredentials = new SDMCredentials();
+      sdmCredentials.setUrl(mockUrl);
+      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+
+      ServiceException exception =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                sdmServiceImpl.getFolderIdByPath(parentId, jwtToken, repositoryId, sdmCredentials);
+              });
+      assertEquals(SDMConstants.USER_NOT_AUTHORISED_ERROR, exception.getMessage());
 
     } finally {
       mockWebServer.shutdown();


### PR DESCRIPTION
Currently if a user do not have SDM roles and if they try to upload an attachment, some random error is being thrown. With this PR, we are fixing the error message.

<img width="1326" alt="Screenshot 2025-01-20 at 10 01 47 AM" src="https://github.com/user-attachments/assets/b01a5672-9b52-403e-a5d6-fac457a6675a" />


