### PR TITLE
Fix: Multiple Error Message In Case Of Duplicate File Name

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
@@ -54,7 +54,7 @@ public class SDMCreateAttachmentsHandler implements EventHandler {
 
   public void updateName(CdsCreateEventContext context, List<CdsData> data, String composition)
       throws IOException {
-    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data);
+    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data, composition);
     if (!duplicateFilenames.isEmpty()) {
       handleDuplicateFilenames(context, duplicateFilenames);
     } else {

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
@@ -24,13 +24,7 @@ import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @ServiceName(value = "*", type = ApplicationService.class)
 public class SDMUpdateAttachmentsHandler implements EventHandler {
@@ -53,7 +47,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
 
   public void updateName(CdsUpdateEventContext context, List<CdsData> data, String composition)
       throws IOException {
-    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data);
+    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data, composition);
     if (!duplicateFilenames.isEmpty()) {
       context
           .getMessages()

--- a/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
@@ -32,11 +32,11 @@ public class SDMUtils {
     // Doesn't do anything
   }
 
-  public static Set<String> isFileNameDuplicateInDrafts(List<CdsData> data) {
+  public static Set<String> isFileNameDuplicateInDrafts(List<CdsData> data, String composition) {
     Set<String> uniqueFilenames = new HashSet<>();
     Set<String> duplicateFilenames = new HashSet<>();
     for (Map<String, Object> entity : data) {
-      List<Map<String, Object>> attachments = (List<Map<String, Object>>) entity.get("attachments");
+      List<Map<String, Object>> attachments = (List<Map<String, Object>>) entity.get(composition);
       if (attachments != null) {
         Iterator<Map<String, Object>> iterator = attachments.iterator();
         while (iterator.hasNext()) {

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandlerTest.java
@@ -117,11 +117,11 @@ public class SDMCreateAttachmentsHandlerTest {
     List<CdsData> data = new ArrayList<>();
     Set<String> duplicateFilenames = new HashSet<>(Arrays.asList("file1.txt", "file2.txt"));
     sdmUtilsMockedStatic
-        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data))
+        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data, "composition"))
         .thenReturn(duplicateFilenames);
 
     // Act
-    handler.updateName(context, data, "");
+    handler.updateName(context, data, "composition");
 
     // Assert
     verify(messages, times(1))
@@ -134,7 +134,7 @@ public class SDMCreateAttachmentsHandlerTest {
     // Arrange
     List<CdsData> data = new ArrayList<>();
     sdmUtilsMockedStatic
-        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data))
+        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data, "composition"))
         .thenReturn(Collections.emptySet());
 
     // Act
@@ -161,7 +161,7 @@ public class SDMCreateAttachmentsHandlerTest {
 
     // Mock utility methods
     sdmUtilsMockedStatic
-        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data))
+        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data, "composition"))
         .thenReturn(Collections.emptySet());
 
     // Act
@@ -407,7 +407,7 @@ public class SDMCreateAttachmentsHandlerTest {
 
     // Mock duplicate file name
     sdmUtilsMockedStatic
-        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data))
+        .when(() -> SDMUtils.isFileNameDuplicateInDrafts(data, "composition"))
         .thenReturn(new HashSet<>());
 
     // Mock attachment entity

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
@@ -113,10 +113,10 @@ public class SDMUpdateAttachmentsHandlerTest {
     when(context.getMessages()).thenReturn(messages);
     sdmUtilsMockedStatic = mockStatic(SDMUtils.class);
     sdmUtilsMockedStatic
-        .when(() -> isFileNameDuplicateInDrafts(data))
+        .when(() -> isFileNameDuplicateInDrafts(data, "composition"))
         .thenReturn(duplicateFilenames);
 
-    handler.updateName(context, data, "");
+    handler.updateName(context, data, "composition");
 
     verify(messages, times(1))
         .error(

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -85,7 +85,7 @@ public class SDMUtilsTest {
     when(mockCdsData.get("attachments")).thenReturn(attachments); // Correctly mock get method
     data.add(mockCdsData);
 
-    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data);
+    Set<String> duplicateFilenames = SDMUtils.isFileNameDuplicateInDrafts(data, "attachments");
 
     assertTrue(duplicateFilenames.contains("file1.txt"));
   }


### PR DESCRIPTION
This PR is intended to fix the issue where the error message was repeated as many number of times as the number of facets defined . 

Successful integration test: 

![image](https://github.com/user-attachments/assets/5cad9054-2712-47b9-85ff-703fd5506a2e)
