### PR TITLE
retry logic bug fix

### DIFF
--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -547,7 +547,7 @@
                             com/sap/cds/sdm/service/RetryUtils.class
                         </exclude>
                         <exclude>
-                            com/sap/cds/sdm/service/RetryUtils.RetryAttempts.class
+                            com/sap/cds/sdm/service/RetryUtils$RetryAttempt.class
                         </exclude>
                         <exclude>
                             com/sap/cds/sdm/caching/**

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -547,6 +547,9 @@
                             com/sap/cds/sdm/service/RetryUtils.class
                         </exclude>
                         <exclude>
+                            com/sap/cds/sdm/service/RetryUtils.RetryAttempts.class
+                        </exclude>
+                        <exclude>
                             com/sap/cds/sdm/caching/**
                         </exclude>
                     </excludes>

--- a/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
@@ -49,7 +49,8 @@ public class ReadAheadInputStream extends InputStream {
     executor.submit(
         () -> {
           try {
-            while (totalBytesRead.get() < totalSize) {
+            boolean continueLoading = true;
+            while (continueLoading && totalBytesRead.get() < totalSize) {
               AtomicReference<byte[]> bufferRef = new AtomicReference<>(new byte[CHUNK_SIZE]);
               AtomicLong bytesReadAtomic = new AtomicLong(0);
 
@@ -69,15 +70,15 @@ public class ReadAheadInputStream extends InputStream {
                 // Ensure last chunk is enqueued
                 chunkQueue.put(bufferRef.get());
 
-                // Only mark as last chunk after enqueuing the last chunk
+                // Mark as last chunk if all bytes are read
                 if (totalBytesRead.get() >= totalSize) {
                   lastChunkLoaded.set(true);
                   logger.info("Last chunk successfully queued and marked.");
-                  break;
+                  continueLoading = false; // Exit the loop
                 }
               } else {
                 logger.warn("No bytes read from stream. Possible EOF.");
-                break;
+                continueLoading = false; // Exit the loop
               }
             }
           } catch (InterruptedException e) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
@@ -49,8 +49,7 @@ public class ReadAheadInputStream extends InputStream {
     executor.submit(
         () -> {
           try {
-            boolean continueLoading = true;
-            while (continueLoading && totalBytesRead.get() < totalSize) {
+            while (totalBytesRead.get() < totalSize) {
               AtomicReference<byte[]> bufferRef = new AtomicReference<>(new byte[CHUNK_SIZE]);
               AtomicLong bytesReadAtomic = new AtomicLong(0);
 
@@ -70,15 +69,15 @@ public class ReadAheadInputStream extends InputStream {
                 // Ensure last chunk is enqueued
                 chunkQueue.put(bufferRef.get());
 
-                // Mark as last chunk if all bytes are read
+                // Only mark as last chunk after enqueuing the last chunk
                 if (totalBytesRead.get() >= totalSize) {
                   lastChunkLoaded.set(true);
                   logger.info("Last chunk successfully queued and marked.");
-                  continueLoading = false; // Exit the loop
+                  break;
                 }
               } else {
                 logger.warn("No bytes read from stream. Possible EOF.");
-                continueLoading = false; // Exit the loop
+                break;
               }
             }
           } catch (InterruptedException e) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/RetryUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/RetryUtils.java
@@ -48,28 +48,39 @@ public class RetryUtils {
 
   public static Function<Flowable<Throwable>, Publisher<?>> retryLogic(int maxAttempts) {
     return errors ->
-        errors.flatMap(
-            error ->
-                Flowable.range(1, maxAttempts + 1)
-                    .concatMap(
-                        attempt -> {
-                          if (shouldRetry().test(error) && attempt <= maxAttempts) {
-                            long delay =
-                                (long)
-                                    Math.pow(2, attempt); // Exponential backoff: 2^attempt seconds
-                            logger.info(
-                                "Retry attempt {} failed. Retrying in {} seconds. Error: {}",
-                                attempt,
-                                delay,
-                                error.getMessage(),
-                                error);
-                            return Flowable.timer(delay, TimeUnit.SECONDS).map(ignored -> error);
-                          } else {
-                            logger.error(
-                                "Max attempts reached or no retry condition matched. Exiting with error.");
-                            return Flowable.error(error);
-                          }
-                        })
-                    .onErrorResumeNext(Flowable.just(error)));
+        errors
+            .zipWith(
+                Flowable.range(1, maxAttempts),
+                (error, attempt) -> new RetryAttempt(error, attempt))
+            .flatMap(
+                retry -> {
+                  Throwable error = retry.error;
+                  int attempt = retry.attempt;
+
+                  if (shouldRetry().test(error)) {
+                    long delay = (long) Math.pow(2, attempt); // exponential backoff
+                    logger.info(
+                        "Retry attempt {} failed. Retrying in {} seconds. Error: {}",
+                        attempt,
+                        delay,
+                        error.getMessage());
+                    return Flowable.timer(delay, TimeUnit.SECONDS);
+                  } else {
+                    logger.error(
+                        "No retry condition matched or max attempts reached. Failing permanently. Error: {}",
+                        error.getMessage());
+                    return Flowable.error(error);
+                  }
+                });
+  }
+
+  private static class RetryAttempt {
+    final Throwable error;
+    final int attempt;
+
+    RetryAttempt(Throwable error, int attempt) {
+      this.error = error;
+      this.attempt = attempt;
+    }
   }
 }


### PR DESCRIPTION
Thanks @yashmeet29  for catching a bug running a negative test case. The retries in the case of genuine closure of the stream or real clientAbort exception cases, it was retrying infinitely and causing the state of no return. It was due to a bug in the retryLogic method where _Flowable.range(1, maxAttempts + 1)_ for every error, which creates a fresh sequence of retry attempts for each retry, essentially resetting the attempt counter each time. That means if the original operation fails and emits an error, it enters this retry function and Flowable.range(1, maxAttempts + 1) always emits 1...maxAttempts for every error.
The actual fix is to track the number of attempts across retries not restart the counter in every retry! That is by zipWith the error stream, where attempt counter is wrapped with the error and finally flow back the error to the caller once al attempts are exausted (or off course no error matching pur retry strategy is found)

Following 3 scenarios are tested

1. tested this by putting the computer to sleep when the long running upload is going on resulting in genuine ClientAbort Exception (retried only 5 times) 
2. Also tested the positive scenairo of uploading the large file
3. As a third test, tested the upload with randomly induced exception making sure retry is attemoted and file upload continues and completes successfully even after this is true for several chunks

```
if (!onceEOF && Math.random() < 0.0001) {
                        onceEOF = true;
                        throw new RuntimeException(
                            new org.apache.catalina.connector.ClientAbortException(
                                new java.io.EOFException("Simulated client abort")));
                      }
```