### PR TITLE
Excluding class from sonar scan 

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -70,7 +70,7 @@ jobs:
               -Dsonar.junit.reportPaths=sdm/target/surefire-reports \
               -Dsonar.coverage.jacoco.xmlReportPaths=sdm/target/site/jacoco/jacoco.xml \
               -Dsonar.inclusions=**/*.java \
-              -Dsonar.exclusions=**/target/**,**/node_modules/**,sdm/src/main/test/**,cap-notebook/*.capnb,sdm/src/main/java/com/sap/cds/sdm/model/**,sdm/src/main/java/com/sap/cds/sdm/caching/CacheKey.java,sdm/src/main/java/com/sap/cds/sdm/caching/RepoKey.java,sdm/src/main/java/com/sap/cds/sdm/caching/TokenCacheKey.java \
+              -Dsonar.exclusions=**/target/**,**/node_modules/**,sdm/src/main/test/**,cap-notebook/*.capnb,sdm/src/main/java/com/sap/cds/sdm/model/**,sdm/src/main/java/com/sap/cds/sdm/caching/CacheKey.java,sdm/src/main/java/com/sap/cds/sdm/caching/RepoKey.java,sdm/src/main/java/com/sap/cds/sdm/caching/TokenCacheKey.java,sdm/src/main/java/com/sap/cds/sdm/caching/SecondaryTypesKey.java \
               -Dsonar.java.file.suffixes=.java \
               -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
               -Dsonar.login=${{ secrets.SONAR_TOKEN }}

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -41,7 +41,7 @@ public class SDMConstants {
   public static final int CONNECTION_TIMEOUT = 1200;
   public static final String ONBOARD_REPO_MESSAGE =
       "Repository with name %s  and id %s onboarded successfully";
-  public static final String ONBOARD_REPO__ERROR_MESSAGE =
+  public static final String ONBOARD_REPO_ERROR_MESSAGE =
       "Error in onboarding repository with name %s";
   public static final String UPDATE_ATTACHMENT_ERROR = "Could not update the attachment";
 

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
@@ -189,7 +189,7 @@ public class TokenHandler {
     DefaultHttpClientFactory.DefaultHttpClientFactoryBuilder builder =
         DefaultHttpClientFactory.builder();
     if (connectionPoolConfig == null) {
-      Duration timeout = Duration.ofSeconds((long) SDMConstants.CONNECTION_TIMEOUT);
+      Duration timeout = Duration.ofSeconds(SDMConstants.CONNECTION_TIMEOUT);
       builder.timeoutMilliseconds((int) timeout.toMillis());
       builder.maxConnectionsPerRoute(SDMConstants.MAX_CONNECTIONS);
       builder.maxConnectionsTotal(SDMConstants.MAX_CONNECTIONS);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAdminServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAdminServiceImpl.java
@@ -43,7 +43,7 @@ public class SDMAdminServiceImpl implements SDMAdminService {
           SDMConstants.ONBOARD_REPO_MESSAGE, repository.getDisplayName(), repositoryId);
     } catch (IOException e) {
       throw new ServiceException(
-          String.format(SDMConstants.ONBOARD_REPO__ERROR_MESSAGE, repository.getDisplayName()),
+          String.format(SDMConstants.ONBOARD_REPO_ERROR_MESSAGE, repository.getDisplayName()),
           e.getMessage());
     }
   }


### PR DESCRIPTION
This PR is to fix the sonar scan by excluding the secondarytypeskey class due to this [issue](https://community.sonarsource.com/t/sonarqube-lombok-says-removed-unused-private-field/116949) some other sonar issues. 