### PR TITLE
SDMEXT-850and 851:[Java] Implement API requests to SDM using Cloud SDK

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -34,7 +34,7 @@ jobs:
           mvn clean install -P unit-tests  -DskipIntegrationTests
         
       - name: Download Synopsys Detect Script
-        run: curl --silent -O https://detect.synopsys.com/detect9.sh
+        run: curl --silent -O https://detect.synopsys.com/detect10.sh
 
       - name: Run & analyze BlackDuck Scan
         run: |

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -34,11 +34,11 @@ jobs:
           mvn clean install -P unit-tests  -DskipIntegrationTests
         
       - name: Download Synopsys Detect Script
-        run: curl --silent -O https://detect.synopsys.com/detect10.sh
+        run: curl --silent -O https://detect.synopsys.com/detect9.sh
 
       - name: Run & analyze BlackDuck Scan
         run: |
-          bash ./detect10.sh -d \
+          bash ./detect9.sh -d \
           --logging.level.com.synopsys.integration=DEBUG  \
           --blackduck.url="https://sap.blackducksoftware.com" \
           --blackduck.api.token=""${{ secrets.BLACKDUCK_TOKEN }}""   \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -53,4 +53,4 @@ jobs:
           --detect.project.name="SAP_DOC_MGMT_CAPPLUGIN_JAVA1.0" \
           --detect.project.version.name="1.0" \
           --detect.code.location.name="SAP_DOC_MGMT_CAPPLUGIN_JAVA1.0/1.0" \
-          --detect.source.path="/sapmnt/home/I355238/actions-runner_cap-java/_work/sdm/sdm/sdm"
+          --detect.source.path="/sapmnt/home/I355238/actions-runner/_work/sdm/sdm/sdm"

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run & analyze BlackDuck Scan
         run: |
-          bash ./detect9.sh -d \
+          bash ./detect10.sh -d \
           --logging.level.com.synopsys.integration=DEBUG  \
           --blackduck.url="https://sap.blackducksoftware.com" \
           --blackduck.api.token=""${{ secrets.BLACKDUCK_TOKEN }}""   \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: cap-java
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -53,4 +53,4 @@ jobs:
           --detect.project.name="SAP_DOC_MGMT_CAPPLUGIN_JAVA1.0" \
           --detect.project.version.name="1.0" \
           --detect.code.location.name="SAP_DOC_MGMT_CAPPLUGIN_JAVA1.0/1.0" \
-          --detect.source.path="/sapmnt/home/I355238/actions-runner/_work/sdm/sdm/sdm"
+          --detect.source.path="/home/runner/work/sdm/sdm/sdm"

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <generation-folder>src/gen</generation-folder>
 
         <test-spring-boot-version>3.2.5</test-spring-boot-version>
+        <sdk-bom-version>5.15.0</sdk-bom-version>
     </properties>
 
     <groupId>com.sap.cds</groupId>
