### PR TITLE
[Java] Support restricting upload to N attachments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.1.1-SNAPSHOT</revision>
+        <revision>1.2.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/caching/CacheConfig.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/caching/CacheConfig.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
-import org.ehcache.config.builders.*;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.expiry.Duration;
 import org.ehcache.expiry.Expirations;
 import org.slf4j.Logger;
@@ -18,6 +20,7 @@ public class CacheConfig {
   private static Cache<TokenCacheKey, String> userAuthoritiesTokenCache;
   private static Cache<RepoKey, String> versionedRepoCache;
   private static Cache<SecondaryTypesKey, List<String>> secondaryTypesCache;
+  private static Cache<String, String> maxAllowedAttachmentsCache;
   private static final int HEAP_SIZE = 1000;
   private static final int USER_TOKEN_EXPIRY = 660;
   private static final int ACCESS_TOKEN_EXPIRY = 660;
@@ -74,6 +77,13 @@ public class CacheConfig {
                     (Class<List<String>>) (Class<?>) List.class,
                     ResourcePoolsBuilder.heap(HEAP_SIZE))
                 .withExpiry(Expirations.noExpiration()));
+
+    maxAllowedAttachmentsCache =
+        cacheManager.createCache(
+            "maxAllowedAttachmentsCache",
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                    String.class, String.class, ResourcePoolsBuilder.heap(HEAP_SIZE))
+                .withExpiry(Expirations.noExpiration()));
   }
 
   public static Cache<CacheKey, String> getUserTokenCache() {
@@ -90,6 +100,10 @@ public class CacheConfig {
 
   public static Cache<RepoKey, String> getVersionedRepoCache() {
     return versionedRepoCache;
+  }
+
+  public static Cache<String, String> getMaxAllowedAttachmentsCache() {
+    return maxAllowedAttachmentsCache;
   }
 
   public static Cache<SecondaryTypesKey, List<String>> getSecondaryTypesCache() {

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -45,10 +45,15 @@ public class SDMConstants {
   public static final String ONBOARD_REPO_ERROR_MESSAGE =
       "Error in onboarding repository with name %s";
   public static final String UPDATE_ATTACHMENT_ERROR = "Could not update the attachment";
+  public static final String ATTACHMENT_MAXCOUNT = "SDM.Attachments.maxCount";
+  public static final String ATTACHMENT_MAXCOUNT_ERROR_MSG = "SDM.Attachments.maxCountError";
+  public static final String MAX_COUNT_ERROR_MESSAGE =
+      "Cannot upload more than %s attachments as set up by the application";
   public static final String NO_SDM_BINDING = "No SDM binding found";
   public static final String DI_TOKEN_EXCHANGE_ERROR = "Error fetching DI token with JWT bearer";
   public static final String DI_TOKEN_EXCHANGE_PARAMS =
       "/oauth/token?grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer";
+  public static final String DRAFT_NOT_FOUND = "Attachment draft entity not found";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentInfo.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentInfo.java
@@ -1,0 +1,17 @@
+package com.sap.cds.sdm.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttachmentInfo {
+  private long attachmentCount;
+  private String errorMessage;
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
@@ -23,4 +23,5 @@ public class CmisDocument {
   private String status;
   private String mimeType;
   private long contentLength;
+  private String subdomain;
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -2,6 +2,7 @@ package com.sap.cds.sdm.persistence;
 
 import com.sap.cds.Result;
 import com.sap.cds.Row;
+import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.CqnSelect;
@@ -10,11 +11,7 @@ import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.services.persistence.PersistenceService;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class DBQuery {
   private DBQuery() {
@@ -63,10 +60,14 @@ public class DBQuery {
   }
 
   public static List<CmisDocument> getAttachmentsForFolder(
-      CdsEntity attachmentEntity, PersistenceService persistenceService, String folderId) {
+      String entity,
+      PersistenceService persistenceService,
+      String folderId,
+      AttachmentMarkAsDeletedEventContext context) {
+    Optional<CdsEntity> attachmentEntity = context.getModel().findEntity(entity + "_drafts");
     List<CmisDocument> cmisDocuments = new ArrayList<>();
     CqnSelect q =
-        Select.from(attachmentEntity)
+        Select.from(attachmentEntity.get())
             .columns("fileName", "IsActiveEntity", "ID", "folderId", "repositoryId", "objectId")
             .where(doc -> doc.get("folderId").eq(folderId));
     Result result = persistenceService.run(q);
@@ -78,6 +79,23 @@ public class DBQuery {
       cmisDocument.setAttachmentId(row.get("ID").toString());
       cmisDocument.setObjectId(row.get("objectId").toString());
       cmisDocuments.add(cmisDocument);
+    }
+    if (cmisDocuments.isEmpty()) {
+      attachmentEntity = context.getModel().findEntity(entity);
+      q =
+          Select.from(attachmentEntity.get())
+              .columns("fileName", "IsActiveEntity", "ID", "folderId", "repositoryId", "objectId")
+              .where(doc -> doc.get("folderId").eq(folderId));
+      result = persistenceService.run(q);
+      for (Row row : result.list()) {
+        CmisDocument cmisDocument = new CmisDocument();
+        cmisDocument.setFolderId(row.get("folderId").toString());
+        cmisDocument.setRepositoryId(row.get("repositoryId").toString());
+        cmisDocument.setFileName(row.get("fileName").toString());
+        cmisDocument.setAttachmentId(row.get("ID").toString());
+        cmisDocument.setObjectId(row.get("objectId").toString());
+        cmisDocuments.add(cmisDocument);
+      }
     }
     return cmisDocuments;
   }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -314,6 +314,7 @@ public class SDMServiceImpl implements SDMService {
   public String getFolderIdByPath(
       String parentId, String repositoryId, SDMCredentials sdmCredentials, String token) {
     String subdomain = TokenHandler.getSubdomainFromToken(token);
+    String folderId = null;
     var httpClient =
         TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
     String sdmUrl =
@@ -323,15 +324,20 @@ public class SDMServiceImpl implements SDMService {
             + "/root/"
             + parentId
             + "?cmisselector=object";
-    HttpPost getFolderRequest = new HttpPost(sdmUrl);
+    HttpGet getFolderRequest = new HttpGet(sdmUrl);
     try (var response = (CloseableHttpResponse) httpClient.execute(getFolderRequest)) {
       int responseCode = response.getStatusLine().getStatusCode();
       if (responseCode == 200) {
-        return EntityUtils.toString(response.getEntity());
+        JSONObject jsonObject = new JSONObject(EntityUtils.toString(response.getEntity()));
+        folderId =
+            jsonObject
+                .getJSONObject("properties")
+                .getJSONObject("cmis:objectId")
+                .getString("value");
       } else if (responseCode == 403) {
         throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
       }
-      return null;
+      return folderId;
     } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("upload"));
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -9,10 +9,7 @@ import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCr
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentReadEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentRestoreEventContext;
-import com.sap.cds.reflect.CdsAssociationType;
-import com.sap.cds.reflect.CdsElement;
-import com.sap.cds.reflect.CdsEntity;
-import com.sap.cds.reflect.CdsModel;
+import com.sap.cds.reflect.*;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
@@ -31,7 +28,6 @@ import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.utils.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,102 +60,8 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
             + context.getParameterInfo().getHeaders().get("content-length")
             + " At "
             + System.currentTimeMillis());
-    String len = context.getParameterInfo().getHeaders().get("content-length");
-    long contentLen = !StringUtils.isEmpty(len) ? Long.parseLong(len) : -1;
-    String subdomain = "";
-    String repositoryId = SDMConstants.REPOSITORY_ID;
-    AuthenticationInfo authInfo = context.getAuthenticationInfo();
-    JwtTokenAuthenticationInfo jwtTokenInfo = authInfo.as(JwtTokenAuthenticationInfo.class);
-    String jwtToken = jwtTokenInfo.getToken();
-    String repocheck = sdmService.checkRepositoryType(jwtToken, repositoryId);
-    CmisDocument cmisDocument = new CmisDocument();
-    if ("Versioned".equals(repocheck)) {
-      throw new ServiceException(SDMConstants.VERSIONED_REPO_ERROR);
-    }
-    Map<String, Object> attachmentIds = context.getAttachmentIds();
-    String upIdKey = "";
-    String upID = "";
-    CdsModel model = context.getModel();
-    Optional<CdsEntity> attachmentDraftEntity =
-        model.findEntity(context.getAttachmentEntity() + "_drafts");
-    Optional<CdsElement> upAssociation = attachmentDraftEntity.get().findAssociation("up_");
-    // if association is found, try to get foreign key to parent entity
-    if (upAssociation.isPresent()) {
-      CdsElement association = upAssociation.get();
-      // get association type
-      CdsAssociationType assocType = association.getType();
-      // get the refs of the association
-      List<String> fkElements = assocType.refs().map(ref -> "up__" + ref.path()).toList();
-      upIdKey = fkElements.get(0);
-      upID = (String) attachmentIds.get(upIdKey);
-    }
-    Result result =
-        DBQuery.getAttachmentsForUPID(
-            attachmentDraftEntity.get(), persistenceService, upID, upIdKey);
-    if (!result.list().isEmpty()) {
-      MediaData data = context.getData();
-
-      String filename = data.getFileName();
-      String fileid = (String) attachmentIds.get("ID");
-      String mimeType = (String) data.get("mimeType");
-      String errorMessageDI = "";
-      boolean nameConstraint = SDMUtils.isRestrictedCharactersInName(filename);
-      if (nameConstraint) {
-        throw new ServiceException(
-            SDMConstants.nameConstraintMessage(Collections.singletonList(filename), "Upload"));
-      }
-      Boolean duplicate = duplicateCheck(filename, fileid, result);
-      if (Boolean.TRUE.equals(duplicate)) {
-        throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
-      }
-      subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
-      String folderId = sdmService.getFolderId(result, persistenceService, upID, jwtToken);
-      cmisDocument.setFileName(filename);
-      cmisDocument.setAttachmentId(fileid);
-      InputStream contentStream = (InputStream) data.get("content");
-      cmisDocument.setContent(contentStream);
-      cmisDocument.setParentId((String) attachmentIds.get(upIdKey));
-      cmisDocument.setRepositoryId(repositoryId);
-      cmisDocument.setFolderId(folderId);
-      cmisDocument.setMimeType(mimeType);
-      cmisDocument.setContentLength(contentLen);
-      SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
-      JSONObject createResult = null;
-      try {
-        createResult =
-            documentService.createDocumentRx(cmisDocument, sdmCredentials, jwtToken).blockingGet();
-        logger.info("Synchronous Response from documentServiceRx: " + createResult.toString());
-        logger.info("Upload Finished at: " + System.currentTimeMillis());
-      } catch (Exception e) {
-        logger.error("Error in documentServiceRx: \n" + Arrays.toString(e.getStackTrace()));
-        throw new ServiceException(
-            SDMConstants.getGenericError(AttachmentService.EVENT_CREATE_ATTACHMENT), e);
-      }
-
-      if (createResult.get("status") == "duplicate") {
-        throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
-      } else if (createResult.get("status") == "virus") {
-        throw new ServiceException(SDMConstants.getVirusFilesError(filename));
-      } else if (createResult.get("status") == "fail") {
-        errorMessageDI = createResult.get("message").toString();
-        throw new ServiceException(errorMessageDI);
-      } else {
-        cmisDocument.setObjectId(createResult.get("objectId").toString());
-        addAttachmentToDraft(attachmentDraftEntity.get(), persistenceService, cmisDocument);
-      }
-    }
-
-    context.setContentId(
-        cmisDocument.getObjectId()
-            + ":"
-            + cmisDocument.getFolderId()
-            + ":"
-            + context.getAttachmentEntity()
-            + ":"
-            + subdomain);
-    context.getData().setStatus("Clean");
-    context.getData().setContent(null);
-    context.setCompleted();
+    validateRepository(context);
+    processEntities(context);
   }
 
   @On(event = AttachmentService.EVENT_MARK_ATTACHMENT_AS_DELETED)
@@ -173,9 +75,9 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       String entity = contextValues[2];
       String subdomain = contextValues[3];
       // check if only attachment exists against the folderId
-      Optional<CdsEntity> attachmentEntity = context.getModel().findEntity(entity);
+
       List<CmisDocument> cmisDocuments =
-          DBQuery.getAttachmentsForFolder(attachmentEntity.get(), persistenceService, folderId);
+          DBQuery.getAttachmentsForFolder(entity, persistenceService, folderId, context);
       if (cmisDocuments.isEmpty()) {
         // deleteFolder API
         sdmService.deleteDocument("deleteTree", folderId, userEmail, subdomain);
@@ -240,5 +142,167 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       }
     }
     return false;
+  }
+
+  private void validateRepository(AttachmentCreateEventContext eventContext)
+      throws ServiceException, IOException {
+    JwtTokenAuthenticationInfo jwtTokenInfo =
+        eventContext.getAuthenticationInfo().as(JwtTokenAuthenticationInfo.class);
+    String jwtToken = jwtTokenInfo.getToken();
+    String repositoryId = SDMConstants.REPOSITORY_ID;
+    String repocheck = sdmService.checkRepositoryType(jwtToken, repositoryId);
+    if ("Versioned".equals(repocheck)) {
+      throw new ServiceException(SDMConstants.VERSIONED_REPO_ERROR);
+    }
+  }
+
+  private void processEntities(AttachmentCreateEventContext eventContext)
+      throws ServiceException, IOException {
+    Map<String, Object> attachmentIds = eventContext.getAttachmentIds();
+    CdsEntity attachmentDraftEntity = getAttachmentDraftEntity(eventContext);
+    String upIdKey = getUpIdKey(attachmentDraftEntity);
+    String upID = (String) attachmentIds.get(upIdKey);
+
+    Result result =
+        DBQuery.getAttachmentsForUPID(attachmentDraftEntity, persistenceService, upID, upIdKey);
+    checkAttachmentConstraints(eventContext, result);
+
+    MediaData data = eventContext.getData();
+    validateFileName(data.getFileName(), result, attachmentIds);
+    createDocumentInSDM(data, result, eventContext, attachmentIds, upIdKey, upID);
+  }
+
+  private CdsEntity getAttachmentDraftEntity(AttachmentCreateEventContext eventContext) {
+    CdsModel model = eventContext.getModel();
+    Optional<CdsEntity> attachmentDraftEntity =
+        model.findEntity(eventContext.getAttachmentEntity() + "_drafts");
+    return attachmentDraftEntity.orElseThrow(
+        () -> new ServiceException(SDMConstants.DRAFT_NOT_FOUND));
+  }
+
+  private String getUpIdKey(CdsEntity attachmentDraftEntity) {
+    String upIdKey = "";
+    Optional<CdsElement> upAssociation = attachmentDraftEntity.findAssociation("up_");
+    if (upAssociation.isPresent()) {
+      CdsElement association = upAssociation.get();
+      // get association type
+      CdsAssociationType assocType = association.getType();
+      // get the refs of the association
+      List<String> fkElements = assocType.refs().map(ref -> "up__" + ref.path()).toList();
+      upIdKey = fkElements.get(0);
+    }
+    return upIdKey;
+  }
+
+  private void checkAttachmentConstraints(AttachmentCreateEventContext eventContext, Result result)
+      throws ServiceException {
+    long rowCount = result.rowCount();
+    String errorMessageCount =
+        SDMUtils.getAttachmentCountAndMessage(
+            eventContext.getModel().entities().toList(), eventContext.getAttachmentEntity());
+
+    String[] maxCountArr = errorMessageCount.split("__");
+    long maxCount = Long.parseLong(maxCountArr[0]);
+    if (maxCount > 0 && rowCount > maxCount) {
+      String message = maxCountArr[1];
+      if (message != null && !"null".equalsIgnoreCase(message)) {
+        throw new ServiceException(message);
+      }
+      throw new ServiceException(String.format(SDMConstants.MAX_COUNT_ERROR_MESSAGE, maxCount));
+    }
+  }
+
+  private void validateFileName(String filename, Result result, Map<String, Object> attachmentIds)
+      throws ServiceException {
+    if (SDMUtils.isRestrictedCharactersInName(filename)) {
+      throw new ServiceException(
+          SDMConstants.nameConstraintMessage(Collections.singletonList(filename), "Upload"));
+    }
+    String fileid = (String) attachmentIds.get("ID");
+    if (duplicateCheck(filename, fileid, result)) {
+      throw new ServiceException(SDMConstants.getDuplicateFilesError(filename));
+    }
+  }
+
+  private void createDocumentInSDM(
+      MediaData data,
+      Result result,
+      AttachmentCreateEventContext eventContext,
+      Map<String, Object> attachmentIds,
+      String upIdKey,
+      String upID)
+      throws ServiceException, IOException {
+
+    CmisDocument cmisDocument = new CmisDocument();
+    String jwtToken =
+        eventContext.getAuthenticationInfo().as(JwtTokenAuthenticationInfo.class).getToken();
+    String repositoryId = SDMConstants.REPOSITORY_ID;
+    String folderId = sdmService.getFolderId(result, persistenceService, upID, jwtToken);
+    String len = eventContext.getParameterInfo().getHeaders().get("content-length");
+    long contentLen = !StringUtils.isEmpty(len) ? Long.parseLong(len) : -1;
+    setCmisDocumentProperties(
+        cmisDocument, data, attachmentIds, folderId, repositoryId, upIdKey, contentLen);
+
+    SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
+    JSONObject createResult = sdmService.createDocument(cmisDocument, sdmCredentials, jwtToken);
+    logger.info("Synchronous Response from documentServiceRx: " + createResult.toString());
+    logger.info("Upload Finished at: " + System.currentTimeMillis());
+    handleCreateDocumentResult(cmisDocument, createResult, eventContext);
+  }
+
+  private void setCmisDocumentProperties(
+      CmisDocument cmisDocument,
+      MediaData data,
+      Map<String, Object> attachmentIds,
+      String folderId,
+      String repositoryId,
+      String upIdKey,
+      long contentlen) {
+    cmisDocument.setFileName(data.getFileName());
+    cmisDocument.setAttachmentId((String) attachmentIds.get("ID"));
+    cmisDocument.setContent((InputStream) data.get("content"));
+    cmisDocument.setParentId((String) attachmentIds.get(upIdKey));
+    cmisDocument.setRepositoryId(repositoryId);
+    cmisDocument.setFolderId(folderId);
+    cmisDocument.setMimeType((String) data.get("mimeType"));
+    cmisDocument.setContentLength(contentlen);
+  }
+
+  private void handleCreateDocumentResult(
+      CmisDocument cmisDocument, JSONObject createResult, AttachmentCreateEventContext eventContext)
+      throws ServiceException {
+    String status = createResult.get("status").toString();
+
+    switch (status) {
+      case "duplicate":
+        throw new ServiceException(SDMConstants.getDuplicateFilesError(cmisDocument.getFileName()));
+      case "virus":
+        throw new ServiceException(SDMConstants.getVirusFilesError(cmisDocument.getFileName()));
+      case "fail":
+        throw new ServiceException(createResult.get("message").toString());
+      default:
+        cmisDocument.setObjectId(createResult.get("objectId").toString());
+        addAttachmentToDraft(
+            getAttachmentDraftEntity(eventContext), persistenceService, cmisDocument);
+        finalizeContext(eventContext, cmisDocument);
+    }
+  }
+
+  private void finalizeContext(
+      AttachmentCreateEventContext eventContext, CmisDocument cmisDocument) {
+    String subdomain =
+        TokenHandler.getSubdomainFromToken(
+            eventContext.getAuthenticationInfo().as(JwtTokenAuthenticationInfo.class).getToken());
+    eventContext.setContentId(
+        cmisDocument.getObjectId()
+            + ":"
+            + cmisDocument.getFolderId()
+            + ":"
+            + eventContext.getAttachmentEntity()
+            + ":"
+            + subdomain);
+    eventContext.getData().setStatus("Clean");
+    eventContext.getData().setContent(null);
+    eventContext.setCompleted();
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
@@ -4,7 +4,9 @@ import com.sap.cds.CdsData;
 import com.sap.cds.reflect.CdsAnnotation;
 import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.sdm.caching.CacheConfig;
 import com.sap.cds.sdm.constants.SDMConstants;
+import com.sap.cds.sdm.model.AttachmentInfo;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.IOException;
@@ -219,5 +221,64 @@ public class SDMUtils {
     }
 
     return updatedSecondaryProperties;
+  }
+
+  public static String getAttachmentCountAndMessage(
+      List<CdsEntity> entities, CdsEntity attachmentEntity) {
+    String maxCount =
+        CacheConfig.getMaxAllowedAttachmentsCache().get(attachmentEntity.getQualifiedName());
+
+    if (maxCount == null) {
+      AttachmentInfo attachmentInfo = new AttachmentInfo();
+      determineAttachmentDetails(attachmentEntity, entities, attachmentInfo);
+      maxCount = attachmentInfo.getAttachmentCount() + "__" + attachmentInfo.getErrorMessage();
+      CacheConfig.getMaxAllowedAttachmentsCache()
+          .put(attachmentEntity.getQualifiedName(), maxCount);
+    }
+    return maxCount;
+  }
+
+  private static void determineAttachmentDetails(
+      CdsEntity attachmentEntity, List<CdsEntity> entities, AttachmentInfo attachmentInfo) {
+
+    for (CdsEntity cdsEntity : entities) {
+      if (isRelatedEntity(attachmentEntity, cdsEntity)) {
+        processCompositions(cdsEntity, attachmentInfo, attachmentEntity);
+      }
+    }
+  }
+
+  private static boolean isRelatedEntity(CdsEntity attachmentEntity, CdsEntity cdsEntity) {
+    String attachmentQualifiedName = attachmentEntity.getQualifiedName();
+    return attachmentQualifiedName.contains(cdsEntity.getQualifiedName())
+        && !attachmentQualifiedName.equals(cdsEntity.getQualifiedName());
+  }
+
+  private static void processCompositions(
+      CdsEntity cdsEntity, AttachmentInfo attachmentInfo, CdsEntity attachmentEntity) {
+    List<CdsElement> compositions = cdsEntity.compositions().toList();
+
+    for (CdsElement cdsElement : compositions) {
+      if (cdsElement != null) {
+        String elementName = cdsElement.getQualifiedName().replaceAll(":", ".");
+        if (elementName.equalsIgnoreCase(attachmentEntity.getQualifiedName())) {
+          retrieveAnnotations(cdsElement, attachmentInfo);
+        }
+      }
+    }
+  }
+
+  private static void retrieveAnnotations(CdsElement cdsElement, AttachmentInfo attachmentInfo) {
+
+    Optional<CdsAnnotation<Object>> maxcountAnnotation =
+        cdsElement.findAnnotation(SDMConstants.ATTACHMENT_MAXCOUNT);
+    maxcountAnnotation.ifPresent(
+        annotation ->
+            attachmentInfo.setAttachmentCount(Long.parseLong(annotation.getValue().toString())));
+
+    Optional<CdsAnnotation<Object>> errormsgAnnotation =
+        cdsElement.findAnnotation(SDMConstants.ATTACHMENT_MAXCOUNT_ERROR_MSG);
+    errormsgAnnotation.ifPresent(
+        annotation -> attachmentInfo.setErrorMessage(annotation.getValue().toString()));
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -520,13 +520,14 @@ public class SDMServiceImplTest {
           .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
           .thenReturn(httpClient);
 
-      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
       when(response.getStatusLine()).thenReturn(statusLine);
       when(statusLine.getStatusCode()).thenReturn(200);
       when(response.getEntity()).thenReturn(entity);
-      InputStream inputStream = new ByteArrayInputStream("ExpectedFolderId".getBytes());
-      when(entity.getContent()).thenReturn(inputStream);
 
+      InputStream inputStream = new ByteArrayInputStream(expectedResponse.getBytes());
+      when(entity.getContent()).thenReturn(inputStream);
+      // when(EntityUtils.toString(entity)).thenReturn(expectedResponse);
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
       String actualResponse =
@@ -548,7 +549,7 @@ public class SDMServiceImplTest {
           .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
           .thenReturn(httpClient);
 
-      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
       when(response.getStatusLine()).thenReturn(statusLine);
       when(statusLine.getStatusCode()).thenReturn(500);
       when(response.getEntity()).thenReturn(entity);
@@ -581,7 +582,7 @@ public class SDMServiceImplTest {
       when(mockSdmCredentials.getUrl()).thenReturn("http://example.com/");
 
       // Simulate IOException during HTTP call
-      when(mockHttpClient.execute(any(HttpPost.class))).thenThrow(new IOException("Network error"));
+      when(mockHttpClient.execute(any(HttpGet.class))).thenThrow(new IOException("Network error"));
 
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool);
 
@@ -619,7 +620,7 @@ public class SDMServiceImplTest {
           .when(() -> TokenHandler.getHttpClient(any(), any(), any(), eq("TOKEN_EXCHANGE")))
           .thenReturn(httpClient);
 
-      when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+      when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
       when(response.getStatusLine()).thenReturn(statusLine);
       when(statusLine.getStatusCode()).thenReturn(403);
       when(response.getEntity()).thenReturn(entity);

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -61,6 +62,7 @@ public class SDMAttachmentsServiceHandlerTest {
   private SDMAttachmentsServiceHandler handlerSpy;
   private PersistenceService persistenceService;
   @Mock private AttachmentMarkAsDeletedEventContext attachmentMarkAsDeletedEventContext;
+
   @Mock private AttachmentRestoreEventContext restoreEventContext;
   private SDMService sdmService;
   private DocumentUploadService documentUploadService;
@@ -85,6 +87,8 @@ public class SDMAttachmentsServiceHandlerTest {
 
   @Mock private SDMCredentials sdmCredentials;
   @Mock private DeletionUserInfo deletionUserInfo;
+  Map<String, String> headers = new HashMap<>();
+  @Mock ParameterInfo parameterInfo;
 
   @BeforeEach
   public void setUp() {
@@ -104,6 +108,9 @@ public class SDMAttachmentsServiceHandlerTest {
     when(deletionUserInfo.getName()).thenReturn(userEmail);
     when(mockContext.getUserInfo()).thenReturn(userInfo);
     when(userInfo.getName()).thenReturn(userEmail);
+
+    headers.put("content-length", "100000");
+
     handlerSpy =
         spy(
             new SDMAttachmentsServiceHandler(
@@ -117,7 +124,32 @@ public class SDMAttachmentsServiceHandlerTest {
     Messages mockMessages = mock(Messages.class);
     MediaData mockMediaData = mock(MediaData.class);
     CdsModel mockModel = mock(CdsModel.class);
+    try (MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      when(sdmService.checkRepositoryType(anyString(), any())).thenReturn("Versioned");
+      when(mockContext.getMessages()).thenReturn(mockMessages);
+      when(mockMessages.error("Upload not supported for versioned repositories."))
+          .thenReturn(mockMessage);
+      when(mockContext.getData()).thenReturn(mockMediaData);
+      when(mockContext.getModel()).thenReturn(mockModel);
+      when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+      when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+      when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+      when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+      when(parameterInfo.getHeaders()).thenReturn(headers);
+      // Use assertThrows to expect a ServiceException and validate the message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
 
+      // Verify the exception message
+      assertEquals("Upload not supported for versioned repositories.", thrown.getMessage());
+    }
     ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
     Map<String, String> mockHeaders = new HashMap<>();
     mockHeaders.put("content-length", "12345");
@@ -185,7 +217,11 @@ public class SDMAttachmentsServiceHandlerTest {
     when(mockContext.getData()).thenReturn(mockMediaData);
     doReturn(true).when(handlerSpy).duplicateCheck(any(), any(), any());
 
-    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class)) {
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       dbQueryMockedStatic
           .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
           .thenReturn(mockResult);
@@ -203,7 +239,7 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
+  @Test
   public void testCreateNonVersionedDIDuplicate() throws IOException {
     // Initialize mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();
@@ -255,8 +291,10 @@ public class SDMAttachmentsServiceHandlerTest {
     // Mock DBQuery and TokenHandler
     try (MockedStatic<DBQuery> DBQueryMockedStatic = mockStatic(DBQuery.class);
         MockedStatic<TokenHandler> tokenHandlerMockedStatic = mockStatic(TokenHandler.class);
-        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class)) {
-
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       DBQueryMockedStatic.when(
               () ->
                   DBQuery.getAttachmentsForUPID(
@@ -264,6 +302,7 @@ public class SDMAttachmentsServiceHandlerTest {
           .thenReturn(mockResult);
 
       SDMCredentials mockSdmCredentials = mock(SDMCredentials.class);
+
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
 
       // Mock SDMUtils.isRestrictedCharactersInName
@@ -283,7 +322,7 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
+  @Test
   public void testCreateNonVersionedDIVirus() throws IOException {
     // Initialize mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();
@@ -333,11 +372,16 @@ public class SDMAttachmentsServiceHandlerTest {
 
     try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-            Mockito.mockStatic(TokenHandler.class)) {
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       dbQueryMockedStatic
           .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
 
       // Use assertThrows to expect a ServiceException and validate the message
@@ -353,7 +397,7 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
+  @Test
   public void testCreateNonVersionedDIOther() throws IOException {
     // Initialization of mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();
@@ -402,11 +446,16 @@ public class SDMAttachmentsServiceHandlerTest {
 
     try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-            Mockito.mockStatic(TokenHandler.class)) {
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       dbQueryMockedStatic
           .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
 
       // Use assertThrows to expect a ServiceException and validate the message
@@ -422,7 +471,7 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
+  @Test
   public void testCreateNonVersionedDISuccess() throws IOException {
     // Initialization of mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();
@@ -472,11 +521,16 @@ public class SDMAttachmentsServiceHandlerTest {
     when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
     try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-            Mockito.mockStatic(TokenHandler.class)) {
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       dbQueryMockedStatic
           .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
       handlerSpy.createAttachment(mockContext);
       verifyNoInteractions(mockMessages);
@@ -491,10 +545,9 @@ public class SDMAttachmentsServiceHandlerTest {
     mockAttachmentIds.put("ID", "id");
     mockAttachmentIds.put("repositoryId", "repo1");
     MediaData mockMediaData = mock(MediaData.class);
-    Result mockResult = mock(Result.class);
+
     Row mockRow = mock(Row.class);
     List<Row> nonEmptyRowList = List.of(mockRow);
-    CdsEntity mockEntity = mock(CdsEntity.class);
     CdsEntity mockDraftEntity = mock(CdsEntity.class);
     byte[] byteArray = "Example content".getBytes();
     InputStream contentStream = new ByteArrayInputStream(byteArray);
@@ -503,7 +556,7 @@ public class SDMAttachmentsServiceHandlerTest {
     mockCreateResult.put("url", "url");
     mockCreateResult.put("name", "sample.pdf");
     mockCreateResult.put("objectId", "objectId");
-
+    Result mockResult = mock(Result.class);
     when(mockMediaData.getFileName()).thenReturn("sample.pdf");
     when(mockMediaData.getContent()).thenReturn(contentStream);
     when(mockContext.getModel()).thenReturn(cdsModel);
@@ -528,14 +581,19 @@ public class SDMAttachmentsServiceHandlerTest {
     try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
             Mockito.mockStatic(TokenHandler.class)) {
+      when(mockResult.rowCount()).thenReturn(2L);
+      String upId = "8219w112dd";
+      String upIdKey = "ew32332";
+
       dbQueryMockedStatic
-          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .when(() -> DBQuery.getAttachmentsForUPID(cdsEntity, persistenceService, null, ""))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
-
+      when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+      when(parameterInfo.getHeaders()).thenReturn(headers);
       handlerSpy.createAttachment(mockContext);
-      verifyNoInteractions(mockMessages);
+      // verifyNoInteractions(mockMessages);
     }
   }
 
@@ -582,7 +640,10 @@ public class SDMAttachmentsServiceHandlerTest {
         MockedStatic<TokenHandler> tokenHandlerMockedStatic =
             Mockito.mockStatic(TokenHandler.class)) {
       dbQueryMockedStatic
-          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .when(
+              () ->
+                  DBQuery.getAttachmentsForUPID(
+                      cdsEntity, persistenceService, anyString(), anyString()))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
@@ -592,7 +653,7 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
+  @Test
   public void testCreateNonVersionedNameConstraint() throws IOException {
     // Initialization of mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();
@@ -642,6 +703,9 @@ public class SDMAttachmentsServiceHandlerTest {
           .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
           .thenReturn(mockResult);
       SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
       tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
       sdmUtilsMockedStatic
           .when(() -> SDMUtils.isRestrictedCharactersInName(anyString()))
@@ -675,8 +739,9 @@ public class SDMAttachmentsServiceHandlerTest {
       cmisDocument = new CmisDocument();
       cmisDocument.setObjectId("objectId2");
       cmisDocuments.add(cmisDocument);
+
       mockedDBQuery
-          .when(() -> DBQuery.getAttachmentsForFolder(cdsEntity, persistenceService, folderId))
+          .when(() -> DBQuery.getAttachmentsForFolder(any(), any(), any(), any()))
           .thenReturn(cmisDocuments);
 
       handlerSpy.markAttachmentAsDeleted(attachmentMarkAsDeletedEventContext);
@@ -691,14 +756,16 @@ public class SDMAttachmentsServiceHandlerTest {
       when(attachmentMarkAsDeletedEventContext.getModel()).thenReturn(cdsModel);
       when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(cdsEntity));
       List<CmisDocument> cmisDocuments = new ArrayList<>();
+      String entity = "Books.attachments";
       CmisDocument cmisDocument = new CmisDocument();
       cmisDocument.setObjectId("objectId");
       cmisDocuments.add(cmisDocument);
       cmisDocument = new CmisDocument();
       cmisDocument.setObjectId("objectId2");
       cmisDocuments.add(cmisDocument);
+
       mockedDBQuery
-          .when(() -> DBQuery.getAttachmentsForFolder(cdsEntity, persistenceService, folderId))
+          .when(() -> DBQuery.getAttachmentsForFolder(any(), any(), any(), any()))
           .thenReturn(cmisDocuments);
 
       handlerSpy.markAttachmentAsDeleted(attachmentMarkAsDeletedEventContext);
@@ -712,8 +779,12 @@ public class SDMAttachmentsServiceHandlerTest {
       when(attachmentMarkAsDeletedEventContext.getModel()).thenReturn(cdsModel);
       when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(cdsEntity));
       List<CmisDocument> cmisDocuments = new ArrayList<>();
+      String entity = "Books.attachments";
       mockedDBQuery
-          .when(() -> DBQuery.getAttachmentsForFolder(cdsEntity, persistenceService, folderId))
+          .when(
+              () ->
+                  DBQuery.getAttachmentsForFolder(
+                      entity, persistenceService, folderId, attachmentMarkAsDeletedEventContext))
           .thenReturn(cmisDocuments);
       handlerSpy.markAttachmentAsDeleted(attachmentMarkAsDeletedEventContext);
       verify(sdmService).deleteDocument("deleteTree", folderId, userEmail, subdomain);
@@ -749,33 +820,37 @@ public class SDMAttachmentsServiceHandlerTest {
   @Test
   void testDuplicateCheck_WithDuplicate() {
     Result result = mock(Result.class);
+    try (MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      // Mocking a raw list of maps
+      List<Map> mockedResultList = new ArrayList<>();
 
-    // Mocking a raw list of maps
-    List<Map> mockedResultList = new ArrayList<>();
+      // Creating a map with duplicate filename but different file ID
+      Map<String, Object> attachment1 = new HashMap<>();
+      attachment1.put("fileName", "sample.pdf");
+      attachment1.put("ID", "1234"); // Different ID, not a duplicate
+      attachment1.put("repositoryId", "repoid");
+      Map<String, Object> attachment2 = new HashMap<>();
+      attachment2.put("fileName", "sample.pdf");
+      attachment2.put("ID", "456"); // Same filename but different ID (this is the duplicate)
+      attachment2.put("repositoryId", "repoid");
+      mockedResultList.add((Map) attachment1);
+      mockedResultList.add((Map) attachment2);
 
-    // Creating a map with duplicate filename but different file ID
-    Map<String, Object> attachment1 = new HashMap<>();
-    attachment1.put("fileName", "sample.pdf");
-    attachment1.put("ID", "1234"); // Different ID, not a duplicate
-    attachment1.put("repositoryId", "repoid");
-    Map<String, Object> attachment2 = new HashMap<>();
-    attachment2.put("fileName", "sample.pdf");
-    attachment2.put("ID", "456"); // Same filename but different ID (this is the duplicate)
-    attachment1.put("repositoryId", "repoid");
-    mockedResultList.add((Map) attachment1);
-    mockedResultList.add((Map) attachment2);
+      // Mocking the result to return the list containing the attachments
+      when(result.listOf(Map.class)).thenReturn((List) mockedResultList);
 
-    // Mocking the result to return the list containing the attachments
-    when(result.listOf(Map.class)).thenReturn((List) mockedResultList);
+      String filename = "sample.pdf";
+      String fileid = "123"; // The fileid to check, same as attachment1, different from attachment2
 
-    String filename = "sample.pdf";
-    String fileid = "123"; // The fileid to check, same as attachment1, different from attachment2
+      // Checking for duplicate
+      boolean isDuplicate = handlerSpy.duplicateCheck(filename, fileid, result);
 
-    // Checking for duplicate
-    boolean isDuplicate = handlerSpy.duplicateCheck(filename, fileid, result);
-
-    // Assert that a duplicate is found
-    assertTrue(isDuplicate, "Expected to find a duplicate");
+      // Assert that a duplicate is found
+      assertTrue(isDuplicate, "Expected to find a duplicate");
+    }
   }
 
   @Test
@@ -857,5 +932,161 @@ public class SDMAttachmentsServiceHandlerTest {
   @Test
   public void testRestoreAttachment() {
     handlerSpy.restoreAttachment(restoreEventContext);
+  }
+
+  @Test
+  public void testMaxCountErrorMessage() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
+    CdsEntity mockEntity = mock(CdsEntity.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    byte[] byteArray = "Example content".getBytes();
+    InputStream contentStream = new ByteArrayInputStream(byteArray);
+    JSONObject mockCreateResult = new JSONObject();
+
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    when(mockMediaData.getContent()).thenReturn(contentStream);
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(mockResult.rowCount()).thenReturn(3L);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    when(sdmService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("1__Only 1 Attachment is allowed");
+      dbQueryMockedStatic
+          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .thenReturn(mockResult);
+      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+      when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+      when(parameterInfo.getHeaders()).thenReturn(headers);
+      // Use assertThrows to expect a ServiceException and validate the message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
+
+      // Verify the exception message
+      assertEquals("Only 1 Attachment is allowed", thrown.getMessage());
+    }
+  }
+
+  @Test
+  public void testMaxCountError() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
+    CdsEntity mockEntity = mock(CdsEntity.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    byte[] byteArray = "Example content".getBytes();
+    InputStream contentStream = new ByteArrayInputStream(byteArray);
+    JSONObject mockCreateResult = new JSONObject();
+
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    when(mockMediaData.getContent()).thenReturn(contentStream);
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(mockResult.rowCount()).thenReturn(3L);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    when(sdmService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+    when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+    when(parameterInfo.getHeaders()).thenReturn(headers);
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("1__null");
+      dbQueryMockedStatic
+          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .thenReturn(mockResult);
+      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+
+      // Use assertThrows to expect a ServiceException and validate the message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
+
+      // Verify the exception message
+      assertEquals(
+          "Cannot upload more than 1 attachments as set up by the application",
+          thrown.getMessage());
+    }
+  }
+
+  @Test
+  public void throwAttachmetDraftEntityException() throws IOException {
+
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+    when(parameterInfo.getHeaders()).thenReturn(headers);
+    when(cdsModel.findEntity(anyString()))
+        .thenThrow(new ServiceException(SDMConstants.DRAFT_NOT_FOUND));
+    ServiceException thrown =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              handlerSpy.createAttachment(mockContext);
+            });
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -1,5 +1,6 @@
 package unit.com.sap.cds.sdm.utilities;
 
+import static com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,17 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import com.google.gson.JsonObject;
 import com.sap.cds.CdsData;
-import com.sap.cds.reflect.CdsAnnotation;
-import com.sap.cds.reflect.CdsElement;
-import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.ql.cqn.CqnSelect;
+import com.sap.cds.reflect.*;
+import com.sap.cds.sdm.caching.CacheConfig;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.utilities.SDMUtils;
@@ -33,9 +29,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.ehcache.Cache;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -52,16 +50,20 @@ public class SDMUtilsTest {
   @Mock private CdsEntity mockEntity;
   @Mock private CdsElement mockElement;
   @Mock private CdsAnnotation<Object> mockAnnotation;
-  @Mock private JsonObject jsonObjectMock;
   @Mock private HttpEntity responseEntity;
+  @Mock private CdsEntity attachmentEntity;
+  @Mock private CdsAnnotation<Object> maxcountAnnotation;
+
+  @Mock private CdsAnnotation<Object> errormsgAnnotation;
+  private List<CdsEntity> entities;
 
   private void setUp() {
     mockedDbQuery = mockStatic(DBQuery.class);
     mockEntity = mock(CdsEntity.class);
     mockElement = mock(CdsElement.class);
     mockAnnotation = mock(CdsAnnotation.class);
-    jsonObjectMock = mock(JsonObject.class);
     responseEntity = mock(HttpEntity.class);
+    entities = new ArrayList<>();
   }
 
   @Test
@@ -581,7 +583,7 @@ public class SDMUtilsTest {
     assertTrue(result.containsKey("property1"));
     assertNull(
         result.get(
-            "property1")); // Since property1 is null in attachment and non-null in DB, it should be
+            "property1")); // Since property1 is null in attachment and non-null in DB, it should
     // set to null
   }
 
@@ -639,5 +641,480 @@ public class SDMUtilsTest {
     List<String> result =
         SDMUtils.getSecondaryTypeProperties(Optional.of(entity), Map.of("key1", "value1"));
     assertEquals(List.of("key1"), result);
+  }
+
+  @Test
+  public void testGetAttachmentCountAndMessage_CachePresent() {
+    try (MockedStatic<CacheConfig> cacheConfigMockedStatic = mockStatic(CacheConfig.class)) {
+      Cache mockCache = mock(Cache.class);
+      String errorMessageCount = "1__Only one attachment allowed";
+      cacheConfigMockedStatic
+          .when(CacheConfig::getMaxAllowedAttachmentsCache)
+          .thenReturn(mockCache);
+      when(mockCache.get(any())).thenReturn(errorMessageCount);
+      // Invoke the method
+      String result = getAttachmentCountAndMessage(entities, attachmentEntity);
+
+      // Assert the result - no processing occurs so default is used
+      assertEquals("1__Only one attachment allowed", result);
+    }
+  }
+
+  @Test
+  public void testGetAttachmentCountAndMessage_NoAnnotations() {
+    try (MockedStatic<CacheConfig> cacheConfigMockedStatic = mockStatic(CacheConfig.class)) {
+      Cache mockCache = mock(Cache.class);
+      cacheConfigMockedStatic
+          .when(CacheConfig::getMaxAllowedAttachmentsCache)
+          .thenReturn(mockCache);
+      when(mockCache.get(any())).thenReturn(null);
+      CdsElement cdsElement = mock(CdsElement.class);
+
+      // Set up the composition elements
+      List<CdsElement> compElements = Collections.singletonList(cdsElement);
+      // when(cdsEntity.compositions().toList()).thenReturn(() -> compElements);
+
+      // Set up the annotations
+      CdsEntity entityOne = mock(CdsEntity.class);
+      CdsEntity entityTwo = mock(CdsEntity.class);
+      when(entityOne.getQualifiedName()).thenReturn("com.sap.demo.EntityOne");
+      when(entityTwo.getQualifiedName()).thenReturn("com.sap.demo.EntityOne");
+      when(attachmentEntity.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+      entities = List.of(entityOne, entityTwo);
+      // Invoke the method
+      String result = getAttachmentCountAndMessage(entities, attachmentEntity);
+
+      // Assert the result
+      assertEquals("0__null", result);
+    }
+  }
+
+  @Test
+  public void testGetAttachmentCountAndMessage_AnnotationsPresent() {
+    try (MockedStatic<CacheConfig> cacheConfigMockedStatic = mockStatic(CacheConfig.class)) {
+      Cache mockCache = mock(Cache.class);
+      cacheConfigMockedStatic
+          .when(CacheConfig::getMaxAllowedAttachmentsCache)
+          .thenReturn(mockCache);
+      when(mockCache.get(any())).thenReturn(null);
+      CdsEntity mainEntity =
+          new CdsEntity() {
+            @Override
+            public Stream<CdsAnnotation<?>> annotations() {
+              return null;
+            }
+
+            @Override
+            public <T> Optional<CdsAnnotation<T>> findAnnotation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public boolean isAbstract() {
+              return false;
+            }
+
+            @Override
+            public boolean isView() {
+              return false;
+            }
+
+            @Override
+            public boolean isProjection() {
+              return false;
+            }
+
+            @Override
+            public Optional<CqnSelect> query() {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsParameter> params() {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsAction> actions() {
+              return null;
+            }
+
+            @Override
+            public CdsAction getAction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsAction> findAction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsFunction> functions() {
+              return null;
+            }
+
+            @Override
+            public CdsFunction getFunction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsFunction> findFunction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getElement(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findElement(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getAssociation(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findAssociation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public <S extends CdsStructuredType> S getTargetOf(String s) {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsElement> elements() {
+              return null;
+            }
+
+            @Override
+            public String getQualifiedName() {
+              return "com.sap.demo.EntityOne";
+            }
+
+            @Override
+            public String getName() {
+              return null;
+            }
+
+            @Override
+            public String getQualifier() {
+              return null;
+            }
+
+            public Stream<CdsElement> compositions() {
+              CdsElement element1 = mock(CdsElement.class);
+              CdsElement element2 = mock(CdsElement.class);
+              when(element1.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+              when(element2.getQualifiedName()).thenReturn("demo.abcd:nnn");
+              when(element1.findAnnotation(SDMConstants.ATTACHMENT_MAXCOUNT))
+                  .thenReturn(Optional.of(maxcountAnnotation));
+              when(element1.findAnnotation(SDMConstants.ATTACHMENT_MAXCOUNT_ERROR_MSG))
+                  .thenReturn(Optional.of(errormsgAnnotation));
+              when(maxcountAnnotation.getValue()).thenReturn("1");
+              when(errormsgAnnotation.getValue()).thenReturn("Only 1 attachment allowed");
+
+              List<CdsElement> compositions = List.of(element1, element2);
+
+              // Create a Stream from the List of CdsElements
+              return compositions.stream();
+            }
+          };
+      when(attachmentEntity.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+      entities = List.of(mainEntity);
+      // when(cds)
+      // Invoke the method
+      String result = getAttachmentCountAndMessage(entities, attachmentEntity);
+      // Assert the result
+      assertEquals("1__Only 1 attachment allowed", result);
+    }
+  }
+
+  @Test
+  public void testGetAttachmentCountAndMessage_CountAnnotationsPresent() {
+    try (MockedStatic<CacheConfig> cacheConfigMockedStatic = mockStatic(CacheConfig.class)) {
+      Cache mockCache = mock(Cache.class);
+      cacheConfigMockedStatic
+          .when(CacheConfig::getMaxAllowedAttachmentsCache)
+          .thenReturn(mockCache);
+      when(mockCache.get(any())).thenReturn(null);
+      CdsEntity mainEntity =
+          new CdsEntity() {
+            @Override
+            public Stream<CdsAnnotation<?>> annotations() {
+              return null;
+            }
+
+            @Override
+            public <T> Optional<CdsAnnotation<T>> findAnnotation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public boolean isAbstract() {
+              return false;
+            }
+
+            @Override
+            public boolean isView() {
+              return false;
+            }
+
+            @Override
+            public boolean isProjection() {
+              return false;
+            }
+
+            @Override
+            public Optional<CqnSelect> query() {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsParameter> params() {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsAction> actions() {
+              return null;
+            }
+
+            @Override
+            public CdsAction getAction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsAction> findAction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsFunction> functions() {
+              return null;
+            }
+
+            @Override
+            public CdsFunction getFunction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsFunction> findFunction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getElement(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findElement(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getAssociation(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findAssociation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public <S extends CdsStructuredType> S getTargetOf(String s) {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsElement> elements() {
+              return null;
+            }
+
+            @Override
+            public String getQualifiedName() {
+              return "com.sap.demo.EntityOne";
+            }
+
+            @Override
+            public String getName() {
+              return null;
+            }
+
+            @Override
+            public String getQualifier() {
+              return null;
+            }
+
+            public Stream<CdsElement> compositions() {
+              CdsElement element1 = mock(CdsElement.class);
+              CdsElement element2 = mock(CdsElement.class);
+              when(element1.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+              when(element2.getQualifiedName()).thenReturn("demo.abcd:nnn");
+              when(element1.findAnnotation(SDMConstants.ATTACHMENT_MAXCOUNT))
+                  .thenReturn(Optional.of(maxcountAnnotation));
+
+              when(maxcountAnnotation.getValue()).thenReturn("1");
+
+              List<CdsElement> compositions = List.of(element1, element2);
+              return compositions.stream();
+            }
+          };
+      when(attachmentEntity.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+      entities = List.of(mainEntity);
+      // when(cds)
+      // Invoke the method
+      String result = getAttachmentCountAndMessage(entities, attachmentEntity);
+      // Assert the result
+      assertEquals("1__null", result);
+    }
+  }
+
+  @Test
+  public void testGetAttachmentCountAndMessage_NoAnnotationsPresent() {
+    try (MockedStatic<CacheConfig> cacheConfigMockedStatic = mockStatic(CacheConfig.class)) {
+      Cache mockCache = mock(Cache.class);
+      cacheConfigMockedStatic
+          .when(CacheConfig::getMaxAllowedAttachmentsCache)
+          .thenReturn(mockCache);
+      when(mockCache.get(any())).thenReturn(null);
+      CdsEntity mainEntity =
+          new CdsEntity() {
+            @Override
+            public Stream<CdsAnnotation<?>> annotations() {
+              return null;
+            }
+
+            @Override
+            public <T> Optional<CdsAnnotation<T>> findAnnotation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public boolean isAbstract() {
+              return false;
+            }
+
+            @Override
+            public boolean isView() {
+              return false;
+            }
+
+            @Override
+            public boolean isProjection() {
+              return false;
+            }
+
+            @Override
+            public Optional<CqnSelect> query() {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsParameter> params() {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsAction> actions() {
+              return null;
+            }
+
+            @Override
+            public CdsAction getAction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsAction> findAction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public Stream<CdsFunction> functions() {
+              return null;
+            }
+
+            @Override
+            public CdsFunction getFunction(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsFunction> findFunction(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getElement(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findElement(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public CdsElement getAssociation(String s) {
+              return null;
+            }
+
+            @Override
+            public Optional<CdsElement> findAssociation(String s) {
+              return Optional.empty();
+            }
+
+            @Override
+            public <S extends CdsStructuredType> S getTargetOf(String s) {
+              return null;
+            }
+
+            @Override
+            public Stream<CdsElement> elements() {
+              return null;
+            }
+
+            @Override
+            public String getQualifiedName() {
+              return "com.sap.demo.EntityOne";
+            }
+
+            @Override
+            public String getName() {
+              return null;
+            }
+
+            @Override
+            public String getQualifier() {
+              return null;
+            }
+
+            public Stream<CdsElement> compositions() {
+              CdsElement element1 = mock(CdsElement.class);
+              CdsElement element2 = mock(CdsElement.class);
+              when(element1.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+              when(element2.getQualifiedName()).thenReturn("demo.abcd:nnn");
+              List<CdsElement> compositions = List.of(element1, element2);
+              return compositions.stream();
+            }
+          };
+      when(attachmentEntity.getQualifiedName()).thenReturn("com.sap.demo.EntityOne.Attachments");
+      entities = List.of(mainEntity);
+      String result = getAttachmentCountAndMessage(entities, attachmentEntity);
+      // Assert the result
+      assertEquals("0__null", result);
+    }
   }
 }


### PR DESCRIPTION

<img width="1271" alt="Screenshot 2025-04-07 at 12 45 29 PM" src="https://github.com/user-attachments/assets/4d8cc1b6-d332-4f72-8979-c29047aa1e6e" />
The requirement is to allow only N attachments in the attachments section. This means that users should be allowed to upload only upto (maximum) N attachments either via UI or API.

UT Coverage is above 90%