### PR TITLE
SDMEXT-1162 - Migration from self hosted runner to GitHub Actions runner

### DIFF
--- a/cap-notebook/demoapp/db/pom.xml
+++ b/cap-notebook/demoapp/db/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>sdm</artifactId>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 	

--- a/cap-notebook/demoapp/pom.xml
+++ b/cap-notebook/demoapp/pom.xml
@@ -51,6 +51,19 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<repositories>
+            <repository>
+                <id>github-snapshot</id>
+                <url>https://maven.pkg.github.com/cap-java/sdm</url>
+                <releases>
+                    <enabled>true</enabled>
+                </releases>
+                <snapshots>
+                    <enabled>true</enabled>
+                </snapshots>
+             </repository>
+        </repositories>
+
 	<build>
 		<plugins>
 			<!-- JAVA VERSION -->

--- a/cap-notebook/demoapp/srv/pom.xml
+++ b/cap-notebook/demoapp/srv/pom.xml
@@ -18,7 +18,7 @@
          <dependency>
           <groupId>com.sap.cds</groupId>
            <artifactId>sdm</artifactId>
-          <version>1.0.3-SNAPSHOT</version>
+          <version>1.1.1-SNAPSHOT</version>
         </dependency>
 
 


### PR DESCRIPTION
Updated the pom file with the github published repository.

With this PR now whenever we deploy our application , It'll use the artifact available on github publish.

Testing : https://github.com/cap-java/sdm/actions/runs/14192414326 