### PR TITLE
[SNOW: DINC0293877] Enhancing message for 404 Object Not Found

### DIFF
--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -37,7 +37,7 @@
         <attachments_version>1.0.5</attachments_version>
         <lombok.version>1.18.36</lombok.version>
         <jacoco.version>0.8.7</jacoco.version>
-        <commons-codec.version>1.17.1</commons-codec.version>
+        <commons-codec.version>1.17.2</commons-codec.version>
         <ehcache-version>3.10.8</ehcache-version>
     </properties>
 

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -29,6 +29,7 @@ public class SDMConstants {
       "Enter a valid file name for %s. The following characters are not supported: /, \\";
   public static final String USER_NOT_AUTHORISED_ERROR =
       "You do not have the required permissions to upload attachments. Please contact your administrator for access.";
+  public static final String FILE_NOT_FOUND_ERROR = "Object not found in repository";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -223,6 +223,9 @@ public class SDMServiceImpl implements SDMService {
 
     Response response = client.newCall(request).execute();
     if (!response.isSuccessful()) {
+      if (response.code() == 404) {
+        throw new ServiceException(SDMConstants.FILE_NOT_FOUND_ERROR);
+      }
       response.close();
       throw new ServiceException("Unexpected code");
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -200,17 +200,15 @@ public class SDMServiceImpl implements SDMService {
             + objectId
             + "&cmisselector=content";
 
-    Response response = client.newCall(request).execute();
-    
     HttpGet getContentRequest = new HttpGet(sdmUrl);
     try (var response = (CloseableHttpResponse) httpClient.execute(getContentRequest)) {
       int responseCode = response.getStatusLine().getStatusCode();
       if (responseCode != 200) {
-      response.close();
-      if (response.code() == 404) {
-        throw new ServiceException(SDMConstants.FILE_NOT_FOUND_ERROR);
-      }
-      throw new ServiceException("Unexpected code");
+        response.close();
+        if (responseCode == 404) {
+          throw new ServiceException(SDMConstants.FILE_NOT_FOUND_ERROR);
+        }
+        throw new ServiceException("Unexpected code");
       }
       byte[] responseBody = EntityUtils.toByteArray(response.getEntity());
       try (InputStream inputStream = new ByteArrayInputStream(responseBody)) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -166,7 +166,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     try {
       sdmService.readDocument(objectId, jwtToken, sdmCredentials, context);
     } catch (Exception e) {
-      throw new ServiceException(SDMConstants.NOT_FOUND_ERROR);
+      throw new ServiceException(e.getMessage());
     }
     context.setCompleted();
   }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -747,7 +747,7 @@ public class SDMAttachmentsServiceHandlerTest {
       when(sdmService.checkRepositoryType(SDMConstants.REPOSITORY_ID, token))
           .thenReturn("NotVersioned");
       when(TokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
-      doThrow(new RuntimeException("Read error"))
+      doThrow(new ServiceException(SDMConstants.FILE_NOT_FOUND_ERROR))
           .when(sdmService)
           .readDocument(anyString(), anyString(), any(SDMCredentials.class), eq(mockReadContext));
 
@@ -758,7 +758,7 @@ public class SDMAttachmentsServiceHandlerTest {
                 handlerSpy.readAttachment(mockReadContext);
               });
 
-      assertEquals("Failed to read document.", exception.getMessage());
+      assertEquals("Object not found in repository", exception.getMessage());
     }
   }
 


### PR DESCRIPTION
Currently whenever a user tries to read a document from UI which is not present in backend he gets an error `Failed to serialize payload` and our internal logs show message as `Unexpected code`. This log message is difficult to understand and does not indicate the cause of failure. 

The error `Failed to serialize payload` is been thrown by cds attachmentService and can not be modified. This PR is intended to modify only the log message and make it more understandable. 

Ticket link: https://itsm.services.sap/nav_to.do?uri=x_sapda_devinc_development_incident.do?sys_id=3d9b439f478d92500616b2bd436d4309%26sysparm_view=Development_Incident

Dev Testing:

![image](https://github.com/user-attachments/assets/6806b789-a41a-44cb-a8ac-928a64108b9d)

Blackduck scan
![image](https://github.com/user-attachments/assets/92182edf-3904-422a-b7c9-1950e9ae432e)