@@ -80,7 +81,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+        <dependency>
+            <groupId>com.sap.cloud.sdk</groupId>
+            <artifactId>sdk-bom</artifactId>
+            <version>${sdk-bom-version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
         </dependencies>
+
     </dependencyManagement>
 
     <dependencies>

--- a/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
@@ -72,7 +72,7 @@ public class Registration implements CdsRuntimeConfiguration {
 
   private static CdsProperties.ConnectionPool getConnectionPool(CdsEnvironment env) {
     // the common prefix for the connection pool configuration
-    final String prefix = "cds.attachments.sdm.http.%s";
+    final String prefix = SDMConstants.SDM_CONNECTIONPOOL_PREFIX;
     Duration timeout =
         Duration.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, 1200));
     int maxConnections = env.getProperty(prefix.formatted("maxConnections"), Integer.class, 100);

--- a/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
@@ -2,6 +2,7 @@ package com.sap.cds.sdm.configuration;
 
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.sdm.caching.CacheConfig;
+import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.applicationservice.SDMCreateAttachmentsHandler;
 import com.sap.cds.sdm.handler.applicationservice.SDMReadAttachmentsHandler;
 import com.sap.cds.sdm.handler.applicationservice.SDMUpdateAttachmentsHandler;
@@ -9,10 +10,17 @@ import com.sap.cds.sdm.service.SDMAttachmentsService;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.service.SDMServiceImpl;
 import com.sap.cds.sdm.service.handler.SDMAttachmentsServiceHandler;
+import com.sap.cds.services.environment.CdsEnvironment;
+import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.CdsRuntimeConfiguration;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
+import com.sap.cds.services.utils.environment.ServiceBindingUtils;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import java.time.Duration;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,13 +41,24 @@ public class Registration implements CdsRuntimeConfiguration {
   public void eventHandlers(CdsRuntimeConfigurer configurer) {
     logger.info("Registering event handler for attachment service");
     CacheConfig.initializeCache();
+    CdsRuntime runtime = configurer.getCdsRuntime();
+    CdsEnvironment environment = runtime.getEnvironment();
     var persistenceService =
         configurer
             .getCdsRuntime()
             .getServiceCatalog()
             .getService(PersistenceService.class, PersistenceService.DEFAULT_NAME);
+    List<ServiceBinding> bindings =
+        environment
+            .getServiceBindings()
+            .filter(b -> ServiceBindingUtils.matches(b, SDMConstants.SDM_ENV_NAME))
+            .toList();
+    var binding = !bindings.isEmpty() ? bindings.get(0) : null;
 
-    SDMService sdmService = new SDMServiceImpl();
+    // get HTTP connection pool configuration
+    var connectionPool = getConnectionPool(environment);
+
+    SDMService sdmService = new SDMServiceImpl(binding, connectionPool);
     configurer.eventHandler(buildReadHandler());
     configurer.eventHandler(new SDMCreateAttachmentsHandler(sdmService));
     configurer.eventHandler(new SDMUpdateAttachmentsHandler(persistenceService, sdmService));
@@ -49,6 +68,17 @@ public class Registration implements CdsRuntimeConfiguration {
   private AttachmentService buildAttachmentService() {
     logger.info("Registering SDM attachment service");
     return new SDMAttachmentsService();
+  }
+
+  private static CdsProperties.ConnectionPool getConnectionPool(CdsEnvironment env) {
+    // the common prefix for the connection pool configuration
+    final String prefix = "cds.attachments.sdm.http.%s";
+    Duration timeout =
+        Duration.ofSeconds(env.getProperty(prefix.formatted("timeout"), Integer.class, 1200));
+    int maxConnections = env.getProperty(prefix.formatted("maxConnections"), Integer.class, 100);
+    logger.debug(
+        "Connection pool configuration: timeout={}, maxConnections={}", timeout, maxConnections);
+    return new CdsProperties.ConnectionPool(timeout, maxConnections, maxConnections);
   }
 
   protected EventHandler buildReadHandler() {

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -8,10 +8,6 @@ public class SDMConstants {
   }
 
   public static final String REPOSITORY_ID = System.getenv("REPOSITORY_ID");
-  public static final String BEARER_TOKEN = "Bearer ";
-  public static final int TIMEOUT = 900;
-
-  public static final String TENANT_ID = "X-zid";
   public static final String DUPLICATE_FILE_IN_DRAFT_ERROR_MESSAGE =
       "The file(s) %s have been added multiple times. Please rename and try again.";
   public static final String FILES_RENAME_WARNING_MESSAGE =
@@ -25,12 +21,11 @@ public class SDMConstants {
   public static final String VIRUS_ERROR = "%s contains potential malware and cannot be uploaded.";
   public static final String REPOSITORY_ERROR = "Failed to get repository info.";
   public static final String NOT_FOUND_ERROR = "Failed to read document.";
-  public static final String NAME_CONSTRAINT_WARNING_MESSAGE =
-      "Enter a valid file name for %s. The following characters are not supported: /, \\";
   public static final String SDM_ENV_NAME = "sdm";
 
   public static final String SDM_TOKEN_EXCHANGE_DESTINATION = "sdm-token-exchange-flow";
   public static final String SDM_TECHNICAL_CREDENTIALS_FLOW_DESTINATION = "sdm-technical-user-flow";
+  public static final String SDM_CONNECTIONPOOL_PREFIX = "cds.attachments.sdm.http.%s";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -27,6 +27,10 @@ public class SDMConstants {
   public static final String NOT_FOUND_ERROR = "Failed to read document.";
   public static final String NAME_CONSTRAINT_WARNING_MESSAGE =
       "Enter a valid file name for %s. The following characters are not supported: /, \\";
+  public static final String SDM_ENV_NAME = "sdm";
+
+  public static final String SDM_TOKEN_EXCHANGE_DESTINATION = "sdm-token-exchange-flow";
+  public static final String SDM_TECHNICAL_CREDENTIALS_FLOW_DESTINATION = "sdm-technical-user-flow";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
@@ -34,7 +34,7 @@ public class TokenHandler {
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  public TokenHandler() {
+  private TokenHandler() {
     throw new IllegalStateException("TokenHandler class");
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
@@ -1,7 +1,5 @@
 package com.sap.cds.sdm.handler;
 
-import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
-import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.ASSERTION;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,43 +8,33 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.sap.cds.sdm.caching.CacheConfig;
-import com.sap.cds.sdm.caching.CacheKey;
 import com.sap.cds.sdm.caching.TokenCacheKey;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.SDMCredentials;
+import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingAccessor;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
-import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
-import com.sap.cloud.security.xsuaa.http.HttpHeaders;
-import com.sap.cloud.security.xsuaa.http.MediaType;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpClientFactory;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
+import com.sap.cloud.sdk.cloudplatform.connectivity.OAuth2DestinationBuilder;
+import com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf;
+import com.sap.cloud.security.config.ClientCredentials;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.http.client.HttpClient;
 
 public class TokenHandler {
-  private static final Logger logger = LoggerFactory.getLogger(TokenHandler.class);
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  private TokenHandler() {
+  public TokenHandler() {
     throw new IllegalStateException("TokenHandler class");
   }
 
@@ -57,6 +45,11 @@ public class TokenHandler {
   public static String toString(byte[] bytes) {
     return new String(requireNonNull(bytes), StandardCharsets.UTF_8);
   }
+
+  private static final String SDM_TOKEN_ENDPOINT = "url";
+  private static final String SDM_URL = "uri";
+  private static final String CLIENT_ID = "clientid";
+  private static final String CLIENT_SECRET = "clientsecret";
 
   public static SDMCredentials getSDMCredentials() {
     List<ServiceBinding> allServiceBindings =
@@ -76,62 +69,6 @@ public class TokenHandler {
     sdmCredentials.setClientId(uaa.get("clientid").toString());
     sdmCredentials.setClientSecret(uaa.get("clientsecret").toString());
     return sdmCredentials;
-  }
-
-  public static String getAccessToken(SDMCredentials sdmCredentials, String token)
-      throws IOException {
-    // Fetch the token from Cache if present use it else generate and store
-    JsonObject payloadObj = getTokenFields(token);
-    String email = payloadObj.get("email").getAsString();
-    JsonObject tenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
-    String subdomain = tenantDetails.get("zdn").getAsString();
-    String tokenexpiry = payloadObj.get("exp").getAsString();
-    CacheKey cacheKey = new CacheKey();
-    cacheKey.setKey(email + "_" + subdomain);
-    cacheKey.setExpiration(tokenexpiry);
-    String cachedToken = CacheConfig.getClientCredentialsTokenCache().get(cacheKey);
-    if (cachedToken == null) {
-      String userCredentials =
-          sdmCredentials.getClientId() + ":" + sdmCredentials.getClientSecret();
-      String authHeaderValue = "Basic " + Base64.encodeBase64String(toBytes(userCredentials));
-      String bodyParams = "grant_type=client_credentials";
-      byte[] postData = toBytes(bodyParams);
-      String baseTokenUrl = sdmCredentials.getBaseTokenUrl();
-      if (subdomain != null && !subdomain.equals("")) {
-        String providersubdomain =
-            baseTokenUrl.substring(baseTokenUrl.indexOf("/") + 2, baseTokenUrl.indexOf("."));
-        baseTokenUrl = baseTokenUrl.replace(providersubdomain, subdomain);
-      }
-      String authurl = baseTokenUrl + "/oauth/token";
-      URL url = new URL(authurl);
-      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      conn.setRequestProperty("Authorization", authHeaderValue);
-      conn.setRequestMethod("POST");
-      conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-      conn.setRequestProperty("charset", "utf-8");
-      conn.setRequestProperty("Content-Length", "" + postData.length);
-      conn.setUseCaches(false);
-      conn.setDoInput(true);
-      conn.setDoOutput(true);
-      try (DataOutputStream os = new DataOutputStream(conn.getOutputStream())) {
-        os.write(postData);
-      }
-      String resp;
-      try (DataInputStream is = new DataInputStream(conn.getInputStream());
-          BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
-        resp = br.lines().collect(Collectors.joining("\n"));
-      }
-      conn.disconnect();
-      cachedToken = mapper.readValue(resp, JsonNode.class).get("access_token").asText();
-      String expiryTime = payloadObj.get("exp").getAsString();
-      cacheKey = new CacheKey();
-      JsonObject jsonTenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
-      subdomain = jsonTenantDetails.get("zdn").getAsString();
-      cacheKey.setKey(payloadObj.get("email").getAsString() + "_" + subdomain);
-      cacheKey.setExpiration(expiryTime);
-      CacheConfig.getClientCredentialsTokenCache().put(cacheKey, cachedToken);
-    }
-    return cachedToken;
   }
 
   public static String getUserTokenFromAuthorities(
@@ -187,22 +124,6 @@ public class TokenHandler {
     return cachedToken;
   }
 
-  public static String getDIToken(String token, SDMCredentials sdmCredentials) throws IOException {
-    JsonObject payloadObj = getTokenFields(token);
-    String email = payloadObj.get("email").getAsString();
-    JsonObject tenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
-    String subdomain = tenantDetails.get("zdn").getAsString();
-    String tokenexpiry = payloadObj.get("exp").getAsString();
-    CacheKey cacheKey = new CacheKey();
-    cacheKey.setKey(email + "_" + subdomain);
-    cacheKey.setExpiration(tokenexpiry);
-    String cachedToken = CacheConfig.getUserTokenCache().get(cacheKey);
-    if (cachedToken == null) {
-      cachedToken = generateDITokenFromTokenExchange(token, sdmCredentials, payloadObj);
-    }
-    return cachedToken;
-  }
-
   public static String getDITokenUsingAuthorities(
       SDMCredentials sdmCredentials, String email, String subdomain) throws IOException {
     TokenCacheKey cacheKey = new TokenCacheKey();
@@ -210,54 +131,6 @@ public class TokenHandler {
     String cachedToken = CacheConfig.getUserAuthoritiesTokenCache().get(cacheKey);
     if (cachedToken == null) {
       cachedToken = getUserTokenFromAuthorities(email, subdomain, sdmCredentials);
-    }
-    return cachedToken;
-  }
-
-  private static String generateDITokenFromTokenExchange(
-      String token, SDMCredentials sdmCredentials, JsonObject payloadObj)
-      throws OAuth2ServiceException {
-    String cachedToken = null;
-    CloseableHttpClient httpClient = null;
-    try {
-      httpClient = HttpClients.createDefault();
-      if (sdmCredentials.getClientId() == null) {
-        throw new IOException("No SDM binding found");
-      }
-      Map<String, String> parameters = fillTokenExchangeBody(token, sdmCredentials);
-      HttpPost httpPost = new HttpPost(sdmCredentials.getBaseTokenUrl() + "/oauth/token");
-      httpPost.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.value());
-      httpPost.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED.value());
-      httpPost.setHeader(SDMConstants.TENANT_ID, getTokenFields(token).get("zid").getAsString());
-
-      List<BasicNameValuePair> basicNameValuePairs =
-          parameters.entrySet().stream()
-              .map(entry -> new BasicNameValuePair(entry.getKey(), entry.getValue()))
-              .collect(Collectors.toList());
-      httpPost.setEntity(new UrlEncodedFormEntity(basicNameValuePairs));
-      HttpResponse response = httpClient.execute(httpPost);
-      String responseBody = extractResponseBodyAsString(response);
-      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-        logger.error("Error fetching token with JWT bearer : " + responseBody);
-      }
-      Map<String, Object> accessTokenMap = new JSONObject(responseBody).toMap();
-      cachedToken = String.valueOf(accessTokenMap.get("access_token"));
-      String expiryTime = payloadObj.get("exp").getAsString();
-      CacheKey cacheKey = new CacheKey();
-      JsonObject tenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
-      String subdomain = tenantDetails.get("zdn").getAsString();
-      cacheKey.setKey(payloadObj.get("email").getAsString() + "_" + subdomain);
-      cacheKey.setExpiration(expiryTime);
-      CacheConfig.getUserTokenCache().put(cacheKey, cachedToken);
-    } catch (UnsupportedEncodingException e) {
-      throw new OAuth2ServiceException("Unexpected error parsing URI: " + e.getMessage());
-    } catch (ClientProtocolException e) {
-      throw new OAuth2ServiceException(
-          "Unexpected error while fetching client protocol: " + e.getMessage());
-    } catch (IOException e) {
-      logger.error("Error in POST request while fetching token with JWT bearer", e.getMessage());
-    } finally {
-      safeClose(httpClient);
     }
     return cachedToken;
   }
@@ -270,30 +143,53 @@ public class TokenHandler {
     return jelement.getAsJsonObject();
   }
 
-  private static Map<String, String> fillTokenExchangeBody(String token, SDMCredentials sdmEnv) {
-    Map<String, String> parameters = new HashMap<>();
-    parameters.put(GRANT_TYPE, GRANT_TYPE_JWT_BEARER);
-    parameters.put(CLIENT_ID, sdmEnv.getClientId());
-    parameters.put(CLIENT_SECRET, sdmEnv.getClientSecret());
-    parameters.put(ASSERTION, token);
-    return parameters;
+  public static HttpClient getHttpClient(
+      ServiceBinding binding,
+      CdsProperties.ConnectionPool connectionPoolConfig,
+      String subdomain,
+      String type) {
+
+    Map<String, Object> uaaCredentials = binding.getCredentials();
+    Map<String, Object> uaa = (Map<String, Object>) uaaCredentials.get("uaa");
+    ClientCredentials clientCredentials =
+        new ClientCredentials(uaa.get(CLIENT_ID).toString(), uaa.get(CLIENT_SECRET).toString());
+    String baseTokenUrl = uaa.get(SDM_TOKEN_ENDPOINT).toString();
+    if (subdomain != null && !subdomain.equals("")) {
+      String providersubdomain =
+          baseTokenUrl.substring(baseTokenUrl.indexOf("/") + 2, baseTokenUrl.indexOf("."));
+      baseTokenUrl = baseTokenUrl.replace(providersubdomain, subdomain);
+    }
+
+    DefaultHttpDestination destination;
+    if (type.equals("TOKEN_EXCHANGE")) {
+      destination =
+          OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
+              .withTokenEndpoint(baseTokenUrl)
+              .withClient(clientCredentials, OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+              .property("name", SDMConstants.SDM_TOKEN_EXCHANGE_DESTINATION)
+              .build();
+    } else {
+      destination =
+          OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
+              .withTokenEndpoint(baseTokenUrl)
+              .withClient(clientCredentials, OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT)
+              .property("name", SDMConstants.SDM_TECHNICAL_CREDENTIALS_FLOW_DESTINATION)
+              .build();
+    }
+
+    DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder =
+        DefaultHttpClientFactory.builder();
+    builder.timeoutMilliseconds((int) connectionPoolConfig.getTimeout().toMillis());
+    builder.maxConnectionsPerRoute(connectionPoolConfig.getMaxConnectionsPerRoute());
+    builder.maxConnectionsTotal(connectionPoolConfig.getMaxConnections());
+    DefaultHttpClientFactory factory = builder.build();
+
+    return factory.createHttpClient(destination);
   }
 
-  private static String extractResponseBodyAsString(HttpResponse response) throws IOException {
-    // Ensure that InputStream and BufferedReader are automatically closed
-    try (InputStream inputStream = response.getEntity().getContent();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
-      return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
-    }
-  }
-
-  private static void safeClose(CloseableHttpClient httpClient) {
-    if (httpClient != null) {
-      try {
-        httpClient.close();
-      } catch (IOException ex) {
-        logger.error("Failed to close httpclient " + ex.getMessage());
-      }
-    }
+  public static String getSubdomainFromToken(String token) {
+    JsonObject payloadObj = TokenHandler.getTokenFields(token);
+    JsonObject tenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
+    return tenantDetails.get("zdn").getAsString();
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
@@ -148,43 +148,45 @@ public class TokenHandler {
       CdsProperties.ConnectionPool connectionPoolConfig,
       String subdomain,
       String type) {
+    if (!binding.getCredentials().isEmpty()) {
+      Map<String, Object> uaaCredentials = binding.getCredentials();
+      Map<String, Object> uaa = (Map<String, Object>) uaaCredentials.get("uaa");
+      ClientCredentials clientCredentials =
+          new ClientCredentials(uaa.get(CLIENT_ID).toString(), uaa.get(CLIENT_SECRET).toString());
+      String baseTokenUrl = uaa.get(SDM_TOKEN_ENDPOINT).toString();
+      if (subdomain != null && !subdomain.isEmpty()) {
+        String providersubdomain =
+            baseTokenUrl.substring(baseTokenUrl.indexOf("/") + 2, baseTokenUrl.indexOf("."));
+        baseTokenUrl = baseTokenUrl.replace(providersubdomain, subdomain);
+      }
 
-    Map<String, Object> uaaCredentials = binding.getCredentials();
-    Map<String, Object> uaa = (Map<String, Object>) uaaCredentials.get("uaa");
-    ClientCredentials clientCredentials =
-        new ClientCredentials(uaa.get(CLIENT_ID).toString(), uaa.get(CLIENT_SECRET).toString());
-    String baseTokenUrl = uaa.get(SDM_TOKEN_ENDPOINT).toString();
-    if (subdomain != null && !subdomain.equals("")) {
-      String providersubdomain =
-          baseTokenUrl.substring(baseTokenUrl.indexOf("/") + 2, baseTokenUrl.indexOf("."));
-      baseTokenUrl = baseTokenUrl.replace(providersubdomain, subdomain);
+      DefaultHttpDestination destination;
+      if (type.equals("TOKEN_EXCHANGE")) {
+        destination =
+            OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
+                .withTokenEndpoint(baseTokenUrl)
+                .withClient(clientCredentials, OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                .property("name", SDMConstants.SDM_TOKEN_EXCHANGE_DESTINATION)
+                .build();
+      } else {
+        destination =
+            OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
+                .withTokenEndpoint(baseTokenUrl)
+                .withClient(clientCredentials, OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT)
+                .property("name", SDMConstants.SDM_TECHNICAL_CREDENTIALS_FLOW_DESTINATION)
+                .build();
+      }
+
+      DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder =
+          DefaultHttpClientFactory.builder();
+      builder.timeoutMilliseconds((int) connectionPoolConfig.getTimeout().toMillis());
+      builder.maxConnectionsPerRoute(connectionPoolConfig.getMaxConnectionsPerRoute());
+      builder.maxConnectionsTotal(connectionPoolConfig.getMaxConnections());
+      DefaultHttpClientFactory factory = builder.build();
+
+      return factory.createHttpClient(destination);
     }
-
-    DefaultHttpDestination destination;
-    if (type.equals("TOKEN_EXCHANGE")) {
-      destination =
-          OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
-              .withTokenEndpoint(baseTokenUrl)
-              .withClient(clientCredentials, OnBehalfOf.NAMED_USER_CURRENT_TENANT)
-              .property("name", SDMConstants.SDM_TOKEN_EXCHANGE_DESTINATION)
-              .build();
-    } else {
-      destination =
-          OAuth2DestinationBuilder.forTargetUrl(uaaCredentials.get(SDM_URL).toString())
-              .withTokenEndpoint(baseTokenUrl)
-              .withClient(clientCredentials, OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT)
-              .property("name", SDMConstants.SDM_TECHNICAL_CREDENTIALS_FLOW_DESTINATION)
-              .build();
-    }
-
-    DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder =
-        DefaultHttpClientFactory.builder();
-    builder.timeoutMilliseconds((int) connectionPoolConfig.getTimeout().toMillis());
-    builder.maxConnectionsPerRoute(connectionPoolConfig.getMaxConnectionsPerRoute());
-    builder.maxConnectionsTotal(connectionPoolConfig.getMaxConnections());
-    DefaultHttpClientFactory factory = builder.build();
-
-    return factory.createHttpClient(destination);
+    return null;
   }
 
   public static String getSubdomainFromToken(String token) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -10,23 +10,23 @@ import org.json.JSONObject;
 
 public interface SDMService {
   public JSONObject createDocument(
-      CmisDocument cmisDocument, String jwtToken, SDMCredentials sdmCredentials) throws IOException;
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, String jwtToken) throws IOException;
 
   public String createFolder(
-      String parentId, String jwtToken, String repositoryId, SDMCredentials sdmCredentials)
+      String parentId, String repositoryId, SDMCredentials sdmCredentials, String jwtToken)
       throws IOException;
 
   public String getFolderId(
-      String jwtToken, Result result, PersistenceService persistenceService, String upID)
+      Result result, PersistenceService persistenceService, String upID, String jwtToken)
       throws IOException;
 
   public String getFolderIdByPath(
-      String parentId, String jwtToken, String repositoryId, SDMCredentials sdmCredentials)
+      String parentId, String repositoryId, SDMCredentials sdmCredentials, String jwtToken)
       throws IOException;
 
-  public String checkRepositoryType(String repositoryId, String token) throws IOException;
+  public String checkRepositoryType(String jwtToken, String repositoryId) throws IOException;
 
-  public JSONObject getRepositoryInfo(String token, SDMCredentials sdmCredentials)
+  public JSONObject getRepositoryInfo(SDMCredentials sdmCredentials, String subdomain)
       throws IOException;
 
   public Boolean isRepositoryVersioned(JSONObject repoInfo, String repositoryId) throws IOException;

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -10,79 +10,74 @@ import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.services.ServiceException;
+import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import okhttp3.*;
 import org.apache.http.HttpEntity;
-import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 
 public class SDMServiceImpl implements SDMService {
+  private final ServiceBinding binding;
+  private final CdsProperties.ConnectionPool connectionPool;
+
+  public SDMServiceImpl(ServiceBinding binding, CdsProperties.ConnectionPool connectionPool) {
+    this.connectionPool = connectionPool;
+    this.binding = binding;
+  }
 
   @Override
   public JSONObject createDocument(
-      CmisDocument cmisDocument, String jwtToken, SDMCredentials sdmCredentials)
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, String jwtToken)
       throws IOException {
-    String accessToken;
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
     Map<String, String> finalResponse = new HashMap<>();
-    accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
-
     String sdmUrl = sdmCredentials.getUrl() + "browser/" + cmisDocument.getRepositoryId() + "/root";
 
-    try (CloseableHttpClient httpClient =
-        HttpClients.custom()
-            .setDefaultRequestConfig(
-                RequestConfig.custom()
-                    .setConnectTimeout(SDMConstants.TIMEOUT * 1000)
-                    .setSocketTimeout(SDMConstants.TIMEOUT * 1000)
-                    .setConnectionRequestTimeout(SDMConstants.TIMEOUT * 1000)
-                    .build())
-            .build()) {
-
-      HttpPost uploadFile = new HttpPost(sdmUrl);
-      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-      uploadFile.setHeader("Authorization", "Bearer " + accessToken);
-      builder.addBinaryBody(
-          "filename",
-          cmisDocument.getContent(),
-          ContentType.create(cmisDocument.getMimeType()),
-          cmisDocument.getFileName());
-      // Add additional form fields
-      builder.addTextBody("cmisaction", "createDocument", ContentType.TEXT_PLAIN);
-      builder.addTextBody("objectId", cmisDocument.getFolderId(), ContentType.TEXT_PLAIN);
-      builder.addTextBody("propertyId[0]", "cmis:name", ContentType.TEXT_PLAIN);
-      builder.addTextBody("propertyValue[0]", cmisDocument.getFileName(), ContentType.TEXT_PLAIN);
-      builder.addTextBody("propertyId[1]", "cmis:objectTypeId", ContentType.TEXT_PLAIN);
-      builder.addTextBody("propertyValue[1]", "cmis:document", ContentType.TEXT_PLAIN);
-      builder.addTextBody("succinct", "true", ContentType.TEXT_PLAIN);
-      HttpEntity multipart = builder.build();
-      uploadFile.setEntity(multipart);
-      executeHttpPost(httpClient, uploadFile, cmisDocument, finalResponse);
-    } catch (IOException e) {
-      throw new ServiceException(SDMConstants.getGenericError("upload"));
-    }
+    HttpPost uploadFile = new HttpPost(sdmUrl);
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    builder.addBinaryBody(
+        "filename",
+        cmisDocument.getContent(),
+        ContentType.create(cmisDocument.getMimeType()),
+        cmisDocument.getFileName());
+    // Add additional form fields
+    builder.addTextBody("cmisaction", "createDocument", ContentType.TEXT_PLAIN);
+    builder.addTextBody("objectId", cmisDocument.getFolderId(), ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[0]", "cmis:name", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[0]", cmisDocument.getFileName(), ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[1]", "cmis:objectTypeId", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[1]", "cmis:document", ContentType.TEXT_PLAIN);
+    builder.addTextBody("succinct", "true", ContentType.TEXT_PLAIN);
+    HttpEntity multipart = builder.build();
+    uploadFile.setEntity(multipart);
+    executeHttpPost(httpClient, uploadFile, cmisDocument, finalResponse);
     return new JSONObject(finalResponse);
   }
 
   private void executeHttpPost(
-      CloseableHttpClient httpClient,
+      HttpClient httpClient,
       HttpPost uploadFile,
       CmisDocument cmisDocument,
       Map<String, String> finalResponse)
       throws ServiceException {
-    try (CloseableHttpResponse response = httpClient.execute(uploadFile)) {
+    try (var response = (CloseableHttpResponse) httpClient.execute(uploadFile)) {
       formResponse(cmisDocument, finalResponse, response);
     } catch (IOException e) {
       throw new ServiceException("Error in setting timeout", e.getMessage());
@@ -133,32 +128,25 @@ public class SDMServiceImpl implements SDMService {
 
   @Override
   public int renameAttachments(
-      String jwtToken, SDMCredentials sdmCredentials, CmisDocument cmisDocument)
-      throws IOException {
+      String jwtToken, SDMCredentials sdmCredentials, CmisDocument cmisDocument) {
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    OkHttpClient client = new OkHttpClient();
-    String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
     String sdmUrl = sdmCredentials.getUrl() + "browser/" + repositoryId + "/root";
     String fileName = cmisDocument.getFileName();
     String objectId = cmisDocument.getObjectId();
-    RequestBody requestBody =
-        new MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("cmisaction", "update")
-            .addFormDataPart("propertyId[0]", "cmis:name")
-            .addFormDataPart("propertyValue[0]", fileName)
-            .addFormDataPart("objectId", objectId)
-            .build();
-
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + accessToken)
-            .post(requestBody)
-            .build();
-
-    try (Response response = client.newCall(request).execute()) {
-      return response.code();
+    HttpPost renameRequest = new HttpPost(sdmUrl);
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    // Add additional form fields
+    builder.addTextBody("cmisaction", "update", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[0]", "cmis:name", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[0]", fileName, ContentType.TEXT_PLAIN);
+    builder.addTextBody("objectId", objectId, ContentType.TEXT_PLAIN);
+    HttpEntity multipart = builder.build();
+    renameRequest.setEntity(multipart);
+    try (var response = (CloseableHttpResponse) httpClient.execute(renameRequest)) {
+      return response.getStatusLine().getStatusCode();
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.COULD_NOT_RENAME_THE_ATTACHMENT, e);
     }
@@ -167,8 +155,10 @@ public class SDMServiceImpl implements SDMService {
   @Override
   public String getObject(String jwtToken, String objectId, SDMCredentials sdmCredentials)
       throws IOException {
-    OkHttpClient client = new OkHttpClient();
-    String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+
     String sdmUrl =
         sdmCredentials.getUrl()
             + "browser/"
@@ -176,22 +166,16 @@ public class SDMServiceImpl implements SDMService {
             + "/root?cmisselector=object&objectId="
             + objectId
             + "&succinct=true";
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + accessToken)
-            .get()
-            .build();
 
-    try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful()) {
+    HttpGet getObjectRequest = new HttpGet(sdmUrl);
+    try (var response = (CloseableHttpResponse) httpClient.execute(getObjectRequest)) {
+      if (response.getStatusLine().getStatusCode() != 200) {
         return null;
-      } else {
-        String object = response.body().string();
-        JSONObject jsonObject = new JSONObject(object);
-        JSONObject succinctProperties = jsonObject.getJSONObject("succinctProperties");
-        return succinctProperties.getString("cmis:name");
       }
+      String responseString = EntityUtils.toString(response.getEntity());
+      JSONObject jsonObject = new JSONObject(responseString);
+      JSONObject succinctProperties = jsonObject.getJSONObject("succinctProperties");
+      return succinctProperties.getString("cmis:name");
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.ATTACHMENT_NOT_FOUND, e);
     }
@@ -202,11 +186,12 @@ public class SDMServiceImpl implements SDMService {
       String objectId,
       String jwtToken,
       SDMCredentials sdmCredentials,
-      AttachmentReadEventContext context)
-      throws IOException {
+      AttachmentReadEventContext context) {
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    OkHttpClient client = new OkHttpClient();
-    String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+
     String sdmUrl =
         sdmCredentials.getUrl()
             + "browser/"
@@ -214,32 +199,26 @@ public class SDMServiceImpl implements SDMService {
             + "/root?objectID="
             + objectId
             + "&cmisselector=content";
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", "Bearer " + accessToken)
-            .get()
-            .build();
 
-    Response response = client.newCall(request).execute();
-    if (!response.isSuccessful()) {
-      response.close();
-      throw new ServiceException("Unexpected code");
-    }
-
-    InputStream documentStream = response.body().byteStream();
-    try {
-      context.getData().setContent(documentStream);
+    HttpGet getContentRequest = new HttpGet(sdmUrl);
+    try (var response = (CloseableHttpResponse) httpClient.execute(getContentRequest)) {
+      int responseCode = response.getStatusLine().getStatusCode();
+      if (responseCode != 200) {
+        response.close();
+        throw new ServiceException("Unexpected code " + responseCode);
+      }
+      byte[] responseBody = EntityUtils.toByteArray(response.getEntity());
+      try (InputStream inputStream = new ByteArrayInputStream(responseBody)) {
+        context.getData().setContent(inputStream);
+      }
     } catch (Exception e) {
-      response.close();
       throw new ServiceException("Failed to set document stream in context");
     }
   }
 
   @Override
   public String getFolderId(
-      String jwtToken, Result result, PersistenceService persistenceService, String upID)
-      throws IOException {
+      Result result, PersistenceService persistenceService, String upID, String token) {
 
     List<Map<String, Object>> resultList =
         result.listOf(Map.class).stream()
@@ -262,9 +241,9 @@ public class SDMServiceImpl implements SDMService {
     SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
 
     if (folderId == null) {
-      folderId = getFolderIdByPath(upID, jwtToken, SDMConstants.REPOSITORY_ID, sdmCredentials);
+      folderId = getFolderIdByPath(upID, SDMConstants.REPOSITORY_ID, sdmCredentials, token);
       if (folderId == null) {
-        folderId = createFolder(upID, jwtToken, SDMConstants.REPOSITORY_ID, sdmCredentials);
+        folderId = createFolder(upID, SDMConstants.REPOSITORY_ID, sdmCredentials, token);
         JSONObject jsonObject = new JSONObject(folderId);
         JSONObject succinctProperties = jsonObject.getJSONObject("succinctProperties");
         folderId = succinctProperties.getString("cmis:objectId");
@@ -275,10 +254,10 @@ public class SDMServiceImpl implements SDMService {
 
   @Override
   public String getFolderIdByPath(
-      String parentId, String jwtToken, String repositoryId, SDMCredentials sdmCredentials)
-      throws IOException {
-    OkHttpClient client = new OkHttpClient();
-    String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
+      String parentId, String repositoryId, SDMCredentials sdmCredentials, String token) {
+    String subdomain = TokenHandler.getSubdomainFromToken(token);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
     String sdmUrl =
         sdmCredentials.getUrl()
             + "browser/"
@@ -286,63 +265,49 @@ public class SDMServiceImpl implements SDMService {
             + "/root/"
             + parentId
             + "?cmisselector=object";
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + accessToken)
-            .get()
-            .build();
-
-    try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful()) {
+    HttpPost getFolderRequest = new HttpPost(sdmUrl);
+    try (var response = (CloseableHttpResponse) httpClient.execute(getFolderRequest)) {
+      if (response.getStatusLine().getStatusCode() != 200) {
         return null;
-      } else {
-        String responseBody = response.body().string();
-        JSONObject jsonObject = new JSONObject(responseBody);
-        JSONObject properties = jsonObject.getJSONObject("properties");
-        JSONObject cmisObjectId = properties.getJSONObject("cmis:objectId");
-        String folderId = cmisObjectId.getString("value");
-        return folderId;
       }
-    }
-  }
-
-  @Override
-  public String createFolder(
-      String parentId, String jwtToken, String repositoryId, SDMCredentials sdmCredentials)
-      throws IOException {
-    OkHttpClient client = new OkHttpClient();
-    String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
-    String sdmUrl = sdmCredentials.getUrl() + "browser/" + repositoryId + "/root";
-    RequestBody requestBody =
-        new MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("cmisaction", "createFolder")
-            .addFormDataPart("propertyId[0]", "cmis:name")
-            .addFormDataPart("propertyValue[0]", parentId)
-            .addFormDataPart("propertyId[1]", "cmis:objectTypeId")
-            .addFormDataPart("propertyValue[1]", "cmis:folder")
-            .addFormDataPart("succinct", "true")
-            .build();
-
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + accessToken)
-            .post(requestBody)
-            .build();
-
-    try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful())
-        throw new ServiceException(SDMConstants.getGenericError("upload"));
-      return response.body().string();
+      return EntityUtils.toString(response.getEntity());
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
   }
 
   @Override
-  public String checkRepositoryType(String repositoryId, String jwttoken) throws IOException {
+  public String createFolder(
+      String parentId, String repositoryId, SDMCredentials sdmCredentials, String jwtToken) {
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+    String sdmUrl = sdmCredentials.getUrl() + "browser/" + repositoryId + "/root";
+    HttpPost createFolderRequest = new HttpPost(sdmUrl);
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    // Add additional form fields
+    builder.addTextBody("cmisaction", "createFolder", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[0]", "cmis:name", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[0]", parentId, ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[1]", "cmis:objectTypeId", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[1]", "cmis:folder", ContentType.TEXT_PLAIN);
+    builder.addTextBody("succinct", "true", ContentType.TEXT_PLAIN);
+    HttpEntity multipart = builder.build();
+    createFolderRequest.setEntity(multipart);
+    try (var response = (CloseableHttpResponse) httpClient.execute(createFolderRequest)) {
+      int responseCode = response.getStatusLine().getStatusCode();
+      String responseBody = EntityUtils.toString(response.getEntity());
+      if (responseCode != 201) {
+        throw new ServiceException("Failed to create folder. " + responseBody);
+      }
+      return responseBody;
+    } catch (IOException e) {
+      throw new ServiceException("Failed to create folder " + e.getMessage());
+    }
+  }
+
+  @Override
+  public String checkRepositoryType(String jwttoken, String repositoryId) {
     RepoKey repoKey = new RepoKey();
     JsonObject payloadObj = TokenHandler.getTokenFields(jwttoken);
     JsonObject tenantDetails = payloadObj.get("ext_attr").getAsJsonObject();
@@ -353,8 +318,7 @@ public class SDMServiceImpl implements SDMService {
     Boolean isVersioned;
     if (type == null) {
       SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
-      String token = TokenHandler.getAccessToken(sdmCredentials, jwttoken);
-      JSONObject repoInfo = getRepositoryInfo(token, sdmCredentials);
+      JSONObject repoInfo = getRepositoryInfo(sdmCredentials, subdomain);
       isVersioned = isRepositoryVersioned(repoInfo, repositoryId);
     } else {
       isVersioned = "Versioned".equals(type);
@@ -375,37 +339,29 @@ public class SDMServiceImpl implements SDMService {
     }
   }
 
-  public JSONObject getRepositoryInfo(String token, SDMCredentials sdmCredentials)
-      throws IOException {
+  public JSONObject getRepositoryInfo(SDMCredentials sdmCredentials, String subdomain) {
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    OkHttpClient client = new OkHttpClient();
+    var httpClient =
+        TokenHandler.getHttpClient(
+            binding, connectionPool, subdomain, "TECHNICAL_CREDENTIALS_FLOW");
+
     String getRepoInfoUrl =
         sdmCredentials.getUrl() + "browser/" + repositoryId + "?cmisselector=repositoryInfo";
-
-    Request request =
-        new Request.Builder()
-            .url(getRepoInfoUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + token)
-            .get()
-            .build();
-
-    try (Response response = client.newCall(request).execute()) {
-      if (!response.isSuccessful()) {
+    HttpGet getRepoInfoRequest = new HttpGet(getRepoInfoUrl);
+    try (var response = (CloseableHttpResponse) httpClient.execute(getRepoInfoRequest)) {
+      if (response.getStatusLine().getStatusCode() != 200)
         throw new ServiceException(SDMConstants.REPOSITORY_ERROR);
-      }
-      String responseBody = response.body().string();
-      return new JSONObject(responseBody);
+      String responseString = EntityUtils.toString(response.getEntity());
+      return new JSONObject(responseString);
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.REPOSITORY_ERROR);
     }
   }
 
-  public Boolean isRepositoryVersioned(JSONObject repoInfo, String repositoryId)
-      throws IOException {
+  public Boolean isRepositoryVersioned(JSONObject repoInfo, String repositoryId) {
     repoInfo = repoInfo.getJSONObject(repositoryId);
     JSONObject capabilities = repoInfo.getJSONObject("capabilities");
     String type = capabilities.getString("capabilityContentStreamUpdatability");
-
     if ("pwconly".equals(type)) {
       type = "Versioned";
     } else {
@@ -419,28 +375,21 @@ public class SDMServiceImpl implements SDMService {
   public int deleteDocument(String cmisaction, String objectId, String userEmail, String subdomain)
       throws IOException {
     SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
-    OkHttpClient client = new OkHttpClient();
+
+    HttpClient httpClient = HttpClients.createDefault();
     String accessToken =
         TokenHandler.getDITokenUsingAuthorities(sdmCredentials, userEmail, subdomain);
-
     String sdmUrl = sdmCredentials.getUrl() + "browser/" + SDMConstants.REPOSITORY_ID + "/root";
-
-    RequestBody requestBody =
-        new MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("cmisaction", cmisaction)
-            .addFormDataPart("objectId", objectId)
-            .build();
-
-    Request request =
-        new Request.Builder()
-            .url(sdmUrl)
-            .addHeader("Authorization", SDMConstants.BEARER_TOKEN + accessToken)
-            .post(requestBody)
-            .build();
-
-    try (Response response = client.newCall(request).execute()) {
-      return response.code();
+    HttpPost deleteDocumentRequest = new HttpPost(sdmUrl);
+    deleteDocumentRequest.setHeader("Authorization", "Bearer " + accessToken);
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    // Add additional form fields
+    builder.addTextBody("cmisaction", cmisaction, ContentType.TEXT_PLAIN);
+    builder.addTextBody("objectId", objectId, ContentType.TEXT_PLAIN);
+    HttpEntity multipart = builder.build();
+    deleteDocumentRequest.setEntity(multipart);
+    try (var response = (CloseableHttpResponse) httpClient.execute(deleteDocumentRequest)) {
+      return response.getStatusLine().getStatusCode();
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("delete"));
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -267,10 +267,13 @@ public class SDMServiceImpl implements SDMService {
             + "?cmisselector=object";
     HttpPost getFolderRequest = new HttpPost(sdmUrl);
     try (var response = (CloseableHttpResponse) httpClient.execute(getFolderRequest)) {
-      if (response.getStatusLine().getStatusCode() != 200) {
-        return null;
+      int responseCode = response.getStatusLine().getStatusCode();
+      if (responseCode == 200) {
+        return EntityUtils.toString(response.getEntity());
+      } else if (responseCode == 403) {
+        throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
       }
-      return EntityUtils.toString(response.getEntity());
+      return null;
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
@@ -297,10 +300,12 @@ public class SDMServiceImpl implements SDMService {
     try (var response = (CloseableHttpResponse) httpClient.execute(createFolderRequest)) {
       int responseCode = response.getStatusLine().getStatusCode();
       String responseBody = EntityUtils.toString(response.getEntity());
-      if (responseCode != 201) {
+      if (responseCode == 201) return responseBody;
+      else if (responseCode == 403) {
+        throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
+      } else {
         throw new ServiceException("Failed to create folder. " + responseBody);
       }
-      return responseBody;
     } catch (IOException e) {
       throw new ServiceException("Failed to create folder " + e.getMessage());
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -2,7 +2,6 @@ package com.sap.cds.sdm.service.handler;
 
 import static com.sap.cds.sdm.persistence.DBQuery.*;
 
-import com.google.gson.JsonObject;
 import com.sap.cds.Result;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
 import com.sap.cds.feature.attachments.service.AttachmentService;
@@ -53,7 +52,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     AuthenticationInfo authInfo = context.getAuthenticationInfo();
     JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);
     String jwtToken = jwtTokenInfo.getToken();
-    String repocheck = sdmService.checkRepositoryType(repositoryId, jwtToken);
+    String repocheck = sdmService.checkRepositoryType(jwtToken, repositoryId);
     CmisDocument cmisDocument = new CmisDocument();
     if ("Versioned".equals(repocheck)) {
       throw new ServiceException(SDMConstants.VERSIONED_REPO_ERROR);
@@ -81,10 +80,8 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
         if (Boolean.TRUE.equals(duplicate)) {
           throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
         } else {
-          JsonObject tokenDetails = TokenHandler.getTokenFields(jwtToken);
-          JsonObject tenantDetails = tokenDetails.get("ext_attr").getAsJsonObject();
-          subdomain = tenantDetails.get("zdn").getAsString();
-          String folderId = sdmService.getFolderId(jwtToken, result, persistenceService, upID);
+          subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+          String folderId = sdmService.getFolderId(result, persistenceService, upID, jwtToken);
           cmisDocument.setFileName(filename);
           cmisDocument.setAttachmentId(fileid);
           InputStream contentStream = (InputStream) data.get("content");
@@ -95,7 +92,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
           cmisDocument.setMimeType(mimeType);
           SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
           JSONObject createResult =
-              sdmService.createDocument(cmisDocument, jwtToken, sdmCredentials);
+              sdmService.createDocument(cmisDocument, sdmCredentials, jwtToken);
 
           if (createResult.get("status") == "duplicate") {
             throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/configuration/RegistrationTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/configuration/RegistrationTest.java
@@ -14,7 +14,9 @@ import com.sap.cds.services.outbox.OutboxService;
 import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.runtime.CdsRuntime;
 import com.sap.cds.services.runtime.CdsRuntimeConfigurer;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,6 +41,17 @@ public class RegistrationTest {
     when(cdsRuntime.getServiceCatalog()).thenReturn(serviceCatalog);
     CdsEnvironment environment = mock(CdsEnvironment.class);
     when(cdsRuntime.getEnvironment()).thenReturn(environment);
+    ServiceBinding binding1 = mock(ServiceBinding.class);
+    ServiceBinding binding2 = mock(ServiceBinding.class);
+    ServiceBinding binding3 = mock(ServiceBinding.class);
+
+    // Create a stream of bindings to be returned by environment.getServiceBindings()
+    Stream<ServiceBinding> bindingsStream = Stream.of(binding1, binding2, binding3);
+    when(environment.getProperty("cds.attachments.sdm.http.timeout", Integer.class, 1200))
+        .thenReturn(1800);
+    when(environment.getProperty("cds.attachments.sdm.http.maxConnections", Integer.class, 100))
+        .thenReturn(200);
+
     persistenceService = mock(PersistenceService.class);
     attachmentService = mock(AttachmentService.class);
     outboxService = mock(OutboxService.class);
@@ -53,6 +66,9 @@ public class RegistrationTest {
     verify(configurer).service(serviceArgumentCaptor.capture());
     var services = serviceArgumentCaptor.getAllValues();
     assertThat(services).hasSize(1);
+    String prefix = "test";
+
+    // Perform the property reading
 
     var attachmentServiceFound =
         services.stream().anyMatch(service -> service instanceof AttachmentService);

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/TokenHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/TokenHandlerTest.java
@@ -7,62 +7,101 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.google.gson.JsonObject;
 import com.sap.cds.sdm.caching.CacheConfig;
-import com.sap.cds.sdm.caching.CacheKey;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.SDMCredentials;
+import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingAccessor;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceBindingAccessor;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpClientFactory;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.client.HttpClient;
 import org.ehcache.Cache;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 public class TokenHandlerTest {
   private String email = "email-value";
   private String subdomain = "subdomain-value";
+  private static final String SDM_TOKEN_ENDPOINT = "url";
+  private static final String SDM_URL = "uri";
+
+  private static final String CLIENT_ID = "clientid";
+  private static final String CLIENT_SECRET = "clientsecret";
+  @Mock private ServiceBinding binding;
+
+  @Mock private CdsProperties.ConnectionPool connectionPoolConfig;
+
+  @Mock private DefaultHttpClientFactory factory;
+
+  @Mock private HttpClient httpClient;
+
+  private Map<String, Object> uaaCredentials;
+  private Map<String, Object> uaa;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    uaaCredentials = new HashMap<>();
+    uaa = new HashMap<>();
+
+    uaa.put(CLIENT_ID, "test-client-id");
+    uaa.put(CLIENT_SECRET, "test-client-secret");
+    uaa.put(SDM_TOKEN_ENDPOINT, "https://test-token-url.com");
+
+    uaaCredentials.put("uaa", uaa);
+    uaaCredentials.put(SDM_URL, "https://example.com");
+
+    when(binding.getCredentials()).thenReturn(uaaCredentials);
+    when(connectionPoolConfig.getTimeout()).thenReturn(Duration.ofMillis(1000));
+    when(connectionPoolConfig.getMaxConnectionsPerRoute()).thenReturn(10);
+    when(connectionPoolConfig.getMaxConnections()).thenReturn(100);
+
+    // Instantiate and mock the factory
+    when(factory.createHttpClient(any(DefaultHttpDestination.class))).thenReturn(httpClient);
+  }
 
   @Test
-  public void testGetDIToken() throws IOException {
-    JsonObject expected = new JsonObject();
-    expected.addProperty(
-        "email", "john.doe@example.com"); // Correct the property name as expected in the method
-    expected.addProperty(
-        "exp", "1234567890"); // Correct the property name as expected in the method
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("zdn", "tenant");
-    expected.add("ext_attr", jsonObject);
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    try (MockedStatic<CacheConfig> cacheConfigMockedStatic =
-        Mockito.mockStatic(CacheConfig.class)) {
+  public void testGetHttpClientForTokenExchange() {
+    HttpClient client =
+        TokenHandler.getHttpClient(binding, connectionPoolConfig, "subdomain", "TOKEN_EXCHANGE");
 
-      Cache<String, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn("cachedToken"); // Cache is empty
-      cacheConfigMockedStatic.when(CacheConfig::getUserTokenCache).thenReturn(mockCache);
-      String result =
-          TokenHandler.getDIToken(
-              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.efgtgCjF7bxG2kEgYbkTObovuZN5YQP5t7yr9aPKntk",
-              mockSdmCredentials);
-      assertEquals("cachedToken", result); // Adjust based on the expected result
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
-    }
+    assertNotNull(client);
+  }
+
+  @Test
+  public void testGetHttpClientForTechnicalUser() {
+    HttpClient client =
+        TokenHandler.getHttpClient(binding, connectionPoolConfig, "subdomain", "TECHNICAL_USER");
+
+    assertNotNull(client);
+  }
+
+  @Test
+  public void testGetHttpClientWithNullSubdomain() {
+    HttpClient client =
+        TokenHandler.getHttpClient(binding, connectionPoolConfig, null, "TOKEN_EXCHANGE");
+
+    assertNotNull(client);
+  }
+
+  @Test
+  public void testGetHttpClientWithEmptySubdomain() {
+    HttpClient client =
+        TokenHandler.getHttpClient(binding, connectionPoolConfig, "", "TOKEN_EXCHANGE");
+
+    assertNotNull(client);
   }
 
   @Test
@@ -93,138 +132,6 @@ public class TokenHandlerTest {
               });
 
       assertEquals("subdomain-value.com", exception.getMessage());
-    }
-  }
-
-  @Test
-  public void testGetDITokenNoCache() throws IOException {
-    JsonObject mockPayload = new JsonObject();
-    mockPayload.addProperty("email", "john.doe@example.com");
-    mockPayload.addProperty("exp", "1234567890");
-    mockPayload.addProperty("zid", "tenant-id-value");
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("zdn", "tenant");
-    mockPayload.add("ext_attr", jsonObject);
-    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
-    CloseableHttpResponse mockResponse = Mockito.mock(CloseableHttpResponse.class);
-    HttpEntity mockEntity = Mockito.mock(HttpEntity.class);
-    StatusLine mockStatusLine = Mockito.mock(StatusLine.class);
-
-    Mockito.when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
-    Mockito.when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-    Mockito.when(mockEntity.getContent())
-        .thenReturn(new ByteArrayInputStream("{\"access_token\": \"mockedToken\"}".getBytes()));
-    Mockito.when(mockResponse.getEntity()).thenReturn(mockEntity);
-
-    Mockito.when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
-
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    Mockito.when(mockSdmCredentials.getClientId()).thenReturn("mockClientId");
-    Mockito.when(mockSdmCredentials.getBaseTokenUrl()).thenReturn("https://mock.url");
-
-    try (MockedStatic<HttpClients> httpClientsMockedStatic = Mockito.mockStatic(HttpClients.class);
-        MockedStatic<CacheConfig> cacheConfigMockedStatic =
-            Mockito.mockStatic(CacheConfig.class); ) {
-      httpClientsMockedStatic.when(HttpClients::createDefault).thenReturn(mockHttpClient);
-      Cache<String, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn(null); // Cache is empty
-
-      cacheConfigMockedStatic.when(CacheConfig::getUserTokenCache).thenReturn(mockCache);
-      String result =
-          TokenHandler.getDIToken(
-              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJ6aWQiOiJ0ZW5hbnQtaWQtdmFsdWUiLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.MHwowSANGLEUQojz65Y7EVFC_bvojDL8guXA5kjuKuw",
-              mockSdmCredentials);
-      assertEquals("mockedToken", result); // Adjust based on the expected result
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  public void testGetDITokenNoCacheNoSDMBinding() throws IOException {
-    JsonObject mockPayload = new JsonObject();
-    mockPayload.addProperty("email", "john.doe@example.com");
-    mockPayload.addProperty("exp", "1234567890");
-    mockPayload.addProperty("zid", "tenant-id-value");
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("zdn", "tenant");
-    mockPayload.add("ext_attr", jsonObject);
-    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
-    CloseableHttpResponse mockResponse = Mockito.mock(CloseableHttpResponse.class);
-    HttpEntity mockEntity = Mockito.mock(HttpEntity.class);
-    StatusLine mockStatusLine = Mockito.mock(StatusLine.class);
-
-    Mockito.when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
-    Mockito.when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-    Mockito.when(mockEntity.getContent())
-        .thenReturn(new ByteArrayInputStream("{\"access_token\": \"mockedToken\"}".getBytes()));
-    Mockito.when(mockResponse.getEntity()).thenReturn(mockEntity);
-
-    Mockito.when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
-
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    Mockito.when(mockSdmCredentials.getClientId()).thenReturn(null);
-    Mockito.when(mockSdmCredentials.getBaseTokenUrl()).thenReturn("https://mock.url");
-
-    try (MockedStatic<HttpClients> httpClientsMockedStatic = Mockito.mockStatic(HttpClients.class);
-        MockedStatic<CacheConfig> cacheConfigMockedStatic =
-            Mockito.mockStatic(CacheConfig.class); ) {
-      httpClientsMockedStatic.when(HttpClients::createDefault).thenReturn(mockHttpClient);
-      Cache<String, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn(null); // Cache is empty
-
-      cacheConfigMockedStatic.when(CacheConfig::getUserTokenCache).thenReturn(mockCache);
-      String result =
-          TokenHandler.getDIToken(
-              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.efgtgCjF7bxG2kEgYbkTObovuZN5YQP5t7yr9aPKntk",
-              mockSdmCredentials);
-      assertEquals(null, result); // Adjust based on the expected result
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  public void testGetDITokenNoCacheStatusCodeError() throws IOException {
-    JsonObject mockPayload = new JsonObject();
-    mockPayload.addProperty("email", "john.doe@example.com");
-    mockPayload.addProperty("exp", "1234567890");
-    mockPayload.addProperty("zid", "tenant-id-value");
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("zdn", "tenant");
-    mockPayload.add("ext_attr", jsonObject);
-    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
-    CloseableHttpResponse mockResponse = Mockito.mock(CloseableHttpResponse.class);
-    HttpEntity mockEntity = Mockito.mock(HttpEntity.class);
-    StatusLine mockStatusLine = Mockito.mock(StatusLine.class);
-
-    Mockito.when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
-    Mockito.when(mockStatusLine.getStatusCode()).thenReturn(123);
-    Mockito.when(mockEntity.getContent())
-        .thenReturn(new ByteArrayInputStream("{\"access_token\": \"mockedToken\"}".getBytes()));
-    Mockito.when(mockResponse.getEntity()).thenReturn(mockEntity);
-
-    Mockito.when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
-
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    Mockito.when(mockSdmCredentials.getClientId()).thenReturn("mockClientId");
-    Mockito.when(mockSdmCredentials.getBaseTokenUrl()).thenReturn("https://mock.url");
-
-    try (MockedStatic<HttpClients> httpClientsMockedStatic = Mockito.mockStatic(HttpClients.class);
-        MockedStatic<CacheConfig> cacheConfigMockedStatic =
-            Mockito.mockStatic(CacheConfig.class); ) {
-      httpClientsMockedStatic.when(HttpClients::createDefault).thenReturn(mockHttpClient);
-      Cache<String, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn(null); // Cache is empty
-
-      cacheConfigMockedStatic.when(CacheConfig::getUserTokenCache).thenReturn(mockCache);
-      String result =
-          TokenHandler.getDIToken(
-              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJ6aWQiOiJ0ZW5hbnQtaWQtdmFsdWUiLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.MHwowSANGLEUQojz65Y7EVFC_bvojDL8guXA5kjuKuw",
-              mockSdmCredentials);
-      assertEquals("mockedToken", result); // Adjust based on the expected result
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -260,69 +167,6 @@ public class TokenHandlerTest {
       assertEquals("https://mock.service.url", result.getUrl());
       assertEquals("mockClientId", result.getClientId());
       assertEquals("mockClientSecret", result.getClientSecret());
-    }
-  }
-
-  @Test
-  public void testGetAccessToken() {
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    String token =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.efgtgCjF7bxG2kEgYbkTObovuZN5YQP5t7yr9aPKntk";
-    try (MockedStatic<CacheConfig> cacheConfigMockedStatic =
-        Mockito.mockStatic(CacheConfig.class)) {
-      Cache<CacheKey, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn("cachedToken"); // Cache is empty
-      cacheConfigMockedStatic
-          .when(CacheConfig::getClientCredentialsTokenCache)
-          .thenReturn(mockCache);
-      String result = TokenHandler.getAccessToken(mockSdmCredentials, token);
-      assertEquals("cachedToken", result); // Adjust based on the expected result
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
-    } catch (ProtocolException e) {
-      throw new RuntimeException(e);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  public void testGetAccessTokenNoCache() {
-    SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-    when(mockSdmCredentials.getClientId()).thenReturn("mockClientId");
-    when(mockSdmCredentials.getClientSecret()).thenReturn("mockClientSecret");
-    when(mockSdmCredentials.getBaseTokenUrl()).thenReturn("https://mock.url");
-
-    String token =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.efgtgCjF7bxG2kEgYbkTObovuZN5YQP5t7yr9aPKntk";
-    try (MockedStatic<CacheConfig> cacheConfigMockedStatic =
-        Mockito.mockStatic(CacheConfig.class)) {
-      Cache<CacheKey, String> mockCache = Mockito.mock(Cache.class);
-      Mockito.when(mockCache.get(any())).thenReturn(null); // Cache is empty
-      cacheConfigMockedStatic
-          .when(CacheConfig::getClientCredentialsTokenCache)
-          .thenReturn(mockCache);
-      // String result = TokenHandler.getAccessToken(mockSdmCredentials, token);
-      HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
-      doNothing().when(mockConn).setRequestMethod("POST");
-      ByteArrayOutputStream mockOutputStream = new ByteArrayOutputStream();
-      // when(mockConn.getOutputStream()).thenReturn(new DataOutputStream(mockOutputStream));
-      doReturn(new DataOutputStream(mockOutputStream)).when(mockConn).getOutputStream();
-      doThrow(new IOException()).when(mockConn).getInputStream();
-      Exception exception =
-          assertThrows(
-              IOException.class,
-              () -> {
-                TokenHandler.getAccessToken(mockSdmCredentials, token);
-              });
-
-      assertEquals("tenant.url", exception.getMessage());
-    } catch (OAuth2ServiceException e) {
-      throw new RuntimeException(e);
-    } catch (ProtocolException e) {
-      throw new RuntimeException(e);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -370,5 +214,16 @@ public class TokenHandlerTest {
   @Test
   void testToStringWithNullInput() {
     assertThrows(NullPointerException.class, () -> TokenHandler.toString(null));
+  }
+
+  @Test
+  public void testGetSubdomainFromToken() {
+    String token =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTY4MzQxODI4MCwiZXhwIjoxNjg1OTQ0MjgwLCJleHRfYXR0ciI6eyJ6ZG4iOiJ0ZW5hbnQifX0.efgtgCjF7bxG2kEgYbkTObovuZN5YQP5t7yr9aPKntk";
+    // Performing the actual test
+    String result = TokenHandler.getSubdomainFromToken(token);
+
+    // Asserting the expected result
+    assertEquals("tenant", result);
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -17,7 +17,9 @@ import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.service.*;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.services.ServiceException;
+import com.sap.cds.services.environment.CdsProperties;
 import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,10 +27,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.ehcache.Cache;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -37,10 +46,23 @@ public class SDMServiceImplTest {
   private SDMService SDMService;
   JsonObject expected;
   RepoKey repoKey;
+  @Mock ServiceBinding binding;
+  @Mock CdsProperties.ConnectionPool connectionPool;
+  String subdomain = "SUBDOMAIN";
+
+  private CloseableHttpClient httpClient;
+  private CloseableHttpResponse response;
+
+  StatusLine statusLine;
+  HttpEntity entity;
 
   @BeforeEach
   public void setUp() {
-    SDMService = new SDMServiceImpl();
+    httpClient = mock(CloseableHttpClient.class);
+    response = mock(CloseableHttpResponse.class);
+    statusLine = mock(StatusLine.class);
+    entity = mock(HttpEntity.class);
+    SDMService = new SDMServiceImpl(binding, connectionPool);
     repoKey = new RepoKey();
     expected = new JsonObject();
     expected.addProperty(
@@ -90,60 +112,64 @@ public class SDMServiceImplTest {
 
   @Test
   public void testGetRepositoryInfo() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
-    String mockUrl = mockWebServer.url("/").toString();
+    try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+        Mockito.mockStatic(TokenHandler.class); ) {
+      JSONObject capabilities = new JSONObject();
+      capabilities.put("capabilityContentStreamUpdatability", "other");
+      JSONObject repoInfo = new JSONObject();
+      repoInfo.put("capabilities", capabilities);
+      JSONObject root = new JSONObject();
+      root.put(REPO_ID, repoInfo);
+      tokenHandlerMockedStatic
+          .when(
+              () ->
+                  TokenHandler.getHttpClient(any(), any(), any(), eq("TECHNICAL_CREDENTIALS_FLOW")))
+          .thenReturn(httpClient);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when((response.getEntity())).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(root.toString().getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
 
-    JSONObject capabilities = new JSONObject();
-    capabilities.put("capabilityContentStreamUpdatability", "other");
-    JSONObject repoInfo = new JSONObject();
-    repoInfo.put("capabilities", capabilities);
-    JSONObject root = new JSONObject();
-    root.put(REPO_ID, repoInfo);
+      SDMCredentials sdmCredentials = new SDMCredentials();
+      sdmCredentials.setUrl("test");
+      com.sap.cds.sdm.service.SDMService sdmService = new SDMServiceImpl(binding, connectionPool);
+      JSONObject json = sdmService.getRepositoryInfo(sdmCredentials, subdomain);
 
-    mockWebServer.enqueue(
-        new MockResponse().setBody(root.toString()).addHeader("Content-Type", "application/json"));
-
-    SDMCredentials sdmCredentials = new SDMCredentials();
-    sdmCredentials.setUrl(mockUrl);
-    String token = "token";
-
-    JSONObject json = SDMService.getRepositoryInfo(token, sdmCredentials);
-
-    JSONObject fetchedRepoInfo = json.getJSONObject(REPO_ID);
-    JSONObject fetchedCapabilities = fetchedRepoInfo.getJSONObject("capabilities");
-    assertEquals("other", fetchedCapabilities.getString("capabilityContentStreamUpdatability"));
-
-    mockWebServer.shutdown();
+      JSONObject fetchedRepoInfo = json.getJSONObject(REPO_ID);
+      JSONObject fetchedCapabilities = fetchedRepoInfo.getJSONObject("capabilities");
+      assertEquals("other", fetchedCapabilities.getString("capabilityContentStreamUpdatability"));
+    }
   }
 
   @Test
   public void testGetRepositoryInfoFail() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
-    String mockUrl = mockWebServer.url("/").toString();
+    try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+        Mockito.mockStatic(TokenHandler.class); ) {
+      SDMCredentials sdmCredentials = new SDMCredentials();
+      sdmCredentials.setUrl("test");
+      String token = "token";
+      com.sap.cds.sdm.service.SDMService sdmService = new SDMServiceImpl(binding, connectionPool);
+      SDMCredentials mockSdmCredentials = new SDMCredentials();
+      mockSdmCredentials.setUrl("test");
+      tokenHandlerMockedStatic
+          .when(
+              () ->
+                  TokenHandler.getHttpClient(any(), any(), any(), eq("TECHNICAL_CREDENTIALS_FLOW")))
+          .thenReturn(httpClient);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
 
-    mockWebServer.enqueue(
-        new MockResponse()
-            .setResponseCode(500) // Set HTTP status code to 500 for an internal server error
-            .setBody(
-                "{\"error\":\"Internal Server Error\"}") // Optional: Provide an error message in
-            // the body
-            .addHeader("Content-Type", "application/json"));
-
-    SDMCredentials sdmCredentials = new SDMCredentials();
-    sdmCredentials.setUrl(mockUrl);
-    String token = "token";
-
-    ServiceException exception =
-        assertThrows(
-            ServiceException.class,
-            () -> {
-              SDMService.getRepositoryInfo(token, sdmCredentials);
-            });
-    assertEquals("Failed to get repository info.", exception.getMessage());
-
-    mockWebServer.shutdown();
+      ServiceException exception =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                sdmService.getRepositoryInfo(sdmCredentials, subdomain);
+              });
+      assertEquals("Failed to get repository info.", exception.getMessage());
+    }
   }
 
   @Test
@@ -155,9 +181,12 @@ public class SDMServiceImplTest {
             Mockito.mockStatic(TokenHandler.class); ) {
       Cache<RepoKey, String> mockCache = Mockito.mock(Cache.class);
       tokenHandlerMockedStatic.when(() -> TokenHandler.getTokenFields(token)).thenReturn(expected);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
       Mockito.when(mockCache.get(repoKey)).thenReturn("Versioned");
       cacheConfigMockedStatic.when(CacheConfig::getVersionedRepoCache).thenReturn(mockCache);
-      String result = SDMService.checkRepositoryType(repositoryId, token);
+      String result = SDMService.checkRepositoryType(token, repositoryId);
       assertEquals("Versioned", result);
     }
   }
@@ -170,10 +199,24 @@ public class SDMServiceImplTest {
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
             Mockito.mockStatic(TokenHandler.class); ) {
       Cache<RepoKey, String> mockCache = Mockito.mock(Cache.class);
+      SDMCredentials mockSdmCredentials = new SDMCredentials();
+      mockSdmCredentials.setUrl("test");
+      tokenHandlerMockedStatic
+          .when(
+              () ->
+                  TokenHandler.getHttpClient(any(), any(), any(), eq("TECHNICAL_CREDENTIALS_FLOW")))
+          .thenReturn(httpClient);
       tokenHandlerMockedStatic.when(() -> TokenHandler.getTokenFields(token)).thenReturn(expected);
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getSDMCredentials())
+          .thenReturn(mockSdmCredentials);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when((response.getEntity())).thenReturn(entity);
       Mockito.when(mockCache.get(repoKey)).thenReturn("Non Versioned");
       cacheConfigMockedStatic.when(CacheConfig::getVersionedRepoCache).thenReturn(mockCache);
-      String result = SDMService.checkRepositoryType(repositoryId, token);
+      String result = SDMService.checkRepositoryType(token, repositoryId);
       assertEquals("Non Versioned", result);
     }
   }
@@ -182,7 +225,7 @@ public class SDMServiceImplTest {
   public void testCheckRepositoryTypeNoCacheVersioned() throws IOException {
     String repositoryId = "repo";
     String token = "token";
-    SDMServiceImpl spySDMService = Mockito.spy(new SDMServiceImpl());
+    SDMServiceImpl spySDMService = Mockito.spy(new SDMServiceImpl(binding, connectionPool));
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
             Mockito.mockStatic(TokenHandler.class);
         MockedStatic<CacheConfig> cacheConfigMockedStatic = Mockito.mockStatic(CacheConfig.class)) {
@@ -190,13 +233,27 @@ public class SDMServiceImplTest {
       tokenHandlerMockedStatic.when(() -> TokenHandler.getTokenFields(token)).thenReturn(expected);
       Mockito.when(mockCache.get(repoKey)).thenReturn(null);
       cacheConfigMockedStatic.when(CacheConfig::getVersionedRepoCache).thenReturn(mockCache);
-      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+      SDMCredentials mockSdmCredentials = new SDMCredentials();
+      mockSdmCredentials.setUrl("test");
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getAccessToken(mockSdmCredentials, token))
-          .thenReturn("token");
-
-      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
-
+          .when(
+              () ->
+                  TokenHandler.getHttpClient(any(), any(), any(), eq("TECHNICAL_CREDENTIALS_FLOW")))
+          .thenReturn(httpClient);
+      HttpGet getRepoInfoRequest =
+          new HttpGet(
+              mockSdmCredentials.getUrl()
+                  + "browser/"
+                  + repositoryId
+                  + "?cmisselector=repositoryInfo");
+      tokenHandlerMockedStatic.when(() -> TokenHandler.getTokenFields(token)).thenReturn(expected);
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getSDMCredentials())
+          .thenReturn(mockSdmCredentials);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when((response.getEntity())).thenReturn(entity);
       JSONObject capabilities = new JSONObject();
       capabilities.put(
           "capabilityContentStreamUpdatability",
@@ -205,12 +262,10 @@ public class SDMServiceImplTest {
       repoInfo.put("capabilities", capabilities);
       JSONObject mockRepoData = new JSONObject();
       mockRepoData.put(repositoryId, repoInfo);
+      InputStream inputStream = new ByteArrayInputStream(mockRepoData.toString().getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
 
-      Mockito.doReturn(mockRepoData)
-          .when(spySDMService)
-          .getRepositoryInfo("token", mockSdmCredentials);
-
-      String result = spySDMService.checkRepositoryType(repositoryId, token);
+      String result = spySDMService.checkRepositoryType(token, repositoryId);
       assertEquals("Versioned", result);
     }
   }
@@ -219,7 +274,7 @@ public class SDMServiceImplTest {
   public void testCheckRepositoryTypeNoCacheNonVersioned() throws IOException {
     String repositoryId = "repo";
     String token = "token";
-    SDMServiceImpl spySDMService = Mockito.spy(new SDMServiceImpl());
+    SDMServiceImpl spySDMService = Mockito.spy(new SDMServiceImpl(binding, connectionPool));
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
             Mockito.mockStatic(TokenHandler.class);
         MockedStatic<CacheConfig> cacheConfigMockedStatic = Mockito.mockStatic(CacheConfig.class)) {
@@ -227,12 +282,26 @@ public class SDMServiceImplTest {
       Cache<RepoKey, String> mockCache = Mockito.mock(Cache.class);
       Mockito.when(mockCache.get(repoKey)).thenReturn(null);
       cacheConfigMockedStatic.when(CacheConfig::getVersionedRepoCache).thenReturn(mockCache);
-      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+      SDMCredentials mockSdmCredentials = new SDMCredentials();
+      mockSdmCredentials.setUrl("test");
+      tokenHandlerMockedStatic
+          .when(
+              () ->
+                  TokenHandler.getHttpClient(any(), any(), any(), eq("TECHNICAL_CREDENTIALS_FLOW")))
+          .thenReturn(httpClient);
+      HttpGet getRepoInfoRequest =
+          new HttpGet(
+              mockSdmCredentials.getUrl()
+                  + "browser/"
+                  + repositoryId
+                  + "?cmisselector=repositoryInfo");
       tokenHandlerMockedStatic.when(() -> TokenHandler.getTokenFields(token)).thenReturn(expected);
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getAccessToken(mockSdmCredentials, token))
-          .thenReturn("token");
-      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+          .when(() -> TokenHandler.getSDMCredentials())
+          .thenReturn(mockSdmCredentials);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
 
       JSONObject capabilities = new JSONObject();
       capabilities.put(
@@ -243,84 +312,82 @@ public class SDMServiceImplTest {
       JSONObject mockRepoData = new JSONObject();
       mockRepoData.put(repositoryId, repoInfo);
 
-      Mockito.doReturn(mockRepoData)
-          .when(spySDMService)
-          .getRepositoryInfo("token", mockSdmCredentials);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockRepoData.toString().getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
 
-      String result = spySDMService.checkRepositoryType(repositoryId, token);
+      String result = spySDMService.checkRepositoryType(token, repositoryId);
       assertEquals("Non Versioned", result);
     }
   }
 
   @Test
   public void testCreateFolder() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String expectedResponse = "Folder ID";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(expectedResponse)
-              .addHeader("Content-Type", "application/json"));
+
       String parentId = "123";
       String jwtToken = "jwt_token";
       String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(201);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(expectedResponse.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       String actualResponse =
-          sdmServiceImpl.createFolder(parentId, jwtToken, repositoryId, sdmCredentials);
+          sdmServiceImpl.createFolder(parentId, repositoryId, sdmCredentials, jwtToken);
 
       assertEquals(expectedResponse, actualResponse);
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateFolderFail() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setResponseCode(500) // Set HTTP status code to 500 for an internal server error
-              .setBody(
-                  "{\"error\":\"Internal Server Error\"}") // Optional: Provide an error message in
-              // the body
-              .addHeader("Content-Type", "application/json"));
       String parentId = "123";
       String jwtToken = "jwt_token";
       String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream(
+              "Failed to create folder. Could not upload  the document".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       ServiceException exception =
           assertThrows(
               ServiceException.class,
               () -> {
-                sdmServiceImpl.createFolder(parentId, jwtToken, repositoryId, sdmCredentials);
+                sdmServiceImpl.createFolder(parentId, repositoryId, sdmCredentials, jwtToken);
               });
-      assertEquals("Could not upload the document.", exception.getMessage());
-
-    } finally {
-      mockWebServer.shutdown();
+      assertEquals(
+          "Failed to create folder. Failed to create folder. Could not upload  the document",
+          exception.getMessage());
     }
   }
 
   @Test
   public void testGetFolderIdByPath() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String expectedResponse =
@@ -336,71 +403,64 @@ public class SDMServiceImplTest {
               + "\"value\": \"ExpectedFolderId\""
               + "}}"
               + "}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(expectedResponse)
-              .addHeader("Content-Type", "application/json"));
+
       String parentId = "123";
       String jwtToken = "jwt_token";
       String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream("ExpectedFolderId".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       String actualResponse =
-          sdmServiceImpl.getFolderIdByPath(parentId, jwtToken, repositoryId, sdmCredentials);
+          sdmServiceImpl.getFolderIdByPath(parentId, repositoryId, sdmCredentials, jwtToken);
 
       assertEquals("ExpectedFolderId", actualResponse);
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testGetFolderIdByPathFail() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setResponseCode(500) // Set HTTP status code to 500 for an internal server error
-              .setBody(
-                  "{\"error\":\"Internal Server Error\"}") // Optional: Provide an error message in
-              // the body
-              .addHeader("Content-Type", "application/json"));
       String parentId = "123";
       String jwtToken = "jwt_token";
       String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream("Internal Server".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       String folderId =
-          sdmServiceImpl.getFolderIdByPath(parentId, jwtToken, repositoryId, sdmCredentials);
+          sdmServiceImpl.getFolderIdByPath(parentId, repositoryId, sdmCredentials, jwtToken);
       assertNull(folderId, "Expected folderId to be null");
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateDocument() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
+
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String mockResponseBody = "{\"succinctProperties\": {\"cmis:objectId\": \"objectId\"}}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(mockResponseBody)
-              .addHeader("Content-Type", "application/json"));
 
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("sample.pdf");
@@ -415,17 +475,22 @@ public class SDMServiceImplTest {
       cmisDocument.setMimeType("application/pdf");
 
       String jwtToken = "jwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
 
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(201);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       JSONObject actualResponse =
-          sdmServiceImpl.createDocument(cmisDocument, jwtToken, sdmCredentials);
+          sdmServiceImpl.createDocument(cmisDocument, sdmCredentials, jwtToken);
 
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
@@ -434,23 +499,14 @@ public class SDMServiceImplTest {
       expectedResponse.put("message", "");
       expectedResponse.put("status", "success");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateDocumentFailDuplicate() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String mockResponseBody = "{\"message\": \"Duplicate document found\"}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(mockResponseBody)
-              .setResponseCode(409)
-              .addHeader("Content-Type", "application/json"));
 
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("sample.pdf");
@@ -465,17 +521,21 @@ public class SDMServiceImplTest {
       cmisDocument.setMimeType("application/pdf");
 
       String jwtToken = "jwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(409);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       JSONObject actualResponse =
-          sdmServiceImpl.createDocument(cmisDocument, jwtToken, sdmCredentials);
+          sdmServiceImpl.createDocument(cmisDocument, sdmCredentials, jwtToken);
 
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
@@ -483,24 +543,16 @@ public class SDMServiceImplTest {
       expectedResponse.put("message", "");
       expectedResponse.put("status", "duplicate");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateDocumentFailVirus() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
+
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String mockResponseBody =
           "{\"message\": \"Malware Service Exception: Virus found in the file!\"}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(mockResponseBody)
-              .setResponseCode(409)
-              .addHeader("Content-Type", "application/json"));
 
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("sample.pdf");
@@ -515,17 +567,22 @@ public class SDMServiceImplTest {
       cmisDocument.setMimeType("application/pdf");
 
       String jwtToken = "jwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
 
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(409);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       JSONObject actualResponse =
-          sdmServiceImpl.createDocument(cmisDocument, jwtToken, sdmCredentials);
+          sdmServiceImpl.createDocument(cmisDocument, sdmCredentials, jwtToken);
 
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
@@ -533,25 +590,15 @@ public class SDMServiceImplTest {
       expectedResponse.put("message", "");
       expectedResponse.put("status", "virus");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateDocumentFailOther() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
+
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String mockResponseBody = "{\"message\": \"An unexpected error occurred\"}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(mockResponseBody)
-              .setResponseCode(
-                  500) // Assuming 500 Internal Server Error or another server error code
-              .addHeader("Content-Type", "application/json"));
-
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("sample.pdf");
       cmisDocument.setAttachmentId("attachmentId");
@@ -565,17 +612,22 @@ public class SDMServiceImplTest {
       cmisDocument.setMimeType("application/pdf");
 
       String jwtToken = "jwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
 
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       JSONObject actualResponse =
-          sdmServiceImpl.createDocument(cmisDocument, jwtToken, sdmCredentials);
+          sdmServiceImpl.createDocument(cmisDocument, sdmCredentials, jwtToken);
 
       JSONObject expectedResponse = new JSONObject();
       expectedResponse.put("name", "sample.pdf");
@@ -583,21 +635,13 @@ public class SDMServiceImplTest {
       expectedResponse.put("message", "An unexpected error occurred");
       expectedResponse.put("status", "fail");
       assertEquals(expectedResponse.toString(), actualResponse.toString());
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testCreateDocumentFailRequestError() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-
-      // Enqueue a failure to simulate a network error
-      mockWebServer.shutdown(); // Shut down the server to simulate network error
-
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("sample.pdf");
       cmisDocument.setAttachmentId("attachmentId");
@@ -610,26 +654,27 @@ public class SDMServiceImplTest {
       cmisDocument.setFolderId("folderId");
       cmisDocument.setMimeType("application/pdf");
       String jwtToken = "jwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
-
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream("{\"message\":\"Error in setting timeout\"}".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       try {
-        sdmServiceImpl.createDocument(cmisDocument, jwtToken, sdmCredentials);
-        fail("Expected ServiceException to be thrown");
+        sdmServiceImpl.createDocument(cmisDocument, sdmCredentials, jwtToken);
       } catch (ServiceException e) {
         // Expected exception to be thrown
         assertEquals("Error in setting timeout", e.getMessage());
       }
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
@@ -649,7 +694,7 @@ public class SDMServiceImplTest {
 
       Mockito.when(TokenHandler.getDITokenUsingAuthorities(sdmCredentials, "email", "subdomain"))
           .thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       int actualResponse =
           sdmServiceImpl.deleteDocument("deleteTree", "objectId", "email", "subdomain");
@@ -677,24 +722,29 @@ public class SDMServiceImplTest {
 
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       SDMCredentials sdmCredentials = new SDMCredentials();
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(sdmCredentials);
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+
       // Mock the method `getFolderIdByPath`
       SDMServiceImpl spyService = spy(sdmServiceImpl);
       doReturn(null)
           .when(spyService)
-          .getFolderIdByPath(anyString(), anyString(), anyString(), any(SDMCredentials.class));
+          .getFolderIdByPath(anyString(), anyString(), any(SDMCredentials.class), anyString());
 
       // Mock the method `createFolder`
       doReturn("{\"succinctProperties\":{\"cmis:objectId\":\"newFolderId123\"}}")
           .when(spyService)
-          .createFolder(anyString(), anyString(), anyString(), any(SDMCredentials.class));
+          .createFolder(anyString(), anyString(), any(SDMCredentials.class), anyString());
 
-      String folderId = spyService.getFolderId(jwtToken, result, persistenceService, up__ID);
+      String folderId = spyService.getFolderId(result, persistenceService, up__ID, jwtToken);
       assertEquals("newFolderId123", folderId, "Expected folderId from result list");
     }
   }
@@ -715,7 +765,7 @@ public class SDMServiceImplTest {
 
       Mockito.when(TokenHandler.getDITokenUsingAuthorities(sdmCredentials, "email", "subdomain"))
           .thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       int actualResponse =
           sdmServiceImpl.deleteDocument("delete", "objectId", "email", "subdomain");
@@ -746,7 +796,7 @@ public class SDMServiceImplTest {
 
       Mockito.when(TokenHandler.getDITokenUsingAuthorities(sdmCredentials, "email", "subdomain"))
           .thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       int actualResponse = sdmServiceImpl.deleteDocument("delete", "ewdwe", "email", "subdomain");
 
@@ -777,7 +827,7 @@ public class SDMServiceImplTest {
 
       // Since the exception is thrown before OkHttpClient is used, no need to mock httpClient
       // behavior.
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
       // Assert exception
       IOException thrown =
           assertThrows(
@@ -803,13 +853,13 @@ public class SDMServiceImplTest {
     String jwtToken = "jwtToken";
     String up__ID = "up__ID";
 
-    SDMServiceImpl sdmServiceImpl = spy(new SDMServiceImpl());
+    SDMServiceImpl sdmServiceImpl = spy(new SDMServiceImpl(binding, connectionPool));
 
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       doReturn("folderByPath123")
           .when(sdmServiceImpl)
-          .getFolderIdByPath(anyString(), anyString(), anyString(), any(SDMCredentials.class));
+          .getFolderIdByPath(anyString(), anyString(), any(SDMCredentials.class), anyString());
 
       SDMCredentials sdmCredentials = new SDMCredentials();
       sdmCredentials.setUrl("mockUrl");
@@ -819,12 +869,17 @@ public class SDMServiceImplTest {
       sdmCredentials.setUrl(mockUrl);
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(sdmCredentials);
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+
       MockResponse mockResponse1 =
           new MockResponse().setResponseCode(200).setBody("folderByPath123");
       mockWebServer.enqueue(mockResponse1);
-      String folderId = sdmServiceImpl.getFolderId(jwtToken, result, persistenceService, up__ID);
+      String folderId = sdmServiceImpl.getFolderId(result, persistenceService, up__ID, jwtToken);
       assertEquals("folderByPath123", folderId, "Expected folderId from getFolderIdByPath");
     }
   }
@@ -843,14 +898,14 @@ public class SDMServiceImplTest {
     String up__ID = "up__ID";
 
     // Create a spy of the SDMServiceImpl to mock specific methods
-    SDMServiceImpl sdmServiceImpl = spy(new SDMServiceImpl());
+    SDMServiceImpl sdmServiceImpl = spy(new SDMServiceImpl(binding, connectionPool));
 
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       // Mock the getFolderIdByPath method to return null (so that it will try to create a folder)
       doReturn(null)
           .when(sdmServiceImpl)
-          .getFolderIdByPath(anyString(), anyString(), anyString(), any(SDMCredentials.class));
+          .getFolderIdByPath(anyString(), anyString(), any(SDMCredentials.class), anyString());
 
       // Mock the TokenHandler static method and SDMCredentials instantiation
       SDMCredentials sdmCredentials = new SDMCredentials();
@@ -867,8 +922,12 @@ public class SDMServiceImplTest {
 
       // Mock the token retrieval as well
       tokenHandlerMockedStatic
-          .when(() -> TokenHandler.getDIToken(jwtToken, sdmCredentials))
-          .thenReturn("mockAccessToken");
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
 
       // Mock the createFolder method to return a folder ID when invoked
       JSONObject jsonObject = new JSONObject();
@@ -883,10 +942,10 @@ public class SDMServiceImplTest {
 
       doReturn(jsonObject.toString())
           .when(sdmServiceImpl)
-          .createFolder(anyString(), anyString(), anyString(), any(SDMCredentials.class));
+          .createFolder(anyString(), anyString(), any(SDMCredentials.class), anyString());
 
       // Invoke the method
-      String folderId = sdmServiceImpl.getFolderId(jwtToken, result, persistenceService, up__ID);
+      String folderId = sdmServiceImpl.getFolderId(result, persistenceService, up__ID, jwtToken);
 
       // Assert the folder ID is the newly created one
       assertEquals("newFolderId123", folderId, "Expected newly created folderId");
@@ -895,57 +954,58 @@ public class SDMServiceImplTest {
 
   @Test
   public void testReadDocument_Success() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String expectedContent = "This is a document content.";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(expectedContent)
-              .addHeader("Content-Type", "application/octet-stream"));
       String objectId = "testObjectId";
       String jwtToken = "testJwtToken";
       String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
       AttachmentReadEventContext mockContext = mock(AttachmentReadEventContext.class);
       MediaData mockData = mock(MediaData.class);
       when(mockContext.getData()).thenReturn(mockData);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream("{\"message\":\"Server error\"}".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       sdmServiceImpl.readDocument(objectId, jwtToken, sdmCredentials, mockContext);
 
       verify(mockData).setContent(any(InputStream.class));
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testReadDocument_UnsuccessfulResponse() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
+
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setResponseCode(500) // Set HTTP status code to 500 for an internal server error
-              .setBody(
-                  "{\"error\":\"Server Error\"}") // Update the error message to match the actual
-              // response
-              .addHeader("Content-Type", "application/json"));
       String objectId = "testObjectId";
       String jwtToken = "testJwtToken";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
       AttachmentReadEventContext mockContext = mock(AttachmentReadEventContext.class);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream("{\"message\":\"Server error\"}".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       ServiceException exception =
           assertThrows(
@@ -955,35 +1015,34 @@ public class SDMServiceImplTest {
               });
 
       // Check if the exception message contains the expected first part
-      String expectedMessagePart1 = "Unexpected code";
+      String expectedMessagePart1 = "Failed to set document stream in context";
       assertTrue(exception.getMessage().contains(expectedMessagePart1));
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testReadDocument_ExceptionWhileSettingContent() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
       String expectedContent = "This is a document content.";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setBody(expectedContent)
-              .addHeader("Content-Type", "application/octet-stream"));
       String objectId = "testObjectId";
       String jwtToken = "testJwtToken";
-      String repositoryId = "repository_id";
-      String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
-      sdmCredentials.setUrl(mockUrl);
       AttachmentReadEventContext mockContext = mock(AttachmentReadEventContext.class);
       MediaData mockData = mock(MediaData.class);
       when(mockContext.getData()).thenReturn(mockData);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(expectedContent.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       doThrow(new RuntimeException("Failed to set document stream in context"))
           .when(mockData)
@@ -996,94 +1055,87 @@ public class SDMServiceImplTest {
                 sdmServiceImpl.readDocument(objectId, jwtToken, sdmCredentials, mockContext);
               });
       assertEquals("Failed to set document stream in context", exception.getMessage());
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testRenameAttachments_Success() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
-
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic = mockStatic(TokenHandler.class)) {
-      // Enqueue a successful response
-      mockWebServer.enqueue(new MockResponse().setResponseCode(200));
-
       String jwtToken = "jwt_token";
-      String mockUrl = mockWebServer.url("/").toString();
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setFileName("newFileName");
       cmisDocument.setObjectId("objectId");
 
       SDMCredentials mockSdmCredentials = mock(SDMCredentials.class);
-      when(mockSdmCredentials.getUrl()).thenReturn(mockUrl);
-      when(TokenHandler.getDIToken(jwtToken, mockSdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream("".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       int responseCode =
           sdmServiceImpl.renameAttachments(jwtToken, mockSdmCredentials, cmisDocument);
 
       // Verify the response code
       assertEquals(200, responseCode);
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testGetObject_Success() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      String mockResponseBody = "{\"succinctProperties\": {\"cmis:name\": \"desiredObjectName\"}}";
-      mockWebServer.enqueue(
-          new MockResponse()
-              .setResponseCode(200)
-              .setBody(mockResponseBody)
-              .addHeader("Content-Type", "application/json"));
+      String mockResponseBody = "{\"succinctProperties\": {\"cmis:name\":\"desiredObjectName\"}}";
       String jwtToken = "jwt_token";
       String objectId = "objectId";
-      String mockUrl = mockWebServer.url("/").toString();
+      SDMServiceImpl sdmServiceImpl = Mockito.spy(new SDMServiceImpl(binding, connectionPool));
+      SDMCredentials sdmCredentials = new SDMCredentials();
 
-      SDMServiceImpl sdmServiceImpl = Mockito.spy(new SDMServiceImpl());
-      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-      Mockito.when(mockSdmCredentials.getUrl()).thenReturn(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, mockSdmCredentials))
-          .thenReturn("mockAccessToken");
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      String objectName = sdmServiceImpl.getObject(jwtToken, objectId, mockSdmCredentials);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(200);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      String objectName = sdmServiceImpl.getObject(jwtToken, objectId, sdmCredentials);
       assertEquals("desiredObjectName", objectName);
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 
   @Test
   public void testGetObject_Failure() throws IOException {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.start();
     try (MockedStatic<TokenHandler> tokenHandlerMockedStatic =
         Mockito.mockStatic(TokenHandler.class)) {
-      mockWebServer.enqueue(
-          new MockResponse().setResponseCode(500).addHeader("Content-Type", "application/json"));
       String jwtToken = "jwt_token";
       String objectId = "objectId";
-      String mockUrl = mockWebServer.url("/").toString();
+      SDMServiceImpl sdmServiceImpl = Mockito.spy(new SDMServiceImpl(binding, connectionPool));
+      SDMCredentials sdmCredentials = new SDMCredentials();
 
-      SDMServiceImpl sdmServiceImpl = Mockito.spy(new SDMServiceImpl());
-      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-      Mockito.when(mockSdmCredentials.getUrl()).thenReturn(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, mockSdmCredentials))
-          .thenReturn("mockAccessToken");
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
 
-      String objectName = sdmServiceImpl.getObject(jwtToken, objectId, mockSdmCredentials);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(500);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream = new ByteArrayInputStream("".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+
+      String objectName = sdmServiceImpl.getObject(jwtToken, objectId, sdmCredentials);
       assertNull(objectName);
-
-    } finally {
-      mockWebServer.shutdown();
     }
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -403,14 +403,24 @@ public class SDMServiceImplTest {
       String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
       sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(403);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream(SDMConstants.USER_NOT_AUTHORISED_ERROR.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       ServiceException exception =
           assertThrows(
               ServiceException.class,
               () -> {
-                sdmServiceImpl.createFolder(parentId, jwtToken, repositoryId, sdmCredentials);
+                sdmServiceImpl.createFolder(parentId, repositoryId, sdmCredentials, jwtToken);
               });
       assertEquals(SDMConstants.USER_NOT_AUTHORISED_ERROR, exception.getMessage());
 
@@ -506,14 +516,25 @@ public class SDMServiceImplTest {
       String mockUrl = mockWebServer.url("/").toString();
       SDMCredentials sdmCredentials = new SDMCredentials();
       sdmCredentials.setUrl(mockUrl);
-      Mockito.when(TokenHandler.getDIToken(jwtToken, sdmCredentials)).thenReturn("mockAccessToken");
-      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl();
+      tokenHandlerMockedStatic
+          .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
+          .thenReturn(httpClient);
+
+      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(response.getStatusLine()).thenReturn(statusLine);
+      when(statusLine.getStatusCode()).thenReturn(403);
+      when(response.getEntity()).thenReturn(entity);
+      InputStream inputStream =
+          new ByteArrayInputStream(
+              "Failed to create folder. Could not upload  the document".getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+      SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       ServiceException exception =
           assertThrows(
               ServiceException.class,
               () -> {
-                sdmServiceImpl.getFolderIdByPath(parentId, jwtToken, repositoryId, sdmCredentials);
+                sdmServiceImpl.getFolderIdByPath(parentId, repositoryId, sdmCredentials, jwtToken);
               });
       assertEquals(SDMConstants.USER_NOT_AUTHORISED_ERROR, exception.getMessage());
 


### PR DESCRIPTION
Implement Auth token generation using Cloud SDK
Implement Create Attachment using Cloud SDK end to end. UTs & Integration Tests

This improves the performance of API calls to SDM and uses cloud sdk using httoclient5

https://jira.tools.sap/browse/SDMEXT-850
https://jira.tools.sap/browse/SDMEXT-851

This backlog is to use httpclient5 to all the methods createFolder,getFolderByPath,createDocument,readDocument,rename,delete and getRepositoryInfo.
It improves the performance of calling SDM API's