### PR TITLE
optimize ReadAheadInputStream and DocumentUploadService

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -39,7 +39,7 @@ public class SDMConstants {
   public static final String FILE_NOT_FOUND_ERROR = "Object not found in repository";
   public static final Integer MAX_CONNECTIONS = 100;
   public static final int CONNECTION_TIMEOUT = 1200;
-  public static final int CHUNK_SIZE = 100 * 1024 * 1024; // 100MB Chunk Size
+  public static final int CHUNK_SIZE = 20 * 1024 * 1024; // 20MB Chunk Size
   public static final String ONBOARD_REPO_MESSAGE =
       "Repository with name %s  and id %s onboarded successfully";
   public static final String ONBOARD_REPO_ERROR_MESSAGE =

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -88,7 +88,7 @@ public class DocumentUploadService {
                 int chunkSize = SDMConstants.CHUNK_SIZE;
 
                 if (totalSize <= 200 * 1024 * 1024) {
-                  //  Upload directly if file is ≤ 100MB
+                  //  Upload directly if file is ≤ 200MB
                   return uploadSingleChunk(cmisDocument, headers, sdmUrl);
                 } else {
                   //  Upload in chunks if file is > 100MB

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -87,7 +87,7 @@ public class DocumentUploadService {
                 long totalSize = cmisDocument.getContentLength();
                 int chunkSize = SDMConstants.CHUNK_SIZE;
 
-                if (totalSize <= chunkSize) {
+                if (totalSize <= 200 * 1024 * 1024) {
                   //  Upload directly if file is ≤ 100MB
                   return uploadSingleChunk(cmisDocument, headers, sdmUrl);
                 } else {
@@ -288,7 +288,7 @@ public class DocumentUploadService {
               logger.info("bytesRead is " + bytesRead);
               // Step 4: Fetch remaining bytes before checking EOF
               long remainingBytes = chunkedStream.getRemainingBytes();
-              logger.info("remainingBytes is " + remainingBytes);
+              logger.debug("remainingBytes is " + remainingBytes);
 
               // Step 5: Check if it's the last chunk
               boolean isLastChunk = bytesRead < chunkSize || chunkedStream.isEOFReached();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
@@ -18,9 +18,9 @@ public class ReadAheadInputStream extends InputStream {
   private long position = 0;
   private static final Logger logger = LoggerFactory.getLogger(ReadAheadInputStream.class);
   private final ExecutorService executor =
-      Executors.newCachedThreadPool(); // Thread pool to Read next chunk
+      Executors.newFixedThreadPool(2); // Thread pool to Read next chunk
   private final BlockingQueue<byte[]> chunkQueue =
-      new LinkedBlockingQueue<>(3); // Next chunk is read to a queue
+      new LinkedBlockingQueue<>(5); // Next chunk is read to a queue
 
   public ReadAheadInputStream(InputStream inputStream, long totalSize) throws IOException {
     if (inputStream == null) {
@@ -122,7 +122,6 @@ public class ReadAheadInputStream extends InputStream {
 
   public synchronized long getRemainingBytes() {
     long remaining = totalSize - totalBytesRead;
-    logger.info(" Remaining Bytes: " + remaining);
     return remaining > 0 ? remaining : 0;
   }
 


### PR DESCRIPTION
For handling large file upload in smaller memory there were some optimization required. 
The main reason why with 1G container the 400M file upload was crashing was that the 100M chunk size was higher for the heap to allocate contiguous memorary in the multiples of 100M upfront
Made sure we dont use CachedThreadPool instead a fixed size threadpool. Also slightly increased the size of the queue
Also, decided to use 200MB as a criteria for a single chunk upload and changed the chunk size (incase of file size more than 200M) to 20MB. 
Did an extensive testing with 1G and 2G container juggling between 10M and 20M chunk size and confirmed the mem footprint (heap consumption) is stable across. Off course with 10M the used mem of the heap is lesser but even with 20M chunk size the used mem is just linear. 
For now keeping it 20M chunksize because I would not want to emnate twice the network calls (appendContent) from the container to the DI. Rather settling for this trade off as the gains are mrginal/minimal with 10M chunksize
Here is the detailed test result(refer the attached xl)
[UploadTestMetrics.xlsx](https://github.com/user-attachments/files/19615637/UploadTestMetrics.xlsx)

