### PR TITLE
DINC0400135: Duplicate Check with multiple repository switch.

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -230,17 +230,19 @@ public class SDMServiceImpl implements SDMService {
 
     String folderId = null;
     String repositoryId = null;
+    String repoId = SDMConstants.REPOSITORY_ID;
     for (Map<String, Object> attachment : resultList) {
       if (attachment.get("folderId") != null) {
-        folderId = attachment.get("folderId").toString();
         repositoryId = attachment.get("repositoryId").toString();
+        // check if folderId exists for the repositoryId if not then make folderId null else
+        // continue
+        if (repoId.equalsIgnoreCase(repositoryId)) {
+          folderId = attachment.get("folderId").toString();
+          break;
+        }
       }
     }
-    String repoId = SDMConstants.REPOSITORY_ID;
-    // check if folderId exists for the repositoryId if not then make folderId null else continue
-    if (!repoId.equalsIgnoreCase(repositoryId)) {
-      folderId = null;
-    }
+
     SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
 
     if (folderId == null) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -179,7 +179,11 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     for (Map<String, Object> attachment : resultList) {
       String resultFileName = (String) attachment.get("fileName");
       String resultId = (String) attachment.get("ID");
-      if (filename.equals(resultFileName) && !fileid.equals(resultId)) {
+      String repositoryId = (String) attachment.get("repositoryId");
+      // add a check with repositoryId
+      if (filename.equals(resultFileName)
+          && !fileid.equals(resultId)
+          && SDMConstants.REPOSITORY_ID.equals(repositoryId)) {
         duplicate = attachment;
         break;
       }

--- a/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
@@ -26,7 +26,9 @@ public class SDMUtils {
         while (iterator.hasNext()) {
           Map<String, Object> attachment = iterator.next();
           String filenameInRequest = (String) attachment.get("fileName");
-          if (!uniqueFilenames.add(filenameInRequest)) {
+          String repositoryInRequest = (String) attachment.get("repositoryId");
+          String fileRepositorySpecific = filenameInRequest + "#" + repositoryInRequest;
+          if (!uniqueFilenames.add(fileRepositorySpecific)) {
             duplicateFilenames.add(filenameInRequest);
           }
         }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -131,6 +131,7 @@ public class SDMAttachmentsServiceHandlerTest {
     Map<String, Object> mockattachmentIds = new HashMap<>();
     mockattachmentIds.put("up__ID", "upid");
     mockattachmentIds.put("ID", "id");
+    mockattachmentIds.put("repositoryId", "repo1");
     Result mockResult = mock(Result.class);
     Row mockRow = mock(Row.class);
     List<Row> nonEmptyRowList = List.of(mockRow);
@@ -227,6 +228,7 @@ public class SDMAttachmentsServiceHandlerTest {
     Map<String, Object> mockattachmentIds = new HashMap<>();
     mockattachmentIds.put("up__ID", "upid");
     mockattachmentIds.put("ID", "id");
+    mockattachmentIds.put("repositoryId", "repo1");
     Result mockResult = mock(Result.class);
     Row mockRow = mock(Row.class);
     List<Row> nonEmptyRowList = List.of(mockRow);
@@ -474,6 +476,7 @@ public class SDMAttachmentsServiceHandlerTest {
     Map<String, Object> mockattachmentIds = new HashMap<>();
     mockattachmentIds.put("up__ID", "upid");
     mockattachmentIds.put("ID", "id");
+    mockattachmentIds.put("repositoryId", "repo1");
     Result mockResult = mock(Result.class);
     Row mockRow = mock(Row.class);
     List<Row> nonEmptyRowList = List.of(mockRow);
@@ -543,6 +546,7 @@ public class SDMAttachmentsServiceHandlerTest {
     Map<String, Object> mockattachmentIds = new HashMap<>();
     mockattachmentIds.put("up__ID", "upid");
     mockattachmentIds.put("ID", "id");
+    mockattachmentIds.put("repositoryId", "repo1");
     Result mockResult = mock(Result.class);
     Row mockRow = mock(Row.class);
     List<Row> nonEmptyRowList = List.of(mockRow);
@@ -611,6 +615,7 @@ public class SDMAttachmentsServiceHandlerTest {
     Map<String, Object> mockattachmentIds = new HashMap<>();
     mockattachmentIds.put("up__ID", "upid");
     mockattachmentIds.put("ID", "id");
+    mockattachmentIds.put("repositoryId", "repo1");
     Result mockResult = mock(Result.class);
     MediaData mockMediaData = mock(MediaData.class);
     Messages mockMessages = mock(Messages.class);
@@ -696,12 +701,12 @@ public class SDMAttachmentsServiceHandlerTest {
     // Creating a map with duplicate filename but different file ID
     Map<String, Object> attachment1 = new HashMap<>();
     attachment1.put("fileName", "sample.pdf");
-    attachment1.put("ID", "123"); // Different ID, not a duplicate
-
+    attachment1.put("ID", "1234"); // Different ID, not a duplicate
+    attachment1.put("repositoryId", "repoid");
     Map<String, Object> attachment2 = new HashMap<>();
     attachment2.put("fileName", "sample.pdf");
     attachment2.put("ID", "456"); // Same filename but different ID (this is the duplicate)
-
+    attachment1.put("repositoryId", "repoid");
     mockedResultList.add((Map) attachment1);
     mockedResultList.add((Map) attachment2);
 
@@ -716,6 +721,38 @@ public class SDMAttachmentsServiceHandlerTest {
 
     // Assert that a duplicate is found
     assertTrue(isDuplicate, "Expected to find a duplicate");
+  }
+
+  @Test
+  void testDuplicateCheck_WithDuplicateFilesFor2DifferentRepositories() {
+    Result result = mock(Result.class);
+
+    // Mocking a raw list of maps
+    List<Map> mockedResultList = new ArrayList<>();
+
+    // Creating a map with duplicate filename but different file ID
+    Map<String, Object> attachment1 = new HashMap<>();
+    attachment1.put("fileName", "sample.pdf");
+    attachment1.put("ID", "123"); // Different ID, not a duplicate
+    attachment1.put("repositoryId", "repoid");
+    Map<String, Object> attachment2 = new HashMap<>();
+    attachment2.put("fileName", "sample.pdf");
+    attachment2.put("ID", "456"); // Same filename but different ID (this is the duplicate)
+    attachment1.put("repositoryId", "repoid");
+    mockedResultList.add((Map) attachment1);
+    mockedResultList.add((Map) attachment2);
+
+    // Mocking the result to return the list containing the attachments
+    when(result.listOf(Map.class)).thenReturn((List) mockedResultList);
+
+    String filename = "sample.pdf";
+    String fileid = "123"; // The fileid to check, same as attachment1, different from attachment2
+
+    // Checking for duplicate
+    boolean isDuplicate = handlerSpy.duplicateCheck(filename, fileid, result);
+
+    // Assert that a duplicate is found
+    assertTrue(!isDuplicate, "Expected to find a duplicate");
   }
 
   @Test

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -28,8 +28,10 @@ public class SDMUtilsTest {
     List<Map<String, Object>> attachments = new ArrayList<>();
     Map<String, Object> attachment1 = new HashMap<>();
     attachment1.put("fileName", "file1.txt");
+    attachment1.put("repositoryId", "repo1");
     Map<String, Object> attachment2 = new HashMap<>();
     attachment2.put("fileName", "file1.txt");
+    attachment2.put("repositoryId", "repo1");
     attachments.add(attachment1);
     attachments.add(attachment2);
     entity.put("attachments", attachments);


### PR DESCRIPTION
In the cap-java plugin, filtering attachments based on repository is implemented, however in the duplicate filename check, we check the db to see if any attachments of the same name exists for that up__id.

Added a repositoryId condition with filename for duplicateCheck and  isFileNameDuplicateInDrafts method.

Repo: TEST_REPO

<img width="1467" alt="Screenshot 2025-02-17 at 1 15 35 PM" src="https://github.com/user-attachments/assets/e4a05bc3-2d0b-4205-89fa-c54b1179f184" />

REPO: MY_REPO (same files 1.png and 9.png) uploaded and saved
<img width="1501" alt="Screenshot 2025-02-17 at 1 16 47 PM" src="https://github.com/user-attachments/assets/1cf35c04-eb9a-4ceb-aa35-c0a38185de58" />
