### PR TITLE
Automation test scenarios for support of secondary properties

### DIFF
--- a/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
+++ b/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
@@ -26,7 +26,7 @@ annotate Attachments with @UI: {
     content
        @Core.ContentDisposition: { Filename: fileName, Type: 'inline' }
         @(title: '{i18n>Attachment}');
-       folderId @UI.Hidden;
+    folderId @UI.Hidden;
     repositoryId  @UI.Hidden ;
     objectId  @UI.Hidden ;
     mimeType @UI.Hidden;

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/Api.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/Api.java
@@ -3,6 +3,10 @@ package integration.com.sap.cds.sdm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import okhttp3.*;
 import okio.ByteString;
@@ -459,6 +463,252 @@ public class Api {
     } catch (IOException e) {
       System.out.println("Attachment was not renamed : " + e);
       return "Attachment was not renamed";
+    }
+  }
+
+  public String updateSecondaryProperty(
+      String appUrl,
+      String serviceName,
+      String entityID,
+      String attachmentID,
+      String stringProperty) {
+    MediaType mediaType = MediaType.parse("application/json");
+    RequestBody body =
+        RequestBody.create(
+            mediaType,
+            ByteString.encodeUtf8(
+                "{\n    \"Working___DocumentInfoRecordString\" : \"" + stringProperty + "\"\n}"));
+    Request request =
+        new Request.Builder()
+            .url(
+                "https://"
+                    + appUrl
+                    + "/odata/v4/"
+                    + serviceName
+                    + "/Books_attachments(up__ID="
+                    + entityID
+                    + ",ID="
+                    + attachmentID
+                    + ",IsActiveEntity=false)")
+            .method("PATCH", body)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", token)
+            .build();
+
+    try (Response updateResponse = httpClient.newCall(request).execute()) {
+      if (updateResponse.code() != 200) {
+        System.out.println(
+            "Updating secondary property failed. Error : " + updateResponse.body().string());
+        throw new IOException("Secondary Property was not updated");
+      }
+      return "Updated";
+    } catch (IOException e) {
+      System.out.println("Secondary Property was not updated : " + e);
+      return "Secondary Property was not updated";
+    }
+  }
+
+  public String updateSecondaryProperty(
+      String appUrl,
+      String serviceName,
+      String entityID,
+      String attachmentID,
+      Integer integerProperty) {
+    MediaType mediaType = MediaType.parse("application/json");
+    RequestBody body =
+        RequestBody.create(
+            mediaType,
+            ByteString.encodeUtf8(
+                "{\n    \"Working___DocumentInfoRecordInt\" : " + integerProperty + "\n}"));
+    Request request =
+        new Request.Builder()
+            .url(
+                "https://"
+                    + appUrl
+                    + "/odata/v4/"
+                    + serviceName
+                    + "/Books_attachments(up__ID="
+                    + entityID
+                    + ",ID="
+                    + attachmentID
+                    + ",IsActiveEntity=false)")
+            .method("PATCH", body)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", token)
+            .build();
+
+    try (Response updateResponse = httpClient.newCall(request).execute()) {
+      if (updateResponse.code() != 200) {
+        System.out.println(
+            "Updating secondary property failed. Error : " + updateResponse.body().string());
+        throw new IOException("Secondary Property was not updated");
+      }
+      return "Updated";
+    } catch (IOException e) {
+      System.out.println("Secondary Property was not updated : " + e);
+      return "Secondary Property was not updated";
+    }
+  }
+
+  public String updateSecondaryProperty(
+      String appUrl,
+      String serviceName,
+      String entityID,
+      String attachmentID,
+      LocalDateTime dateTimeProperty) {
+    MediaType mediaType = MediaType.parse("application/json");
+    // Format the LocalDateTime into an ISO 8601 string with zone offset
+    ZonedDateTime zonedDateTime = dateTimeProperty.atZone(ZoneId.systemDefault());
+    String formattedDateTime = zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+    RequestBody body =
+        RequestBody.create(
+            mediaType,
+            ByteString.encodeUtf8(
+                "{\n    \"Working___DocumentInfoRecordDate\" : \"" + formattedDateTime + "\"\n}"));
+    Request request =
+        new Request.Builder()
+            .url(
+                "https://"
+                    + appUrl
+                    + "/odata/v4/"
+                    + serviceName
+                    + "/Books_attachments(up__ID="
+                    + entityID
+                    + ",ID="
+                    + attachmentID
+                    + ",IsActiveEntity=false)")
+            .method("PATCH", body)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", token)
+            .build();
+
+    try (Response updateResponse = httpClient.newCall(request).execute()) {
+      if (updateResponse.code() != 200) {
+        System.out.println(
+            "Updating secondary property failed. Error : " + updateResponse.body().string());
+        throw new IOException("Secondary Property was not updated");
+      }
+      return "Updated";
+    } catch (IOException e) {
+      System.out.println("Secondary Property was not updated : " + e);
+      return "Secondary Property was not updated";
+    }
+  }
+
+  public String updateSecondaryProperty(
+      String appUrl,
+      String serviceName,
+      String entityID,
+      String attachmentID,
+      Boolean booleanProperty) {
+    MediaType mediaType = MediaType.parse("application/json");
+    RequestBody body =
+        RequestBody.create(
+            mediaType,
+            ByteString.encodeUtf8(
+                "{\n    \"Working___DocumentInfoRecordBoolean\" : " + booleanProperty + "\n}"));
+    Request request =
+        new Request.Builder()
+            .url(
+                "https://"
+                    + appUrl
+                    + "/odata/v4/"
+                    + serviceName
+                    + "/Books_attachments(up__ID="
+                    + entityID
+                    + ",ID="
+                    + attachmentID
+                    + ",IsActiveEntity=false)")
+            .method("PATCH", body)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", token)
+            .build();
+
+    try (Response updateResponse = httpClient.newCall(request).execute()) {
+      if (updateResponse.code() != 200) {
+        System.out.println(
+            "Updating secondary property failed. Error : " + updateResponse.body().string());
+        throw new IOException("Secondary Property was not updated");
+      }
+      return "Updated";
+    } catch (IOException e) {
+      System.out.println("Secondary Property was not updated : " + e);
+      return "Secondary Property was not updated";
+    }
+  }
+
+  public String updateInvalidSecondaryProperty(
+      String appUrl,
+      String serviceName,
+      String entityID,
+      String attachmentID,
+      String invalidSecondaryProperty) {
+    MediaType mediaType = MediaType.parse("application/json");
+    String jsonPayload = "{\n    \"abc___myId1\": \"" + invalidSecondaryProperty + "\"\n}";
+    RequestBody body = RequestBody.create(mediaType, ByteString.encodeUtf8(jsonPayload));
+    Request request =
+        new Request.Builder()
+            .url(
+                "https://"
+                    + appUrl
+                    + "/odata/v4/"
+                    + serviceName
+                    + "/Books_attachments(up__ID="
+                    + entityID
+                    + ",ID="
+                    + attachmentID
+                    + ",IsActiveEntity=false)")
+            .method("PATCH", body)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Authorization", token)
+            .build();
+
+    try (Response updateResponse = httpClient.newCall(request).execute()) {
+      if (updateResponse.code() != 200) {
+        System.out.println(
+            "Updating secondary property failed. Error : " + updateResponse.body().string());
+        throw new IOException("Secondary Property was not updated");
+      }
+      return "Updated";
+    } catch (IOException e) {
+      System.out.println("Secondary Property was not updated : " + e);
+      return "Secondary Property was not updated";
+    }
+  }
+
+  public Map<String, Object> fetchAttachmentMetadata(
+      String appUrl, String serviceName, String entityName, String entityID, String attachmentID)
+      throws IOException {
+    // Construct the URL for fetching attachment metadata
+    String url =
+        "https://"
+            + appUrl
+            + "/odata/v4/"
+            + serviceName
+            + "/"
+            + entityName
+            + "_attachments(up__ID="
+            + entityID
+            + ",ID="
+            + attachmentID
+            + ",IsActiveEntity=true)";
+
+    // Make a GET request to fetch the attachment metadata
+    Request request =
+        new Request.Builder().url(url).get().addHeader("Authorization", token).build();
+
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (response.code() != 200) {
+        System.out.println("Response code: " + response.code());
+        System.out.println("Fetch attachment metadata failed. Error: " + response.body().string());
+        throw new IOException("Could not fetch attachment metadata");
+      } else {
+        // Parse the JSON response to extract metadata
+        return objectMapper.readValue(
+            response.body().string(),
+            new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
+      }
     }
   }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/AttachmentsSDMTest.java
