### PR TITLE
[SDMEXT-1041]: Updating Error Message For Special Characters. 

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -40,7 +40,7 @@ public class SDMConstants {
       List<String> fileNameWithRestrictedCharacters, String operation) {
     // Create the base message
     String prefixMessage =
-        "%s unsuccessful. The following file names contain unsupported characters (/, \\). \n\n";
+        "%s unsuccessful. The following filename(s) contain unsupported characters (/, \\). \n\n";
 
     // Create the formatted prefix message
     String formattedPrefixMessage = String.format(prefixMessage, operation);


### PR DESCRIPTION
This PR is intended to update the error message we throw when an attachment name contains an invalid character. 

Jira link: https://jira.tools.sap/browse/SDMEXT-1041

Dev Testing: 
<img width="1337" alt="Screenshot 2025-02-10 at 4 21 33 PM" src="https://github.com/user-attachments/assets/19b86dff-81e4-4fe7-97de-6ab8a1aecaa8" />
