### PR TITLE
SDMEXT-1046: Modify the snapshot deployment Job

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,3 +1,4 @@
+######
 name: Main build and snapshot deploy
 
 env:
@@ -33,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
@@ -40,57 +43,64 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: sapmachine
           cache: maven
-          server-id: artifactory
-          server-username: CAP_DEPLOYMENT_USER
-          server-password: CAP_DEPLOYMENT_PASS
 
       - name: Set up Maven ${{ env.MAVEN_VERSION }}
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: ${{ env.MAVEN_VERSION }}
 
-      - name: Get Revision
-        id: get-revision
+      - name: Get Current Version
+        id: get-current-version
         run: |
           current_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "Current version: $current_version"
           echo "REVISION=$current_version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Check and Update Version
-        if: github.ref == 'refs/heads/develop'
-        id: check-and-update-version
+      - name: Create Branch if Version is not SNAPSHOT
+        if: "! contains(env.REVISION, '-SNAPSHOT')"
+        id: create-branch
         run: |
           current_version=${{ env.REVISION }}
+          new_branch="Release_v${current_version}"
+          echo "Checking if branch $new_branch already exists"
+          if git ls-remote --exit-code --heads origin $new_branch; then
+            echo "Branch $new_branch already exists, not creating new branch."
+          else
+            echo "Branch $new_branch does not exist, creating new branch."
+            git config --local user.name "github-actions"
+            git config --local user.email "github-actions@github.com"
+            git checkout -b $new_branch
+            git push origin $new_branch
+          fi
+        shell: bash
 
+      - name: Check and Update Version
+        id: check-and-update-version
+        if: contains(env.REVISION, '-SNAPSHOT') == false
+        run: |
+          current_version=${{ env.REVISION }}
           # Check if the version already contains '-SNAPSHOT'
           if [[ $current_version != *-SNAPSHOT ]]; then
             echo "Current version does not contain -SNAPSHOT, updating version..."
-
             # Split version into major, minor, and patch parts
             IFS='.' read -r major minor patch <<< "$(echo $current_version | tr '-' '.')"
-
             # Increment the patch number
             new_patch=$((patch + 1))
-
             # Form the new version
             new_version="${major}.${minor}.${new_patch}-SNAPSHOT"
-
             # Update the <revision> property in pom.xml
             sed -i "s|<revision>.*</revision>|<revision>${new_version}</revision>|" pom.xml
-
             echo "Updated version to $new_version"
-
             # Commit the version change
             git config --local user.name "github-actions"
             git config --local user.email "github-actions@github.com"
             git add pom.xml
             git commit -m "Increment version to ${new_version}"
-            git push origin HEAD:testversion
+            git push origin HEAD:$GITHUB_REF_NAME
           else
             echo "Current version already contains -SNAPSHOT, no update needed."
           fi
-
           # Export the updated or original version
           updated_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "UPDATED_VERSION=$updated_version" >> $GITHUB_ENV
@@ -100,7 +110,7 @@ jobs:
         run: |
           echo "Updated version: ${{ env.UPDATED_VERSION }}"
         shell: bash
-
+        
       - name: Deploy snapshot
         if: ${{ endsWith(env.UPDATED_VERSION, '-SNAPSHOT') }}
         run: |
@@ -109,3 +119,4 @@ jobs:
           CAP_DEPLOYMENT_USER: ${{ secrets.CAP_DEPLOYMENT_USER }}
           CAP_DEPLOYMENT_PASS: ${{ secrets.CAP_DEPLOYMENT_PASS }}
         shell: bash
+######


### PR DESCRIPTION
For now snapshot deployment step is getting fail due to below reason :
During the release activity, we change the version as per production release version. So the version name doesn't contains "SNAPSHOT" , due this as per current condition it's skipping the snapshot deployment to artifactory.


Solution: Done the required modification in workflow file to correct the behaviour.

Testing : https://github.com/cap-java/sdm/actions/runs/13174127417/job/36769688624 