@@ -7,15 +7,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.*;
 import okhttp3.*;
 import org.junit.jupiter.api.*;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class AttachmentsSDMTest {
+class AttachmentsSDMTest {
   private static String token;
   private static String entityID;
   private static String entityID2;
+  private static String entityID3;
   private static String appUrl;
   private static String authUrl;
   private static String username;
@@ -30,7 +32,7 @@ public class AttachmentsSDMTest {
   private static String attachmentID4 = "";
 
   @BeforeAll
-  public static void setup() throws IOException {
+  static void setup() throws IOException {
     // Define your clientId and clientSecret
     Properties credentialsProperties = Credentials.getCredentials();
     String clientId = credentialsProperties.getProperty("clientID");
@@ -74,7 +76,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(1)
-  public void testCreateEntityAndCheck() throws IOException {
+  void testCreateEntityAndCheck() {
     System.out.println("Test (1) : Create entity and check if it exists");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
@@ -95,7 +97,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(2)
-  public void testUpdateEmptyEntity() throws IOException {
+  void testUpdateEmptyEntity() {
     System.out.println("Test (2) : Update an existing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -115,7 +117,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(3)
-  public void testUploadSingleAttachmentPDF() throws IOException {
+  void testUploadSingleAttachmentPDF() throws IOException {
     System.out.println("Test (3) : Upload pdf");
     Boolean testStatus = false;
     ClassLoader classLoader = getClass().getClassLoader();
@@ -156,7 +158,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(4)
-  public void testUploadSingleAttachmentTXT() throws IOException {
+  void testUploadSingleAttachmentTXT() throws IOException {
     System.out.println("Test (4) : Upload txt");
     Boolean testStatus = false;
     ClassLoader classLoader = getClass().getClassLoader();
@@ -196,7 +198,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(5)
-  public void testUploadSingleAttachmentEXE() throws IOException {
+  void testUploadSingleAttachmentEXE() throws IOException {
     System.out.println("Test (5) : Upload exe");
     Boolean testStatus = false;
     ClassLoader classLoader = getClass().getClassLoader();
@@ -236,7 +238,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(6)
-  public void testUploadSingleAttachmentPDFDuplicate() throws IOException {
+  void testUploadSingleAttachmentPDFDuplicate() throws IOException {
     System.out.println("Test (6) : Upload duplicate pdf");
     ClassLoader classLoader = getClass().getClassLoader();
     File file = new File(classLoader.getResource("sample.pdf").getFile());
@@ -277,7 +279,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(7)
-  public void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
+  void testUploadSingleAttachmentPDFDuplicateDifferentEntity() throws IOException {
     System.out.println("Test (7) : Upload duplicate pdf in different entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
@@ -334,7 +336,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(8)
-  public void testRenameSingleAttachment() throws IOException {
+  void testRenameSingleAttachment() {
     System.out.println("Test (8) : Rename single attachment");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -347,7 +349,7 @@ public class AttachmentsSDMTest {
           testStatus = true;
         }
       } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
       }
     }
     if (!testStatus) {
@@ -357,7 +359,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(9)
-  public void testRenameMultipleAttachments() throws IOException {
+  void testRenameMultipleAttachments() {
     System.out.println("Test (9) : Rename multiple attachments");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -372,7 +374,7 @@ public class AttachmentsSDMTest {
           testStatus = true;
         }
       } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
       }
     }
     if (!testStatus) {
@@ -382,7 +384,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(10)
-  public void testRenameSingleAttachmentDuplicate() throws IOException {
+  void testRenameSingleAttachmentDuplicate() {
     System.out.println("Test (10) : Rename single attachment duplicate");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -405,7 +407,7 @@ public class AttachmentsSDMTest {
           }
         }
       } else {
-        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
+        api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
       }
     }
     if (!testStatus) {
@@ -415,7 +417,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(11)
-  public void testDeleteSingleAttachment() throws IOException {
+  void testDeleteSingleAttachment() throws IOException {
     System.out.println("Test (11) : Delete single attachment");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -438,7 +440,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(12)
-  public void testDeleteMultipleAttachments() throws IOException {
+  void testDeleteMultipleAttachments() throws IOException {
     System.out.println("Test (12) : Delete multiple attachments");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID);
@@ -464,7 +466,7 @@ public class AttachmentsSDMTest {
 
   @Test
   @Order(13)
-  public void testDeleteEntity() throws IOException {
+  void testDeleteEntity() {
     System.out.println("Test (13) : Delete entity");
     Boolean testStatus = false;
     String response = api.deleteEntity(appUrl, serviceName, entityName, entityID);
@@ -474,6 +476,798 @@ public class AttachmentsSDMTest {
     }
     if (!testStatus) {
       fail("Could not delete entity");
+    }
+  }
+
+  @Test
+  @Order(14)
+  void testUpdateValidSecondaryProperty_beforeEntityIsSaved_singleAttachment() throws IOException {
+    System.out.println("Test (14): Rename & Update secondary property before entity is saved");
+    System.out.println("Creating entity");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID3 = response;
+      System.out.println("Entity created");
+      System.out.println("Creating attachment");
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", entityID3);
+      postData.put("mimeType", "application/pdf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID3, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID1 = createResponse.get(1);
+        System.out.println("Attachment created");
+        String name1 = "sample1234.pdf";
+        String secondaryPropertyString = "sample12345";
+        Integer secondaryPropertyInt = 1234;
+        LocalDateTime secondaryPropertyDateTime = LocalDateTime.now();
+        System.out.println("Renaming and updating secondary properties for attachment");
+        String response1 =
+            api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+        String updateSecondaryPropertyResponse1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString);
+        String updateSecondaryPropertyResponse2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt);
+        String updateSecondaryPropertyResponse3 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime);
+        String updateSecondaryPropertyResponse4 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+        if (response1 == "Renamed"
+            && updateSecondaryPropertyResponse1 == "Updated"
+            && updateSecondaryPropertyResponse2 == "Updated"
+            && updateSecondaryPropertyResponse3 == "Updated"
+            && updateSecondaryPropertyResponse4 == "Updated") {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+          if (response == "Saved") {
+            System.out.println("Entity saved");
+            testStatus = true;
+            System.out.println("Renamed & updated Secondary properties for attachment");
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
+    }
+  }
+
+  @Test
+  @Order(15)
+  void testUpdateValidSecondaryProperty_afterEntityIsSaved_singleAttachment() {
+    System.out.println("Test (15): Rename & Update secondary property after entity is saved");
+    System.out.println("Editing entity");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+    if (response == "Entity in draft mode") {
+      String name1 = "sample.pdf";
+      String secondaryPropertyString = "sample";
+      Integer secondaryPropertyInt = 12;
+      LocalDateTime secondaryPropertyDateTime = LocalDateTime.now();
+      System.out.println("Renaming and updating secondary properties for attachment");
+      String response1 = api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+      String updateSecondaryPropertyResponse1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString);
+      String updateSecondaryPropertyResponse2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt);
+      String updateSecondaryPropertyResponse3 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime);
+      String updateSecondaryPropertyResponse4 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+      if (response1 == "Renamed"
+          && updateSecondaryPropertyResponse1 == "Updated"
+          && updateSecondaryPropertyResponse2 == "Updated"
+          && updateSecondaryPropertyResponse3 == "Updated"
+          && updateSecondaryPropertyResponse4 == "Updated") {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+        if (response == "Saved") {
+          System.out.println("Entity saved");
+          testStatus = true;
+          System.out.println("Renamed & updated Secondary properties for attachment");
+        }
+      }
+      String deleteEntityResponse = api.deleteEntity(appUrl, serviceName, entityName, entityID3);
+      if (deleteEntityResponse != "Entity Deleted") {
+        fail("Could not delete entity");
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property after entity is saved");
+    }
+  }
+
+  @Test
+  @Order(16)
+  void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_singleAttachment()
+      throws IOException {
+    System.out.println(
+        "Test (16): Rename & Update invalid secondary property before entity is saved");
+    System.out.println("Creating entity");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID3 = response;
+      System.out.println("Entity created");
+      System.out.println("Creating attachment");
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", entityID3);
+      postData.put("mimeType", "application/pdf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse =
+          api.createAttachment(appUrl, serviceName, entityName, entityID3, srvpath, postData, file);
+      String check = createResponse.get(0);
+      if (check.equals("Attachment created")) {
+        attachmentID1 = createResponse.get(1);
+        System.out.println("AttachmentID1: " + attachmentID1);
+        System.out.println("Attachment created");
+        String name1 = "sample1234.pdf";
+        String secondaryPropertyString = "sample12345";
+        Integer secondaryPropertyInt = 1234;
+        LocalDateTime secondaryPropertyDateTime = LocalDateTime.now();
+        String invalidProperty = "testid";
+        System.out.println("Renaming and updating invalid secondary properties for attachment");
+        String response1 =
+            api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+        String updateSecondaryPropertyResponse1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString);
+        String updateSecondaryPropertyResponse2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt);
+        String updateSecondaryPropertyResponse3 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime);
+        String updateSecondaryPropertyResponse4 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+        String updateSecondaryPropertyResponse5 =
+            api.updateInvalidSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, invalidProperty);
+        if (response1 == "Renamed"
+            && updateSecondaryPropertyResponse1 == "Updated"
+            && updateSecondaryPropertyResponse2 == "Updated"
+            && updateSecondaryPropertyResponse3 == "Updated"
+            && updateSecondaryPropertyResponse4 == "Updated"
+            && updateSecondaryPropertyResponse5 == "Updated") {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+          Map<String, Object> attachmentMetadata =
+              api.fetchAttachmentMetadata(
+                  appUrl, serviceName, entityName, entityID3, attachmentID1);
+          assertEquals("sample.pdf", attachmentMetadata.get("fileName"));
+          assertNull(attachmentMetadata.get("abc___myId1"));
+          assertNull(attachmentMetadata.get("abc___myId2"));
+          assertNull(attachmentMetadata.get("Working___DocumentInfoRecordString"));
+          assertNull(attachmentMetadata.get("Working___DocumentInfoRecordInt"));
+          assertNull(attachmentMetadata.get("Working___DocumentInfoRecordBoolean"));
+          assertNull(attachmentMetadata.get("Working___DocumentInfoRecordDate"));
+          if (response == "Saved") {
+            System.out.println("Entity saved");
+            testStatus = true;
+            System.out.println(
+                "Rename & update secondary properties for attachment is unsuccessfull");
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
+    }
+  }
+
+  @Test
+  @Order(17)
+  void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_singleAttachment() throws IOException {
+    System.out.println(
+        "Test (17): Rename & Update invalid secondary property after entity is saved");
+    System.out.println("Editing entity");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+    if (response == "Entity in draft mode") {
+      String name1 = "sample.pdf";
+      String secondaryPropertyString = "sample";
+      Integer secondaryPropertyInt = 12;
+      LocalDateTime secondaryPropertyDateTime = LocalDateTime.now();
+      String invalidProperty = "testidinvalid";
+      System.out.println("Renaming and updating invalid secondary properties for attachment");
+      String response1 = api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+      String updateSecondaryPropertyResponse1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString);
+      String updateSecondaryPropertyResponse2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt);
+      String updateSecondaryPropertyResponse3 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime);
+      String updateSecondaryPropertyResponse4 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+      String updateSecondaryPropertyResponse5 =
+          api.updateInvalidSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, invalidProperty);
+      if (response1 == "Renamed"
+          && updateSecondaryPropertyResponse1 == "Updated"
+          && updateSecondaryPropertyResponse2 == "Updated"
+          && updateSecondaryPropertyResponse3 == "Updated"
+          && updateSecondaryPropertyResponse4 == "Updated"
+          && updateSecondaryPropertyResponse5 == "Updated") {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+        Map<String, Object> attachmentMetadata =
+            api.fetchAttachmentMetadata(appUrl, serviceName, entityName, entityID3, attachmentID1);
+        assertEquals("sample.pdf", attachmentMetadata.get("fileName"));
+        assertNull(attachmentMetadata.get("abc___myId1"));
+        assertNull(attachmentMetadata.get("abc___myId2"));
+        assertNull(attachmentMetadata.get("Working___DocumentInfoRecordString"));
+        assertNull(attachmentMetadata.get("Working___DocumentInfoRecordInt"));
+        assertNull(attachmentMetadata.get("Working___DocumentInfoRecordBoolean"));
+        assertNull(attachmentMetadata.get("Working___DocumentInfoRecordDate"));
+        if (response == "Saved") {
+          System.out.println("Entity saved");
+          testStatus = true;
+          System.out.println(
+              "Rename & update secondary properties for attachment is unsuccessfull");
+        }
+      }
+      String deleteEntityResponse = api.deleteEntity(appUrl, serviceName, entityName, entityID3);
+      if (deleteEntityResponse != "Entity Deleted") {
+        fail("Could not delete entity");
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
+    }
+  }
+
+  @Test
+  @Order(18)
+  void testUpdateValidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
+      throws IOException {
+    System.out.println(
+        "Test (18): Rename & Update valid secondary properties for multiple attachments before entity is saved");
+    System.out.println("Creating entity");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID3 = response;
+
+      System.out.println("Entity created");
+
+      System.out.println("Creating attachment PDF");
+      ClassLoader classLoader = getClass().getClassLoader();
+
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+      Map<String, Object> postData1 = new HashMap<>();
+      postData1.put("up__ID", entityID3);
+      postData1.put("mimeType", "application/pdf");
+      postData1.put("createdAt", new Date().toString());
+      postData1.put("createdBy", "test@test.com");
+      postData1.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse1 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData1, file);
+      if (createResponse1.get(0).equals("Attachment created")) {
+        attachmentID1 = createResponse1.get(1);
+        System.out.println("Attachment created");
+      }
+
+      System.out.println("Creating attachment TXT");
+      file = new File(classLoader.getResource("sample.txt").getFile());
+      Map<String, Object> postData2 = new HashMap<>();
+      postData2.put("up__ID", entityID3);
+      postData2.put("mimeType", "application/txt");
+      postData2.put("createdAt", new Date().toString());
+      postData2.put("createdBy", "test@test.com");
+      postData2.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse2 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData2, file);
+      if (createResponse2.get(0).equals("Attachment created")) {
+        attachmentID2 = createResponse2.get(1);
+        System.out.println("Attachment created");
+      }
+
+      System.out.println("Creating attachment EXE");
+      file = new File(classLoader.getResource("sample.exe").getFile());
+      Map<String, Object> postData3 = new HashMap<>();
+      postData3.put("up__ID", entityID3);
+      postData3.put("mimeType", "application/exe");
+      postData3.put("createdAt", new Date().toString());
+      postData3.put("createdBy", "test@test.com");
+      postData3.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse3 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData3, file);
+      if (createResponse3.get(0).equals("Attachment created")) {
+        attachmentID3 = createResponse3.get(1);
+        System.out.println("Attachment created");
+      }
+
+      String check1 = createResponse1.get(0);
+      String check2 = createResponse2.get(0);
+      String check3 = createResponse3.get(0);
+      if (check1.equals("Attachment created")
+          && check2.equals("Attachment created")
+          && check3.equals("Attachment created")) {
+        Boolean attachment1Updated = false;
+        Boolean attachment2Updated = false;
+        Boolean attachment3Updated = false;
+
+        String name1 = "sample1234.pdf";
+        String secondaryPropertyString1 = "sample12345";
+        Integer secondaryPropertyInt1 = 1234;
+        LocalDateTime secondaryPropertyDateTime1 = LocalDateTime.now();
+        System.out.println("Renaming and updating secondary properties for attachment PDF");
+        String responsePDF1 =
+            api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+        String updateSecondaryPropertyResponsePDF1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString1);
+        String updateSecondaryPropertyResponsePDF2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt1);
+        String updateSecondaryPropertyResponsePDF3 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime1);
+        String updateSecondaryPropertyResponsePDF4 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+        if (responsePDF1 == "Renamed"
+            && updateSecondaryPropertyResponsePDF1 == "Updated"
+            && updateSecondaryPropertyResponsePDF2 == "Updated"
+            && updateSecondaryPropertyResponsePDF3 == "Updated"
+            && updateSecondaryPropertyResponsePDF4 == "Updated") {
+          System.out.println("Renamed & updated Secondary properties for attachment PDF");
+          attachment1Updated = true;
+        }
+
+        System.out.println("Updating secondary properties for attachment TXT");
+        String updateSecondaryPropertyResponseTXT1 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID2, true);
+        if (updateSecondaryPropertyResponseTXT1 == "Updated") {
+          System.out.println("Updated Secondary properties for attachment TXT");
+          attachment2Updated = true;
+        }
+
+        String secondaryPropertyString3 = "sample12345";
+        Integer secondaryPropertyInt3 = 1234;
+        LocalDateTime secondaryPropertyDateTime3 = LocalDateTime.now();
+        System.out.println("Updating secondary properties for attachment EXE");
+
+        String updateSecondaryPropertyResponseEXE1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyString3);
+        String updateSecondaryPropertyResponseEXE2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyInt3);
+        String updateSecondaryPropertyResponseEXE3 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyDateTime3);
+
+        if (updateSecondaryPropertyResponseEXE1 == "Updated"
+            && updateSecondaryPropertyResponseEXE2 == "Updated"
+            && updateSecondaryPropertyResponseEXE3 == "Updated") {
+          System.out.println("Updated Secondary properties for attachment EXE");
+          attachment3Updated = true;
+        }
+
+        if (attachment1Updated && attachment2Updated && attachment3Updated) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+          if (response == "Saved") {
+            System.out.println("Entity saved");
+            testStatus = true;
+            System.out.println("Renamed & updated Secondary properties for attachments");
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
+    }
+  }
+
+  @Test
+  @Order(19)
+  void testUpdateValidSecondaryProperty_afterEntityIsSaved_multipleAttachments() {
+    System.out.println(
+        "Test (19): Rename & Update  valid secondary properties for multiple attachments after entity is saved");
+    System.out.println("Editing entity");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+    if (response == "Entity in draft mode") {
+      Boolean attachment1Updated = false;
+      Boolean attachment2Updated = false;
+      Boolean attachment3Updated = false;
+
+      String name1 = "sample1.pdf";
+      String secondaryPropertyString1 = "sample1";
+      Integer secondaryPropertyInt1 = 12;
+      LocalDateTime secondaryPropertyDateTime1 = LocalDateTime.now();
+      System.out.println("Renaming and updating secondary properties for attachment PDF");
+      String responsePDF1 =
+          api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+      String updateSecondaryPropertyResponsePDF1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString1);
+      String updateSecondaryPropertyResponsePDF2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt1);
+      String updateSecondaryPropertyResponsePDF3 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime1);
+      String updateSecondaryPropertyResponsePDF4 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+      if (responsePDF1 == "Renamed"
+          && updateSecondaryPropertyResponsePDF1 == "Updated"
+          && updateSecondaryPropertyResponsePDF2 == "Updated"
+          && updateSecondaryPropertyResponsePDF3 == "Updated"
+          && updateSecondaryPropertyResponsePDF4 == "Updated") {
+        System.out.println("Renamed & updated Secondary properties for attachment PDF");
+        attachment1Updated = true;
+      }
+
+      System.out.println("Updating secondary properties for attachment TXT");
+      String updateSecondaryPropertyResponseTXT1 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID2, false);
+      if (updateSecondaryPropertyResponseTXT1 == "Updated") {
+        System.out.println("Updated Secondary properties for attachment TXT");
+        attachment2Updated = true;
+      }
+
+      String secondaryPropertyString3 = "sample3";
+      Integer secondaryPropertyInt3 = 123;
+      LocalDateTime secondaryPropertyDateTime3 = LocalDateTime.now();
+      System.out.println("Updating secondary properties for attachment EXE");
+
+      String updateSecondaryPropertyResponseEXE1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyString3);
+      String updateSecondaryPropertyResponseEXE2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyInt3);
+      String updateSecondaryPropertyResponseEXE3 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyDateTime3);
+
+      if (updateSecondaryPropertyResponseEXE1 == "Updated"
+          && updateSecondaryPropertyResponseEXE2 == "Updated"
+          && updateSecondaryPropertyResponseEXE3 == "Updated") {
+        System.out.println("Updated Secondary properties for attachment EXE");
+        attachment3Updated = true;
+      }
+
+      if (attachment1Updated && attachment2Updated && attachment3Updated) {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+        if (response == "Saved") {
+          System.out.println("Entity saved");
+          testStatus = true;
+          System.out.println("Renamed & updated Secondary properties for attachments");
+        }
+      }
+      String deleteEntityResponse = api.deleteEntity(appUrl, serviceName, entityName, entityID3);
+      if (deleteEntityResponse != "Entity Deleted") {
+        fail("Could not delete entity");
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property after entity is saved");
+    }
+  }
+
+  @Test
+  @Order(20)
+  void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
+      throws IOException {
+    System.out.println(
+        "Test (20): Rename & Update invalid and valid secondary properties for multiple attachments before entity is saved");
+    System.out.println("Creating entity");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+    if (response != "Could not create entity") {
+      entityID3 = response;
+
+      System.out.println("Entity created");
+
+      System.out.println("Creating attachment PDF");
+      ClassLoader classLoader = getClass().getClassLoader();
+
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+      Map<String, Object> postData1 = new HashMap<>();
+      postData1.put("up__ID", entityID3);
+      postData1.put("mimeType", "application/pdf");
+      postData1.put("createdAt", new Date().toString());
+      postData1.put("createdBy", "test@test.com");
+      postData1.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse1 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData1, file);
+      if (createResponse1.get(0).equals("Attachment created")) {
+        attachmentID1 = createResponse1.get(1);
+        System.out.println("Attachment created");
+      }
+
+      System.out.println("Creating attachment TXT");
+      file = new File(classLoader.getResource("sample.txt").getFile());
+      Map<String, Object> postData2 = new HashMap<>();
+      postData2.put("up__ID", entityID3);
+      postData2.put("mimeType", "application/txt");
+      postData2.put("createdAt", new Date().toString());
+      postData2.put("createdBy", "test@test.com");
+      postData2.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse2 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData2, file);
+      if (createResponse2.get(0).equals("Attachment created")) {
+        attachmentID2 = createResponse2.get(1);
+        System.out.println("Attachment created");
+      }
+
+      System.out.println("Creating attachment EXE");
+      file = new File(classLoader.getResource("sample.exe").getFile());
+      Map<String, Object> postData3 = new HashMap<>();
+      postData3.put("up__ID", entityID3);
+      postData3.put("mimeType", "application/exe");
+      postData3.put("createdAt", new Date().toString());
+      postData3.put("createdBy", "test@test.com");
+      postData3.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse3 =
+          api.createAttachment(
+              appUrl, serviceName, entityName, entityID3, srvpath, postData3, file);
+      if (createResponse3.get(0).equals("Attachment created")) {
+        attachmentID3 = createResponse3.get(1);
+        System.out.println("Attachment created");
+      }
+
+      String check1 = createResponse1.get(0);
+      String check2 = createResponse2.get(0);
+      String check3 = createResponse3.get(0);
+      if (check1.equals("Attachment created")
+          && check2.equals("Attachment created")
+          && check3.equals("Attachment created")) {
+        Boolean attachment1Updated = false;
+        Boolean attachment2Updated = false;
+        Boolean attachment3Updated = false;
+
+        String name1 = "sample1234.pdf";
+        String secondaryPropertyString1 = "sample12345";
+        Integer secondaryPropertyInt1 = 1234;
+        LocalDateTime secondaryPropertyDateTime1 = LocalDateTime.now();
+        String invalidPropertyPDF = "testidinvalidPDF";
+        System.out.println("Renaming and updating invalid secondary properties for attachment PDF");
+        String responsePDF1 =
+            api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+        String updateSecondaryPropertyResponsePDF1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString1);
+        String updateSecondaryPropertyResponsePDF2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt1);
+        String updateSecondaryPropertyResponsePDF3 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime1);
+        String updateSecondaryPropertyResponsePDF4 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+        String updateSecondaryPropertyResponsePDF5 =
+            api.updateInvalidSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID1, invalidPropertyPDF);
+        if (responsePDF1 == "Renamed"
+            && updateSecondaryPropertyResponsePDF1 == "Updated"
+            && updateSecondaryPropertyResponsePDF2 == "Updated"
+            && updateSecondaryPropertyResponsePDF3 == "Updated"
+            && updateSecondaryPropertyResponsePDF4 == "Updated"
+            && updateSecondaryPropertyResponsePDF5 == "Updated") {
+          attachment1Updated = true;
+        }
+
+        System.out.println("Updating valid secondary properties for attachment TXT");
+        String updateSecondaryPropertyResponseTXT1 =
+            api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID2, true);
+        if (updateSecondaryPropertyResponseTXT1 == "Updated") {
+          System.out.println("Updated Secondary properties for attachment TXT");
+          attachment2Updated = true;
+        }
+
+        String secondaryPropertyString3 = "sample12345";
+        Integer secondaryPropertyInt3 = 1234;
+        System.out.println("Updating valid secondary properties for attachment EXE");
+
+        String updateSecondaryPropertyResponseEXE1 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyString3);
+        String updateSecondaryPropertyResponseEXE2 =
+            api.updateSecondaryProperty(
+                appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyInt3);
+
+        if (updateSecondaryPropertyResponseEXE1 == "Updated"
+            && updateSecondaryPropertyResponseEXE2 == "Updated") {
+          System.out.println("Updated Secondary properties for attachment EXE");
+          attachment3Updated = true;
+        }
+
+        if (attachment1Updated && attachment2Updated && attachment3Updated) {
+          response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+          Map<String, Object> attachmentMetadataPDF =
+              api.fetchAttachmentMetadata(
+                  appUrl, serviceName, entityName, entityID3, attachmentID1);
+          assertEquals("sample.pdf", attachmentMetadataPDF.get("fileName"));
+          assertNull(attachmentMetadataPDF.get("abc___myId1"));
+          assertNull(attachmentMetadataPDF.get("abc___myId2"));
+          assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordString"));
+          assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordInt"));
+          assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordBoolean"));
+          assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordDate"));
+
+          Map<String, Object> attachmentMetadataTXT =
+              api.fetchAttachmentMetadata(
+                  appUrl, serviceName, entityName, entityID3, attachmentID2);
+          assertEquals("sample.txt", attachmentMetadataTXT.get("fileName"));
+          assertNull(attachmentMetadataTXT.get("abc___myId1"));
+          assertNull(attachmentMetadataTXT.get("abc___myId2"));
+          assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordString"));
+          assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordInt"));
+          assertTrue((Boolean) attachmentMetadataTXT.get("Working___DocumentInfoRecordBoolean"));
+          assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordDate"));
+
+          Map<String, Object> attachmentMetadataEXE =
+              api.fetchAttachmentMetadata(
+                  appUrl, serviceName, entityName, entityID3, attachmentID3);
+          assertEquals("sample.exe", attachmentMetadataEXE.get("fileName"));
+          assertNull(attachmentMetadataEXE.get("abc___myId1"));
+          assertNull(attachmentMetadataEXE.get("abc___myId2"));
+          assertEquals(
+              "sample12345", attachmentMetadataEXE.get("Working___DocumentInfoRecordString"));
+          assertEquals(1234, attachmentMetadataEXE.get("Working___DocumentInfoRecordInt"));
+
+          if (response == "Saved") {
+            System.out.println("Entity saved");
+            testStatus = true;
+            System.out.println(
+                "Rename & update unsuccessfull for invalid Secondary properties and successfull for valid property attachments");
+          }
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
+    }
+  }
+
+  @Test
+  @Order(21)
+  void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_multipleAttachments()
+      throws IOException {
+    System.out.println(
+        "Test (21): Rename & Update invalid and valid secondary properties for multiple attachments after entity is saved");
+    System.out.println("Editing entity");
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+    if (response == "Entity in draft mode") {
+      Boolean attachment1Updated = false;
+      Boolean attachment2Updated = false;
+      Boolean attachment3Updated = false;
+
+      String name1 = "sample.pdf";
+      String secondaryPropertyString1 = "sample";
+      Integer secondaryPropertyInt1 = 12;
+      LocalDateTime secondaryPropertyDateTime1 = LocalDateTime.now();
+      String invalidPropertyPDF = "testidinvalidPDF";
+      System.out.println("Renaming and updating invalid secondary properties for attachment PDF");
+      String responsePDF1 =
+          api.renameAttachment(appUrl, serviceName, entityID3, attachmentID1, name1);
+      String updateSecondaryPropertyResponsePDF1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyString1);
+      String updateSecondaryPropertyResponsePDF2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyInt1);
+      String updateSecondaryPropertyResponsePDF3 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, secondaryPropertyDateTime1);
+      String updateSecondaryPropertyResponsePDF4 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID1, true);
+      String updateSecondaryPropertyResponsePDF5 =
+          api.updateInvalidSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID1, invalidPropertyPDF);
+      if (responsePDF1 == "Renamed"
+          && updateSecondaryPropertyResponsePDF1 == "Updated"
+          && updateSecondaryPropertyResponsePDF2 == "Updated"
+          && updateSecondaryPropertyResponsePDF3 == "Updated"
+          && updateSecondaryPropertyResponsePDF4 == "Updated"
+          && updateSecondaryPropertyResponsePDF5 == "Updated") {
+        attachment1Updated = true;
+      }
+
+      System.out.println("Updating valid secondary properties for attachment TXT");
+      String updateSecondaryPropertyResponseTXT1 =
+          api.updateSecondaryProperty(appUrl, serviceName, entityID3, attachmentID2, false);
+      if (updateSecondaryPropertyResponseTXT1 == "Updated") {
+        System.out.println("Updated Secondary properties for attachment TXT");
+        attachment2Updated = true;
+      }
+
+      String secondaryPropertyString3 = "sample";
+      Integer secondaryPropertyInt3 = 12;
+      System.out.println("Updating valid secondary properties for attachment EXE");
+
+      String updateSecondaryPropertyResponseEXE1 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyString3);
+      String updateSecondaryPropertyResponseEXE2 =
+          api.updateSecondaryProperty(
+              appUrl, serviceName, entityID3, attachmentID3, secondaryPropertyInt3);
+
+      if (updateSecondaryPropertyResponseEXE1 == "Updated"
+          && updateSecondaryPropertyResponseEXE2 == "Updated") {
+        System.out.println("Updated Secondary properties for attachment EXE");
+        attachment3Updated = true;
+      }
+
+      if (attachment1Updated && attachment2Updated && attachment3Updated) {
+        response = api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, entityID3);
+        Map<String, Object> attachmentMetadataPDF =
+            api.fetchAttachmentMetadata(appUrl, serviceName, entityName, entityID3, attachmentID1);
+        assertEquals("sample.pdf", attachmentMetadataPDF.get("fileName"));
+        assertNull(attachmentMetadataPDF.get("abc___myId1"));
+        assertNull(attachmentMetadataPDF.get("abc___myId2"));
+        assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordString"));
+        assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordInt"));
+        assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordBoolean"));
+        assertNull(attachmentMetadataPDF.get("Working___DocumentInfoRecordDate"));
+
+        Map<String, Object> attachmentMetadataTXT =
+            api.fetchAttachmentMetadata(appUrl, serviceName, entityName, entityID3, attachmentID2);
+        assertEquals("sample.txt", attachmentMetadataTXT.get("fileName"));
+        assertNull(attachmentMetadataTXT.get("abc___myId1"));
+        assertNull(attachmentMetadataTXT.get("abc___myId2"));
+        assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordString"));
+        assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordInt"));
+        assertFalse((Boolean) attachmentMetadataTXT.get("Working___DocumentInfoRecordBoolean"));
+        assertNull(attachmentMetadataTXT.get("Working___DocumentInfoRecordDate"));
+
+        Map<String, Object> attachmentMetadataEXE =
+            api.fetchAttachmentMetadata(appUrl, serviceName, entityName, entityID3, attachmentID3);
+        assertEquals("sample.exe", attachmentMetadataEXE.get("fileName"));
+        assertNull(attachmentMetadataEXE.get("abc___myId1"));
+        assertNull(attachmentMetadataEXE.get("abc___myId2"));
+        assertEquals("sample", attachmentMetadataEXE.get("Working___DocumentInfoRecordString"));
+        assertEquals(12, attachmentMetadataEXE.get("Working___DocumentInfoRecordInt"));
+
+        if (response == "Saved") {
+          System.out.println("Entity saved");
+          testStatus = true;
+          System.out.println(
+              "Rename & update unsuccessfull for invalid Secondary properties and successfull for valid property attachments");
+        }
+        String deleteEntityResponse = api.deleteEntity(appUrl, serviceName, entityName, entityID3);
+        if (deleteEntityResponse != "Entity Deleted") {
+          fail("Could not delete entity");
+        }
+      }
+    }
+    if (!testStatus) {
+      fail("Could not update secondary property before entity is saved");
     }
   }
 }


### PR DESCRIPTION

This PR adds automation test scenarios for support of secondary properties in Java Plugin.

Test Case url: [Wiki Test cases](https://wiki.one.int.sap/wiki/display/sapecm/Test+Cases+for+CAP+Java#:~:text=for%20versioned%20repositories.%22-,10.%C2%A0Support%20secondary%20properties%20in%20attachments,-Prerequisites%3A)

Test Run on developcap space:
<img width="1161" alt="Screenshot 2025-04-10 at 6 06 50 PM" src="https://github.com/user-attachments/assets/16e9b73c-5545-436a-8071-e39998b9cdc6" />

