### PR TITLE
DINC0499167:Attachments uploaded with first repository is visible whe…

### DIFF
--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -63,6 +63,7 @@ public class SDMConstants {
   public static final Integer MAX_CONNECTIONS_PER_ROUTE = 50;
   public static final Integer MAX_CONNECTIONS_TOTAL = 50;
   public static final String REST_V2_REPOSITORIES = "rest/v2/repositories";
+  public static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandler.java
@@ -4,8 +4,6 @@ import com.sap.cds.ql.CQL;
 import com.sap.cds.ql.Predicate;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.ql.cqn.Modifier;
-import com.sap.cds.reflect.CdsAssociationType;
-import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.services.cds.ApplicationService;
 import com.sap.cds.services.cds.CdsReadEventContext;
@@ -13,8 +11,6 @@ import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.Before;
 import com.sap.cds.services.handler.annotations.HandlerOrder;
 import com.sap.cds.services.handler.annotations.ServiceName;
-import java.util.ArrayList;
-import java.util.List;
 
 @ServiceName(value = "*", type = ApplicationService.class)
 public class SDMReadAttachmentsHandler implements EventHandler {
@@ -25,41 +21,20 @@ public class SDMReadAttachmentsHandler implements EventHandler {
   @HandlerOrder(HandlerOrder.DEFAULT)
   public void processBefore(CdsReadEventContext context) {
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    List<String> compositions = getEntityCompositions(context);
-    for (String composition : compositions) {
-      if (context.getTarget().getQualifiedName().contains(composition)) {
-        CqnSelect copy =
-            CQL.copy(
-                context.getCqn(),
-                new Modifier() {
-                  @Override
-                  public Predicate where(Predicate where) {
-                    return CQL.and(where, CQL.get("repositoryId").eq(repositoryId));
-                  }
-                });
-        context.setCqn(copy);
+    if (context.getTarget().getAnnotationValue(SDMConstants.ANNOTATION_IS_MEDIA_DATA, false)) {
+      CqnSelect copy =
+          CQL.copy(
+              context.getCqn(),
+              new Modifier() {
+                @Override
+                public Predicate where(Predicate where) {
+                  return CQL.and(where, CQL.get("repositoryId").eq(repositoryId));
+                }
+              });
+      context.setCqn(copy);
 
-      } else {
-        context.setCqn(context.getCqn());
-      }
+    } else {
+      context.setCqn(context.getCqn());
     }
-  }
-
-  private List<String> getEntityCompositions(CdsReadEventContext context) {
-    List<CdsElement> compositions = context.getTarget().compositions().toList();
-    List<String> attachmentsCompositionList = new ArrayList<>();
-    for (CdsElement cdsElement : compositions) {
-      if (cdsElement != null) {
-        CdsAssociationType cdsAssociationType = cdsElement.getType();
-        String targetAspect =
-            cdsAssociationType.getTargetAspect().isPresent()
-                ? cdsAssociationType.getTargetAspect().get().getQualifiedName()
-                : null;
-        if (targetAspect != null && targetAspect.equalsIgnoreCase("sap.attachments.Attachments")) {
-          attachmentsCompositionList.add(cdsElement.getName());
-        }
-      }
-    }
-    return attachmentsCompositionList;
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandlerTest.java
@@ -10,11 +10,8 @@ import com.sap.cds.reflect.*;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.applicationservice.SDMReadAttachmentsHandler;
 import com.sap.cds.services.cds.CdsReadEventContext;
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,6 +38,8 @@ public class SDMReadAttachmentsHandlerTest {
     CqnSelect select =
         Select.from(cdsEntity).where(doc -> doc.get("repositoryId").eq(REPOSITORY_ID_KEY));
     when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getAnnotationValue(any(), any())).thenReturn(true);
+    when(context.getCqn()).thenReturn(select);
     // Act
     sdmReadAttachmentsHandler.processBefore(context); // Refers to the method you provided
 
@@ -61,57 +60,14 @@ public class SDMReadAttachmentsHandlerTest {
 
     // Mock target
     when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getAnnotationValue(any(), any())).thenReturn(false);
+
     when(context.getCqn()).thenReturn(select);
-    when(cdsEntity.getQualifiedName()).thenReturn(targetEntity);
-
     // Mock composition with Attachments aspect
-    when(mockComposition.getType()).thenReturn(mockAssociationType);
-    when(mockComposition.getName()).thenReturn("attachments");
-    when(mockTargetAspect.getQualifiedName()).thenReturn("sap.attachments.Attachments");
-    when(mockAssociationType.getTargetAspect()).thenReturn(Optional.of(mockTargetAspect));
-
-    // Return a stream with one valid attachment composition
-    when(cdsEntity.compositions()).thenReturn(Stream.of(mockComposition));
-
     // Act
     sdmReadAttachmentsHandler.processBefore(context);
 
     // Assert — since it enters the 'else' clause, it should call setCqn with original select
     verify(context).setCqn(select);
-  }
-
-  @Test
-  void testModifiesCqnWhenEntityMatchesComposition() {
-    // Arrange
-    String targetEntity = "attachments"; // Matches the composition name
-    String expectedRepositoryId = REPOSITORY_ID_KEY;
-
-    // Original query with no WHERE clause
-    CqnSelect originalCqn = Select.from("SomeEntity");
-
-    // Mock context and target entity
-    when(context.getTarget()).thenReturn(cdsEntity);
-    when(context.getCqn()).thenReturn(originalCqn);
-    when(cdsEntity.getQualifiedName()).thenReturn(targetEntity);
-
-    // Mock composition with matching name
-    when(mockComposition.getType()).thenReturn(mockAssociationType);
-    when(mockComposition.getName()).thenReturn("attachments");
-    when(mockTargetAspect.getQualifiedName()).thenReturn("sap.attachments.Attachments");
-    when(mockAssociationType.getTargetAspect()).thenReturn(Optional.of(mockTargetAspect));
-    when(cdsEntity.compositions()).thenReturn(Stream.of(mockComposition));
-
-    // Act
-    sdmReadAttachmentsHandler.processBefore(context);
-
-    // Assert — capture the modified CQN and verify it contains the repositoryId condition
-    ArgumentCaptor<CqnSelect> captor = ArgumentCaptor.forClass(CqnSelect.class);
-    verify(context).setCqn(captor.capture());
-    CqnSelect modifiedCqn = captor.getValue();
-
-    // Basic assertion: check that repositoryId predicate was added
-    String cqnAsString = modifiedCqn.toJson(); // or use toString(), depending on your CQN lib
-    assertTrue(cqnAsString.contains("\"ref\":[\"repositoryId\"]"));
-    assertTrue(cqnAsString.contains("\"val\":\"" + expectedRepositoryId + "\""));
   }
 }


### PR DESCRIPTION
…n application is redeployed with second repository

## Describe your changes
context.getTarget().getAnnotationValue(SDMConstants.ANNOTATION_IS_MEDIA_DATA, false) added this check and only if its composition of attachments repo id check is valid
#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description
<img width="1459" alt="Screenshot 2025-05-14 at 11 47 43 AM" src="https://github.com/user-attachments/assets/25b94ba5-71c2-4dac-811e-d18806af0d14" />

<img width="1303" alt="Screenshot 2025-05-14 at 12 20 46 PM" src="https://github.com/user-attachments/assets/b7620a8b-e4f5-4d02-9924-9ce6561a99f8" />

