### PR TITLE
Fixed the release to oss job

### DIFF
--- a/.github/actions/newrelease/action.yml
+++ b/.github/actions/newrelease/action.yml
@@ -34,7 +34,7 @@ runs:
         #./ensure-license.sh
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        git checkout -b develop
+        git checkout -b Release_v1.0.2
         git commit -am "Update version to $VERSION"
-        git push --set-upstream origin develop
+        git push --set-upstream origin Release_v1.0.2
       shell: bash


### PR DESCRIPTION
We have updated the new_release yml with release branch (Release_v1.0.2) from develop.

Note : We have faced this issue this time only because we have merged new PRs on the develop which is not in release branch.