### PR TITLE
Large file upload fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.3.1
+
+### Fixed
+
+- An issue in uploading large size attachments.
+
 ## Version 1.3.0
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>4.0.0</revision>
+        <revision>1.3.0</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.3.0</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.3.0</revision>
+        <revision>4.0.0</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.3.0</revision>
+        <revision>1.3.1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.3.0</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/configuration/Registration.java
@@ -60,7 +60,7 @@ public class Registration implements CdsRuntimeConfiguration {
     var connectionPool = getConnectionPool(environment);
 
     SDMService sdmService = new SDMServiceImpl(binding, connectionPool);
-    DocumentUploadService documentService = new DocumentUploadService();
+    DocumentUploadService documentService = new DocumentUploadService(binding, connectionPool);
     configurer.eventHandler(buildReadHandler());
     configurer.eventHandler(new SDMCreateAttachmentsHandler(persistenceService, sdmService));
     configurer.eventHandler(new SDMUpdateAttachmentsHandler(persistenceService, sdmService));

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -5,117 +5,75 @@ import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.services.ServiceException;
-import io.reactivex.BackpressureOverflowStrategy;
-import io.reactivex.Flowable;
-import io.reactivex.Single;
+import com.sap.cds.services.environment.CdsProperties;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import java.io.*;
-import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.entity.mime.InputStreamBody;
-import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.ContentBody;
+import org.apache.http.entity.mime.content.InputStreamBody;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DocumentUploadService {
 
-  private final CloseableHttpClient httpClient;
   MemoryMXBean memoryMXBean;
   private static final Logger logger = LoggerFactory.getLogger(DocumentUploadService.class);
+  private final ServiceBinding binding;
+  private final CdsProperties.ConnectionPool connectionPool;
 
-  public DocumentUploadService() {
+  public DocumentUploadService(
+      ServiceBinding binding, CdsProperties.ConnectionPool connectionPool) {
     logger.info("DocumentUploadService is instantiated");
-    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-    connectionManager.setMaxTotal(20);
-    connectionManager.setDefaultMaxPerRoute(5);
 
-    // Configure request with timeouts
-    RequestConfig requestConfig =
-        RequestConfig.custom()
-            .setConnectionRequestTimeout(60, TimeUnit.MINUTES)
-            .setResponseTimeout(60, TimeUnit.MINUTES)
-            .build();
-
-    ConnectionConfig connectionConfig =
-        ConnectionConfig.custom().setConnectTimeout(60, TimeUnit.MINUTES).build();
-    connectionManager.setDefaultConnectionConfig(connectionConfig);
-
-    // Create a HttpClient using the connection manager
-    httpClient =
-        HttpClients.custom()
-            .setConnectionManager(connectionManager)
-            .setDefaultRequestConfig(requestConfig)
-            .build();
-
-    // Getting the handle to Mem management bean to print out heap mem used at required intervals.
-    memoryMXBean = ManagementFactory.getMemoryMXBean();
+    this.connectionPool = connectionPool;
+    this.binding = binding;
   }
 
   /*
-   * Reactive Java implementation to create document.
+   * Implementation to create document.
    */
-  public Single<JSONObject> createDocumentRx(
-      CmisDocument cmisDocument, SDMCredentials sdmCredentials, String jwtToken) {
-    return Single.defer(
-            () -> {
-              try {
-                //  Obtain DI token
-                String accessToken = TokenHandler.getDIToken(jwtToken, sdmCredentials);
-                String sdmUrl =
-                    sdmCredentials.getUrl() + "browser/" + cmisDocument.getRepositoryId() + "/root";
+  public JSONObject createDocument(
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, String jwtToken)
+      throws IOException {
+    try {
+      long totalSize = cmisDocument.getContentLength();
+      int chunkSize = SDMConstants.CHUNK_SIZE;
 
-                //  Set HTTP headers
-                Map<String, String> headers = new HashMap<>();
-                headers.put("Authorization", "Bearer " + accessToken);
-                headers.put("Connection", "keep-alive");
-
-                long totalSize = cmisDocument.getContentLength();
-                int chunkSize = SDMConstants.CHUNK_SIZE;
-
-                if (totalSize <= 200 * 1024 * 1024) {
-                  //  Upload directly if file is ≤ 200MB
-                  return uploadSingleChunk(cmisDocument, headers, sdmUrl);
-                } else {
-                  //  Upload in chunks if file is > 100MB
-                  return uploadLargeFileInChunks(cmisDocument, headers, sdmUrl, chunkSize);
-                }
-              } catch (Exception e) {
-                return Single.error(
-                    new IOException(" Error uploading document: " + e.getMessage(), e));
-              }
-            })
-        .subscribeOn(io.reactivex.schedulers.Schedulers.io());
+      if (totalSize <= 200 * 1024 * 1024) {
+        // Upload directly if file is ≤ 200MB
+        return uploadSingleChunk(cmisDocument, sdmCredentials, jwtToken);
+      } else {
+        String sdmUrl =
+            sdmCredentials.getUrl() + "browser/" + cmisDocument.getRepositoryId() + "/root";
+        // Upload in chunks if file is > 200MB
+        return uploadLargeFileInChunks(cmisDocument, sdmUrl, chunkSize, jwtToken);
+      }
+    } catch (Exception e) {
+      throw new IOException("Error uploading document: " + e.getMessage(), e);
+    }
   }
 
-  private CloseableHttpResponse performRequestWithRetry(String sdmUrl, HttpUriRequestBase request)
-      throws IOException {
-    return Flowable.fromCallable(() -> httpClient.execute(request))
-        .onBackpressureBuffer(
-            3, // Keeping a very low buffer as we hardly need it as the consumer (di call to
-            // appendcontent) is fast enough for the producer (sending the rest call) as we are
-            // making synchronous call
-            () ->
-                logger.error(
-                    "Buffer overflow! Handle appropriately."), // Callback for overflow handling
-            BackpressureOverflowStrategy
-                .ERROR) // Strategy when overflow happens: just emit an error.
-        .retryWhen(RetryUtils.retryLogic(3))
-        .blockingSingle();
+  private void executeHttpPost(
+      HttpClient httpClient,
+      HttpPost uploadFile,
+      CmisDocument cmisDocument,
+      Map<String, String> finalResponse)
+      throws ServiceException {
+    try (CloseableHttpResponse response = (CloseableHttpResponse) httpClient.execute(uploadFile)) {
+      formResponse(cmisDocument, finalResponse, response);
+    } catch (IOException e) {
+      throw new ServiceException("Error in setting timeout", e);
+    }
   }
 
   /*
@@ -123,12 +81,12 @@ public class DocumentUploadService {
    */
   private void appendContentStream(
       CmisDocument cmisDocument,
-      Map<String, String> headers,
       String sdmUrl,
       byte[] chunkBuffer,
       int bytesRead,
       boolean isLastChunk,
-      int chunkIndex)
+      int chunkIndex,
+      String jwtToken)
       throws IOException, ParseException {
 
     MultipartEntityBuilder builder = MultipartEntityBuilder.create();
@@ -143,29 +101,32 @@ public class DocumentUploadService {
     builder.addTextBody("succinct", "true");
     builder.addPart(
         "media",
-        new InputStreamBody(
-            new ByteArrayInputStream(chunkBuffer, 0, bytesRead), cmisDocument.getFileName()));
+        (ContentBody)
+            new InputStreamBody(
+                new ByteArrayInputStream(chunkBuffer, 0, bytesRead), cmisDocument.getFileName()));
 
     HttpEntity entity = builder.build();
-
+    Map<String, String> headers = new HashMap<>();
     HttpPost request = new HttpPost(sdmUrl);
     request.setEntity(entity);
     headers.forEach(request::addHeader);
 
-    long startChunkUploadTime = System.currentTimeMillis();
-    try (CloseableHttpResponse response = performRequestWithRetry(sdmUrl, request)) {
-      long endChunkUploadTime = System.currentTimeMillis();
-      logger.debug(
-          " Chunk "
-              + chunkIndex
-              + " appendContent completed and it took "
-              + ((int) ((endChunkUploadTime - startChunkUploadTime) / 1000))
-              + " seconds");
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+
+    Map<String, String> finalResponse = new HashMap<>();
+
+    try {
+      this.executeHttpPost(httpClient, request, cmisDocument, finalResponse);
+
+    } catch (Exception e) {
+      logger.error("Error in appending content: {}", e.getMessage());
+      throw new IOException("Error in appending content: " + e.getMessage(), e);
     }
   }
 
-  private String createEmptyDocument(
-      CmisDocument cmisDocument, Map<String, String> headers, String sdmUrl)
+  private JSONObject createEmptyDocument(CmisDocument cmisDocument, String sdmUrl, String jwtToken)
       throws IOException, ParseException {
 
     MultipartEntityBuilder builder = MultipartEntityBuilder.create();
@@ -178,215 +139,169 @@ public class DocumentUploadService {
     builder.addTextBody("succinct", "true");
 
     HttpEntity entity = builder.build();
-
     HttpPost request = new HttpPost(sdmUrl);
     request.setEntity(entity);
-    headers.forEach(request::addHeader);
 
-    try (CloseableHttpResponse response = performRequestWithRetry(sdmUrl, request)) {
-      logger.info("Empty Document Created: " + response.getCode());
-      if (response.getEntity() == null) {
-        throw new IOException("Response entity is null!");
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+
+    Map<String, String> finalResponse = new HashMap<>();
+    executeHttpPost(httpClient, request, cmisDocument, finalResponse);
+
+    return new JSONObject(finalResponse);
+  }
+
+  public JSONObject uploadSingleChunk(
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, String jwtToken)
+      throws IOException {
+
+    InputStream originalStream = cmisDocument.getContent();
+    if (originalStream == null) {
+      throw new IOException("File stream is null!");
+    }
+
+    // Prepare Multipart Request
+    String subdomain = TokenHandler.getSubdomainFromToken(jwtToken);
+    var httpClient =
+        TokenHandler.getHttpClient(binding, connectionPool, subdomain, "TOKEN_EXCHANGE");
+
+    String sdmUrl = sdmCredentials.getUrl() + "browser/" + cmisDocument.getRepositoryId() + "/root";
+
+    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+    builder.addBinaryBody(
+        "filename",
+        cmisDocument.getContent(),
+        ContentType.create(cmisDocument.getMimeType()),
+        cmisDocument.getFileName());
+    // Add additional form fields
+    builder.addTextBody("cmisaction", "createDocument", ContentType.TEXT_PLAIN);
+    builder.addTextBody("objectId", cmisDocument.getFolderId(), ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[0]", "cmis:name", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[0]", cmisDocument.getFileName(), ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyId[1]", "cmis:objectTypeId", ContentType.TEXT_PLAIN);
+    builder.addTextBody("propertyValue[1]", "cmis:document", ContentType.TEXT_PLAIN);
+    builder.addTextBody("succinct", "true", ContentType.TEXT_PLAIN);
+    HttpEntity entity = builder.build();
+    HttpPost request = new HttpPost(sdmUrl);
+    request.setEntity(entity);
+
+    Map<String, String> finalResMap = new HashMap<>();
+    executeHttpPost(httpClient, request, cmisDocument, finalResMap);
+
+    return new JSONObject(finalResMap);
+  }
+
+  private JSONObject uploadLargeFileInChunks(
+      CmisDocument cmisDocument, String sdmUrl, int chunkSize, String jwtToken) throws IOException {
+
+    try (ReadAheadInputStream chunkedStream =
+        new ReadAheadInputStream(cmisDocument.getContent(), cmisDocument.getContentLength())) {
+      if (chunkedStream == null) {
+        throw new IOException("File stream is null!");
       }
-      return EntityUtils.toString(response.getEntity());
+
+      // Step 1: Initial Request (Without Content) and Get `objectId`. It is required to
+      // set in every chunk appendContent
+      JSONObject responseBody = createEmptyDocument(cmisDocument, sdmUrl, jwtToken);
+      logger.info("Response Body: {}", responseBody);
+
+      String objectId = responseBody.getString("objectId");
+      cmisDocument.setObjectId(objectId);
+      logger.info("objectId of empty doc is {}", objectId);
+
+      // Step 2: Upload Chunks Sequentially
+      int chunkIndex = 0;
+      byte[] chunkBuffer = new byte[chunkSize];
+      int bytesRead;
+      boolean hasMoreChunks = true;
+      while (hasMoreChunks) {
+        long startChunkUploadTime = System.currentTimeMillis();
+
+        // Step 3: Read next chunk
+        bytesRead = chunkedStream.read(chunkBuffer, 0, chunkSize);
+        logger.info("bytesRead is {}", bytesRead);
+        // Step 4: Fetch remaining bytes before checking EOF
+        long remainingBytes = chunkedStream.getRemainingBytes();
+        logger.info("remainingBytes is {}", remainingBytes);
+
+        // Step 5: Check if it's the last chunk
+        boolean isLastChunk = bytesRead < chunkSize || chunkedStream.isEOFReached();
+
+        // Step 6: If no bytes were read AND queue still has data, fetch from queue
+        if (bytesRead == -1 && !chunkedStream.isChunkQueueEmpty()) {
+          logger.info("Premature exit detected. Fetching last chunk from queue...");
+          byte[] lastChunk = chunkedStream.getLastChunkFromQueue();
+          bytesRead = lastChunk.length;
+          System.arraycopy(lastChunk, 0, chunkBuffer, 0, bytesRead);
+          isLastChunk = true; // It has to be the last chunk
+        }
+
+        // Log every chunk details
+        logger.info(
+            "Chunk {} | BytesRead: {} | RemainingBytes: {} | isLastChunk? {}",
+            chunkIndex,
+            bytesRead,
+            remainingBytes,
+            isLastChunk);
+
+        // Step 7: Append Chunk. Call cmis api to append content stream
+        if (bytesRead > 0) {
+          appendContentStream(
+              cmisDocument, sdmUrl, chunkBuffer, bytesRead, isLastChunk, chunkIndex, jwtToken);
+        }
+
+        long endChunkUploadTime = System.currentTimeMillis();
+        logger.info(
+            "Chunk {} having {} bytes is read and it took {} seconds",
+            chunkIndex,
+            bytesRead,
+            ((int) (endChunkUploadTime - startChunkUploadTime) / 1000));
+
+        chunkIndex++;
+
+        if (isLastChunk) {
+          hasMoreChunks = false;
+        }
+      }
+      return responseBody;
+    } catch (Exception e) {
+      logger.error("Exception in uploadLargeFileInChunks: {}", e.getMessage());
+      throw new IOException(
+          "Error uploading document in chunks. Make sure you are in stable network during the large file upload");
     }
   }
 
-  private Single<JSONObject> uploadSingleChunk(
-      CmisDocument cmisDocument, Map<String, String> headers, String sdmUrl) {
-
-    return Single.defer(
-        () -> {
-          try {
-            //  Initialize ReadAheadInputStream
-            InputStream originalStream = cmisDocument.getContent();
-            if (originalStream == null) {
-              return Single.error(new IOException(" File stream is null!"));
-            }
-
-            //  Prepare Multipart Request
-            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-            builder.addTextBody("cmisaction", "createDocument");
-            builder.addTextBody("objectId", cmisDocument.getFolderId());
-            builder.addTextBody("propertyId[0]", "cmis:name");
-            builder.addTextBody("propertyValue[0]", cmisDocument.getFileName());
-            builder.addTextBody("propertyId[1]", "cmis:objectTypeId");
-            builder.addTextBody("propertyValue[1]", "cmis:document");
-            builder.addTextBody("succinct", "true");
-            // Add media part with file metadata
-
-            builder.addBinaryBody(
-                "filename",
-                cmisDocument.getContent(),
-                ContentType.create(cmisDocument.getMimeType()),
-                cmisDocument.getFileName());
-            HttpEntity entity = builder.build();
-
-            HttpPost request = new HttpPost(sdmUrl);
-            request.setEntity(entity);
-            headers.forEach(request::addHeader);
-            return Single.fromCallable(
-                    () -> {
-                      try (CloseableHttpResponse response =
-                          performRequestWithRetry(sdmUrl, request)) {
-                        String responseBody = EntityUtils.toString(response.getEntity());
-                        logger.debug(" Upload Response: " + responseBody);
-
-                        Map<String, String> finalResMap = new HashMap<>();
-                        formResponse(cmisDocument, finalResMap, responseBody);
-
-                        return new JSONObject(finalResMap);
-                      }
-                    })
-                .toFlowable()
-                .retryWhen(RetryUtils.retryLogic(3))
-                .singleOrError();
-          } catch (Exception e) {
-            return Single.error(
-                new IOException(" Error uploading small document: " + e.getMessage(), e));
-          }
-        });
-  }
-
-  private Single<JSONObject> uploadLargeFileInChunks(
-      CmisDocument cmisDocument, Map<String, String> headers, String sdmUrl, int chunkSize) {
-
-    return Single.defer(
-        () -> {
-          ReadAheadInputStream chunkedStream = null;
-          try {
-            InputStream originalStream = cmisDocument.getContent();
-            if (originalStream == null) {
-              return Single.error(new IOException("File stream is null!"));
-            }
-
-            chunkedStream =
-                new ReadAheadInputStream(originalStream, cmisDocument.getContentLength());
-
-            // Step 1: Initial Request (Without Content) and Get `objectId`. It is required to
-            // set in every chunk appendContent
-            String responseBody = createEmptyDocument(cmisDocument, headers, sdmUrl);
-            logger.debug("Response Body: " + responseBody);
-
-            String objectId =
-                (new JSONObject(responseBody))
-                    .getJSONObject("succinctProperties")
-                    .getString("cmis:objectId");
-            cmisDocument.setObjectId(objectId);
-            logger.info("objectId of empty doc is " + objectId);
-
-            // Step 2: Upload Chunks Sequentially
-            int chunkIndex = 0;
-            byte[] chunkBuffer = new byte[chunkSize];
-            int bytesRead;
-            boolean hasMoreChunks = true;
-            while (hasMoreChunks) {
-              long startChunkUploadTime = System.currentTimeMillis();
-
-              // Step 3: Read next chunk
-              bytesRead = chunkedStream.read(chunkBuffer, 0, chunkSize);
-              logger.debug("bytesRead is " + bytesRead);
-              // Step 4: Fetch remaining bytes before checking EOF
-              long remainingBytes = chunkedStream.getRemainingBytes();
-              logger.debug("remainingBytes is " + remainingBytes);
-
-              // Step 5: Check if it's the last chunk
-              boolean isLastChunk = bytesRead < chunkSize || chunkedStream.isEOFReached();
-
-              // Step 6: If no bytes were read AND queue still has data, fetch from queue
-              if (bytesRead == -1 && !chunkedStream.isChunkQueueEmpty()) {
-                logger.info("Premature exit detected. Fetching last chunk from queue...");
-                byte[] lastChunk = chunkedStream.getLastChunkFromQueue();
-                bytesRead = lastChunk.length;
-                System.arraycopy(lastChunk, 0, chunkBuffer, 0, bytesRead);
-                isLastChunk = true; // It has to be the last chunk
-              }
-
-              // Log every chunk details
-              logger.info(
-                  "Chunk "
-                      + chunkIndex
-                      + " | BytesRead: "
-                      + bytesRead
-                      + " | RemainingBytes: "
-                      + remainingBytes
-                      + " | isLastChunk? "
-                      + isLastChunk);
-
-              // Step 7: Append Chunk. Call cmis api to append content stream
-              if (bytesRead > 0) {
-                appendContentStream(
-                    cmisDocument, headers, sdmUrl, chunkBuffer, bytesRead, isLastChunk, chunkIndex);
-              }
-
-              long endChunkUploadTime = System.currentTimeMillis();
-              logger.debug(
-                  " Chunk "
-                      + chunkIndex
-                      + " having "
-                      + bytesRead
-                      + " bytes is read and it took "
-                      + ((int) (endChunkUploadTime - startChunkUploadTime) / 1000)
-                      + " seconds");
-
-              chunkIndex++;
-
-              if (isLastChunk) {
-                // Just for debug purpose log the heap consumption details.
-                logger.info("Heap Memory Usage during the Upload when chunkIndex is " + chunkIndex);
-                printMemoryConsumption();
-                hasMoreChunks = false;
-              }
-            }
-            // Step 8: Finally use the custom formResponse to return
-            Map<String, String> finalResMap = new HashMap<>();
-            this.formResponse(cmisDocument, finalResMap, responseBody);
-            return Single.just(new JSONObject(finalResMap));
-          } catch (Exception e) {
-            logger.error("Exception in uploadLargeFileInChunks: " + e.getMessage());
-            return Single.error(
-                new IOException("Error uploading document in chunks: " + e.getMessage(), e));
-          } finally {
-            if (chunkedStream != null) {
-              try {
-                chunkedStream.close();
-              } catch (IOException e) {
-                logger.error(
-                    "Error closing chunkedStream: \n" + Arrays.toString(e.getStackTrace()));
-              }
-            }
-          }
-        });
-  }
-
   private void formResponse(
-      CmisDocument cmisDocument, Map<String, String> finalResponse, String responseBody) {
-    logger.info("Entering formResponse method");
+      CmisDocument cmisDocument,
+      Map<String, String> finalResponse,
+      CloseableHttpResponse response) {
     String status = "success";
     String name = cmisDocument.getFileName();
     String id = cmisDocument.getAttachmentId();
     String objectId = "";
     String error = "";
-
     try {
-      logger.debug("Parsing responseBody: " + responseBody);
-      JSONObject jsonResponse = new JSONObject(responseBody);
-      if (jsonResponse.has("succinctProperties")) {
+      String responseString = EntityUtils.toString(response.getEntity());
+      JSONObject jsonResponse = new JSONObject(responseString);
+      int responseCode = response.getStatusLine().getStatusCode();
+      if (responseCode == 201 || responseCode == 200) {
         JSONObject succinctProperties = jsonResponse.getJSONObject("succinctProperties");
+        status = "success";
         objectId = succinctProperties.getString("cmis:objectId");
-      } else if (jsonResponse.has("properties")
-          && jsonResponse.getJSONObject("properties").has("cmis:objectId")) {
-        objectId =
-            jsonResponse
-                .getJSONObject("properties")
-                .getJSONObject("cmis:objectId")
-                .getString("value");
       } else {
-        String message = jsonResponse.optString("message", "Unknown error");
-        status = "fail";
-        error = message;
+        String message = jsonResponse.getString("message");
+        if (responseCode == 409
+            && "Malware Service Exception: Virus found in the file!".equals(message)) {
+          status = "virus";
+        } else if (responseCode == 409) {
+          status = "duplicate";
+        } else {
+          status = "fail";
+          error = message;
+        }
       }
-
+      // Construct the final response
       finalResponse.put("name", name);
       finalResponse.put("id", id);
       finalResponse.put("status", status);
@@ -394,28 +309,8 @@ public class DocumentUploadService {
       if (!objectId.isEmpty()) {
         finalResponse.put("objectId", objectId);
       }
-    } catch (Exception e) {
-      logger.error("Exception in formResponse: " + e.getMessage());
+    } catch (IOException e) {
       throw new ServiceException(SDMConstants.getGenericError("upload"));
     }
-  }
-
-  // Helper method to convert bytes to megabytes
-  private static long bytesToMegabytes(long bytes) {
-    return bytes / (1024 * 1024);
-  }
-
-  /*
-   * Utility method to log the memory usage details
-   */
-  private void printMemoryConsumption() {
-    MemoryUsage heapMemoryUsage = this.memoryMXBean.getHeapMemoryUsage();
-    // Print the heap memory usage details
-    logger.info(
-        "Init: {} MB, \t\t|Used: {} MB \t\t|Committed: {} MB  \t\t|Max: {} MB",
-        bytesToMegabytes(heapMemoryUsage.getInit()),
-        bytesToMegabytes(heapMemoryUsage.getUsed()),
-        bytesToMegabytes(heapMemoryUsage.getCommitted()),
-        bytesToMegabytes(heapMemoryUsage.getMax()));
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
@@ -114,6 +114,10 @@ public class ReadAheadInputStream extends InputStream {
                 .toList()
                 .blockingGet();
 
+        if (results == null || results.isEmpty())
+          throw new IOException("Failed to read chunk: results is null or empty");
+        // Check if the read was successful
+
         int readAttempt = results.get(0);
 
         if (readAttempt == -1) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -53,10 +53,11 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
   @On(event = AttachmentService.EVENT_CREATE_ATTACHMENT)
   public void createAttachment(AttachmentCreateEventContext context) throws IOException {
     logger.info(
-        "CREATE_ATTACHMENT Event Received with content length "
-            + context.getParameterInfo().getHeaders().get("content-length")
-            + " At "
-            + System.currentTimeMillis());
+        "CREATE_ATTACHMENT Event Received with content length {} At {}",
+        (context.getParameterInfo() != null && context.getParameterInfo().getHeaders() != null)
+            ? context.getParameterInfo().getHeaders().get("content-length")
+            : null,
+        System.currentTimeMillis());
     validateRepository(context);
     processEntities(context);
   }
@@ -244,16 +245,16 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
     SDMCredentials sdmCredentials = TokenHandler.getSDMCredentials();
     JSONObject createResult = null;
     try {
-      createResult = sdmService.createDocument(cmisDocument, sdmCredentials, jwtToken);
-      logger.info("Synchronous Response from documentServiceRx: " + createResult.toString());
-      logger.info("Upload Finished at: " + System.currentTimeMillis());
+      createResult = documentService.createDocument(cmisDocument, sdmCredentials, jwtToken);
+      logger.info("Synchronous Response from documentService: {}", createResult);
+      logger.info("Upload Finished at: {}", System.currentTimeMillis());
     } catch (Exception e) {
-      logger.error("Error in documentServiceRx: \n" + Arrays.toString(e.getStackTrace()));
+      logger.error("Error in documentService: \n{}", Arrays.toString(e.getStackTrace()));
       throw new ServiceException(
           SDMConstants.getGenericError(AttachmentService.EVENT_CREATE_ATTACHMENT), e);
     }
-    logger.info("Synchronous Response from documentServiceRx: " + createResult.toString());
-    logger.info("Upload Finished at: " + System.currentTimeMillis());
+    logger.info("Synchronous Response from documentService: {}", createResult);
+    logger.info("Upload Finished at: {}", System.currentTimeMillis());
     handleCreateDocumentResult(cmisDocument, createResult, eventContext);
   }
 

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -237,332 +237,325 @@ public class SDMAttachmentsServiceHandlerTest {
     }
   }
 
-  // @Test
-  // public void testCreateNonVersionedDIDuplicate() throws IOException {
-  //   // Initialize mocks and setup
-  //   Map<String, Object> mockAttachmentIds = new HashMap<>();
-  //   mockAttachmentIds.put("up__ID", "upid");
-  //   mockAttachmentIds.put("ID", "id");
-  //   mockAttachmentIds.put("repositoryId", "repo1");
+  @Test
+  public void testCreateNonVersionedDIDuplicate() throws IOException {
+    // Initialize mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
 
-  //   Result mockResult = mock(Result.class);
-  //   Row mockRow = mock(Row.class);
-  //   List<Row> nonEmptyRowList = List.of(mockRow);
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
 
-  //   MediaData mockMediaData = mock(MediaData.class);
-  //   CdsEntity mockDraftEntity = mock(CdsEntity.class);
-  //   CdsModel mockModel = mock(CdsModel.class);
-  //   CdsElement mockAssociationElement = mock(CdsElement.class);
-  //   CdsAssociationType mockAssocType = mock(CdsAssociationType.class);
-  //   CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    MediaData mockMediaData = mock(MediaData.class);
+    CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsModel mockModel = mock(CdsModel.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssocType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
 
-  //   JSONObject mockCreateResult = new JSONObject();
-  //   mockCreateResult.put("status", "duplicate");
-  //   mockCreateResult.put("name", "sample.pdf");
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "duplicate");
+    mockCreateResult.put("name", "sample.pdf");
 
-  //   ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
-  //   Map<String, String> mockHeaders = new HashMap<>();
-  //   mockHeaders.put("content-length", "12345");
+    ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
+    Map<String, String> mockHeaders = new HashMap<>();
+    mockHeaders.put("content-length", "12345");
 
-  //   when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
-  //   when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
+    when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
+    when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
 
-  //   // Mock return values and method calls
-  //   when(mockContext.getModel()).thenReturn(mockModel);
-  //   when(mockModel.findEntity(anyString())).thenReturn(Optional.of(mockDraftEntity));
-  //   when(mockDraftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
-  //   when(mockAssociationElement.getType()).thenReturn(mockAssocType);
-  //   when(mockAssocType.refs()).thenReturn(Stream.of(mockCqnElementRef));
-  //   when(mockCqnElementRef.path()).thenReturn("ID");
-  //   when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
-  //   when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
-  //   when(mockContext.getData()).thenReturn(mockMediaData);
-  //   when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
-  //   when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
-  //   when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
-  //   when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
-  //   JSONObject mockResponse = new JSONObject();
-  //   mockResponse.put("status", "duplicate");
+    // Mock return values and method calls
+    when(mockContext.getModel()).thenReturn(mockModel);
+    when(mockModel.findEntity(anyString())).thenReturn(Optional.of(mockDraftEntity));
+    when(mockDraftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssocType);
+    when(mockAssocType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    JSONObject mockResponse = new JSONObject();
+    mockResponse.put("status", "duplicate");
 
-  //   // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
-  //   when(documentUploadService.createDocumentRx(any(), any(), any()))
-  //       .thenReturn(Single.just(mockResponse));
-  //   when(mockResult.list()).thenReturn(nonEmptyRowList);
-  //   doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
-  //   when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
+    when(documentUploadService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
 
-  //   // Mock DBQuery and TokenHandler
-  //   try (MockedStatic<DBQuery> DBQueryMockedStatic = mockStatic(DBQuery.class);
-  //       MockedStatic<TokenHandler> tokenHandlerMockedStatic = mockStatic(TokenHandler.class);
-  //       MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
-  //     sdmUtilsMockedStatic
-  //         .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
-  //         .thenReturn("0__null");
-  //     DBQueryMockedStatic.when(
-  //             () ->
-  //                 DBQuery.getAttachmentsForUPID(
-  //                     mockDraftEntity, persistenceService, "upid", "up__ID"))
-  //         .thenReturn(mockResult);
+    // Mock DBQuery and TokenHandler
+    try (MockedStatic<DBQuery> DBQueryMockedStatic = mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic = mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      DBQueryMockedStatic.when(
+              () ->
+                  DBQuery.getAttachmentsForUPID(
+                      mockDraftEntity, persistenceService, "upid", "up__ID"))
+          .thenReturn(mockResult);
 
-  //     SDMCredentials mockSdmCredentials = mock(SDMCredentials.class);
+      SDMCredentials mockSdmCredentials = mock(SDMCredentials.class);
 
-  //
-  // tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
 
-  //     // Mock SDMUtils.isRestrictedCharactersInName
-  //     sdmUtilsMockedStatic
-  //         .when(() -> SDMUtils.isRestrictedCharactersInName(anyString()))
-  //         .thenReturn(false); // Return false to indicate no restricted characters
+      // Mock SDMUtils.isRestrictedCharactersInName
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.isRestrictedCharactersInName(anyString()))
+          .thenReturn(false); // Return false to indicate no restricted characters
 
-  //     when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
-  //     when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
-  //     // Validate ServiceException for duplicate detection
-  //     ServiceException thrown =
-  //         assertThrows(
-  //             ServiceException.class,
-  //             () -> {
-  //               handlerSpy.createAttachment(mockContext);
-  //             });
+      when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+      when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+      // Validate ServiceException for duplicate detection
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
 
-  //     assertEquals(SDMConstants.getDuplicateFilesError("sample.pdf"), thrown.getMessage());
-  //   }
-  // }
+      assertEquals(SDMConstants.getDuplicateFilesError("sample.pdf"), thrown.getMessage());
+    }
+  }
 
-  // @Test
-  // public void testCreateNonVersionedDIVirus() throws IOException {
-  //   // Initialize mocks and setup
-  //   Map<String, Object> mockAttachmentIds = new HashMap<>();
-  //   mockAttachmentIds.put("up__ID", "upid");
-  //   mockAttachmentIds.put("ID", "id");
-  //   mockAttachmentIds.put("repositoryId", "repo1");
-  //   Result mockResult = mock(Result.class);
-  //   Row mockRow = mock(Row.class);
-  //   List<Row> nonEmptyRowList = List.of(mockRow);
-  //   MediaData mockMediaData = mock(MediaData.class);
-  //   CdsEntity mockEntity = mock(CdsEntity.class);
-  //   CdsEntity mockDraftEntity = mock(CdsEntity.class);
-  //   CdsElement mockAssociationElement = mock(CdsElement.class);
-  //   CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
-  //   CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
-  //   byte[] byteArray = "Example content".getBytes();
-  //   InputStream contentStream = new ByteArrayInputStream(byteArray);
-  //   JSONObject mockCreateResult = new JSONObject();
-  //   mockCreateResult.put("status", "virus");
-  //   mockCreateResult.put("name", "sample.pdf");
+  @Test
+  public void testCreateNonVersionedDIVirus() throws IOException {
+    // Initialize mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
+    MediaData mockMediaData = mock(MediaData.class);
+    CdsEntity mockEntity = mock(CdsEntity.class);
+    CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    byte[] byteArray = "Example content".getBytes();
+    InputStream contentStream = new ByteArrayInputStream(byteArray);
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "virus");
+    mockCreateResult.put("name", "sample.pdf");
 
-  //   when(mockMediaData.getFileName()).thenReturn("sample.pdf");
-  //   when(mockMediaData.getContent()).thenReturn(contentStream);
-  //   when(mockContext.getModel()).thenReturn(cdsModel);
-  //   when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
-  //   when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
-  //   when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
-  //   when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
-  //   when(mockCqnElementRef.path()).thenReturn("ID");
-  //   when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
-  //   when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
-  //   when(mockResult.list()).thenReturn(nonEmptyRowList);
-  //   when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
-  //   when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
-  //   when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
-  //   when(mockContext.getData()).thenReturn(mockMediaData);
-  //   doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
-  //   when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
-  //   JSONObject mockResponse = new JSONObject();
-  //   mockResponse.put("status", "virus");
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    when(mockMediaData.getContent()).thenReturn(contentStream);
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    JSONObject mockResponse = new JSONObject();
+    mockResponse.put("status", "virus");
 
-  //   // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
-  //   when(documentUploadService.createDocumentRx(any(), any(), any()))
-  //       .thenReturn(Single.just(mockResponse));
-  //   ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
-  //   Map<String, String> mockHeaders = new HashMap<>();
-  //   mockHeaders.put("content-length", "12345");
+    // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
+    when(documentUploadService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+    ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
+    Map<String, String> mockHeaders = new HashMap<>();
+    mockHeaders.put("content-length", "12345");
 
-  //   when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
-  //   when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
+    when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
+    when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
 
-  //   try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
-  //       MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-  //           Mockito.mockStatic(TokenHandler.class);
-  //       MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
-  //     sdmUtilsMockedStatic
-  //         .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
-  //         .thenReturn("0__null");
-  //     dbQueryMockedStatic
-  //         .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
-  //         .thenReturn(mockResult);
-  //     SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      dbQueryMockedStatic
+          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .thenReturn(mockResult);
+      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
 
-  //
-  // tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
-  //     when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
-  //     when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+      when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+      when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
 
-  //     // Use assertThrows to expect a ServiceException and validate the message
-  //     ServiceException thrown =
-  //         assertThrows(
-  //             ServiceException.class,
-  //             () -> {
-  //               handlerSpy.createAttachment(mockContext);
-  //             });
+      // Use assertThrows to expect a ServiceException and validate the message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
 
-  //     // Verify the exception message
-  //     assertEquals(SDMConstants.getVirusFilesError("sample.pdf"), thrown.getMessage());
-  //   }
-  // }
+      // Verify the exception message
+      assertEquals(SDMConstants.getVirusFilesError("sample.pdf"), thrown.getMessage());
+    }
+  }
 
-  // @Test
-  // public void testCreateNonVersionedDIOther() throws IOException {
-  //   // Initialization of mocks and setup
-  //   Map<String, Object> mockAttachmentIds = new HashMap<>();
-  //   mockAttachmentIds.put("up__ID", "upid");
-  //   mockAttachmentIds.put("ID", "id");
-  //   mockAttachmentIds.put("repositoryId", "repo1");
-  //   MediaData mockMediaData = mock(MediaData.class);
-  //   Result mockResult = mock(Result.class);
-  //   Row mockRow = mock(Row.class);
-  //   List<Row> nonEmptyRowList = List.of(mockRow);
-  //   CdsEntity mockEntity = mock(CdsEntity.class);
-  //   // CdsEntity mockDraftEntity = mock(CdsEntity.class);
-  //   CdsElement mockAssociationElement = mock(CdsElement.class);
-  //   CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
-  //   CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
-  //   byte[] byteArray = "Example content".getBytes();
-  //   InputStream contentStream = new ByteArrayInputStream(byteArray);
-  //   JSONObject mockCreateResult = new JSONObject();
-  //   mockCreateResult.put("status", "fail");
-  //   mockCreateResult.put("message", "Failed due to a DI error");
-  //   ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
-  //   Map<String, String> mockHeaders = new HashMap<>();
-  //   mockHeaders.put("content-length", "12345");
+  @Test
+  public void testCreateNonVersionedDIOther() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
+    CdsEntity mockEntity = mock(CdsEntity.class);
+    // CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    byte[] byteArray = "Example content".getBytes();
+    InputStream contentStream = new ByteArrayInputStream(byteArray);
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "fail");
+    mockCreateResult.put("message", "Failed due to a DI error");
+    ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
+    Map<String, String> mockHeaders = new HashMap<>();
+    mockHeaders.put("content-length", "12345");
 
-  //   when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
-  //   when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
+    when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
+    when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
 
-  //   when(mockMediaData.getFileName()).thenReturn("sample.pdf");
-  //   when(mockMediaData.getContent()).thenReturn(contentStream);
-  //   when(mockContext.getModel()).thenReturn(cdsModel);
-  //   when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
-  //   when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
-  //   when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
-  //   when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
-  //   when(mockCqnElementRef.path()).thenReturn("ID");
-  //   when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
-  //   when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
-  //   when(mockResult.list()).thenReturn(nonEmptyRowList);
-  //   when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
-  //   when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
-  //   when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
-  //   when(mockContext.getData()).thenReturn(mockMediaData);
-  //   doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
-  //   when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
-  //   JSONObject mockResponse = new JSONObject();
-  //   mockResponse.put("status", "fail");
-  //   mockResponse.put("message", "Failed due to a DI error");
-  //   // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
-  //   when(documentUploadService.createDocumentRx(any(), any(), any()))
-  //       .thenReturn(Single.just(mockResponse));
-  //   try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
-  //       MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-  //           Mockito.mockStatic(TokenHandler.class);
-  //       MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
-  //     sdmUtilsMockedStatic
-  //         .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
-  //         .thenReturn("0__null");
-  //     dbQueryMockedStatic
-  //         .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
-  //         .thenReturn(mockResult);
-  //     SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    when(mockMediaData.getContent()).thenReturn(contentStream);
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    JSONObject mockResponse = new JSONObject();
+    mockResponse.put("status", "fail");
+    mockResponse.put("message", "Failed due to a DI error");
+    // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
+    when(documentUploadService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      dbQueryMockedStatic
+          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .thenReturn(mockResult);
+      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
 
-  //
-  // tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
-  //     when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
-  //     when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+      when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+      when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
 
-  //     // Use assertThrows to expect a ServiceException and validate the message
-  //     ServiceException thrown =
-  //         assertThrows(
-  //             ServiceException.class,
-  //             () -> {
-  //               handlerSpy.createAttachment(mockContext);
-  //             });
+      // Use assertThrows to expect a ServiceException and validate the message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
 
-  //     // Verify the exception message
-  //     assertEquals("Failed due to a DI error", thrown.getMessage());
-  //   }
-  // }
+      // Verify the exception message
+      assertEquals("Failed due to a DI error", thrown.getMessage());
+    }
+  }
 
-  // @Test
-  // public void testCreateNonVersionedDISuccess() throws IOException {
-  //   // Initialization of mocks and setup
-  //   Map<String, Object> mockAttachmentIds = new HashMap<>();
-  //   mockAttachmentIds.put("up__ID", "upid");
-  //   mockAttachmentIds.put("ID", "id");
-  //   mockAttachmentIds.put("repositoryId", "repo1");
-  //   MediaData mockMediaData = mock(MediaData.class);
-  //   Result mockResult = mock(Result.class);
-  //   Row mockRow = mock(Row.class);
-  //   List<Row> nonEmptyRowList = List.of(mockRow);
-  //   CdsEntity mockEntity = mock(CdsEntity.class);
-  //   CdsEntity mockDraftEntity = mock(CdsEntity.class);
-  //   CdsElement mockAssociationElement = mock(CdsElement.class);
-  //   CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
-  //   CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
-  //   byte[] byteArray = "Example content".getBytes();
-  //   InputStream contentStream = new ByteArrayInputStream(byteArray);
-  //   JSONObject mockCreateResult = new JSONObject();
-  //   mockCreateResult.put("status", "success");
-  //   mockCreateResult.put("url", "url");
-  //   mockCreateResult.put("name", "sample.pdf");
-  //   mockCreateResult.put("objectId", "objectId");
+  @Test
+  public void testCreateNonVersionedDISuccess() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    Row mockRow = mock(Row.class);
+    List<Row> nonEmptyRowList = List.of(mockRow);
+    CdsEntity mockEntity = mock(CdsEntity.class);
+    CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+    byte[] byteArray = "Example content".getBytes();
+    InputStream contentStream = new ByteArrayInputStream(byteArray);
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "success");
+    mockCreateResult.put("url", "url");
+    mockCreateResult.put("name", "sample.pdf");
+    mockCreateResult.put("objectId", "objectId");
 
-  //   when(mockMediaData.getFileName()).thenReturn("sample.pdf");
-  //   when(mockMediaData.getContent()).thenReturn(contentStream);
-  //   when(mockContext.getModel()).thenReturn(cdsModel);
-  //   when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
-  //   when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
-  //   when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
-  //   when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
-  //   when(mockCqnElementRef.path()).thenReturn("ID");
-  //   when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
-  //   when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
-  //   when(mockResult.list()).thenReturn(nonEmptyRowList);
-  //   when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
-  //   when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
-  //   when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
-  //   when(mockContext.getData()).thenReturn(mockMediaData);
-  //   doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
-  //   when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
-  //   JSONObject mockResponse = new JSONObject();
-  //   mockResponse.put("status", "success");
-  //   mockResponse.put("objectId", "123");
-  //   // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
-  //   when(documentUploadService.createDocumentRx(any(), any(), any()))
-  //       .thenReturn(Single.just(mockResponse));
-  //   ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
-  //   Map<String, String> mockHeaders = new HashMap<>();
-  //   mockHeaders.put("content-length", "12345");
+    when(mockMediaData.getFileName()).thenReturn("sample.pdf");
+    when(mockMediaData.getContent()).thenReturn(contentStream);
+    when(mockContext.getModel()).thenReturn(cdsModel);
+    when(cdsModel.findEntity(anyString())).thenReturn(Optional.of(mockEntity));
+    when(mockEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(mockContext.getAuthenticationInfo()).thenReturn(mockAuthInfo);
+    when(mockAuthInfo.as(JwtTokenAuthenticationInfo.class)).thenReturn(mockJwtTokenInfo);
+    when(mockJwtTokenInfo.getToken()).thenReturn("mockedJwtToken");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(sdmService.getFolderId(any(), any(), any(), any())).thenReturn("folderid");
+    JSONObject mockResponse = new JSONObject();
+    mockResponse.put("status", "success");
+    mockResponse.put("objectId", "123");
+    // Mock the behavior of createDocumentRx to return the mock response wrapped in a Single
+    when(documentUploadService.createDocument(any(), any(), any())).thenReturn(mockCreateResult);
+    ParameterInfo mockParameterInfo = mock(ParameterInfo.class);
+    Map<String, String> mockHeaders = new HashMap<>();
+    mockHeaders.put("content-length", "12345");
 
-  //   when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
-  //   when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
-  //   try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
-  //       MockedStatic<TokenHandler> tokenHandlerMockedStatic =
-  //           Mockito.mockStatic(TokenHandler.class);
-  //       MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
-  //     sdmUtilsMockedStatic
-  //         .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
-  //         .thenReturn("0__null");
-  //     dbQueryMockedStatic
-  //         .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
-  //         .thenReturn(mockResult);
-  //     SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
-  //     when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
-  //     when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
-  //
-  // tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
-  //     handlerSpy.createAttachment(mockContext);
-  //     verifyNoInteractions(mockMessages);
-  //   }
-  // }
+    when(mockContext.getParameterInfo()).thenReturn(mockParameterInfo); // Mock getParameterInfo
+    when(mockParameterInfo.getHeaders()).thenReturn(mockHeaders); // Mock getHeaders
+    try (MockedStatic<DBQuery> dbQueryMockedStatic = Mockito.mockStatic(DBQuery.class);
+        MockedStatic<TokenHandler> tokenHandlerMockedStatic =
+            Mockito.mockStatic(TokenHandler.class);
+        MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class); ) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("0__null");
+      dbQueryMockedStatic
+          .when(() -> DBQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+          .thenReturn(mockResult);
+      SDMCredentials mockSdmCredentials = Mockito.mock(SDMCredentials.class);
+      when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+      when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+
+      tokenHandlerMockedStatic.when(TokenHandler::getSDMCredentials).thenReturn(mockSdmCredentials);
+      handlerSpy.createAttachment(mockContext);
+      verifyNoInteractions(mockMessages);
+    }
+  }
 
   // @Test
   public void testCreateNonVersionedNoUpAssociation() throws IOException {


### PR DESCRIPTION
## Describe your changes
This PR fixes multi-tenant upload and large file upload. Earlier we were initialising httpClient in Constructor. And so, same instance of httpClient was being used for both the tenants, resulting in failure in creating attachment with second tenant. In this PR we are now using cloud-sdk library's httpClient.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Large Files upload
<img width="781" alt="Screenshot 2025-05-27 at 7 04 26 AM" src="https://github.com/user-attachments/assets/36231eb3-f23e-4876-88ca-4651df7c903d" />

SingleChunk tenant1
<img width="1321" alt="Screenshot 2025-05-27 at 7 15 15 AM" src="https://github.com/user-attachments/assets/2872cf54-82b6-4afc-baf8-83a87af3c9b1" />

SingleChunk tenant2
<img width="1321" alt="Screenshot 2025-05-27 at 7 15 27 AM" src="https://github.com/user-attachments/assets/8f29cd08-95a5-47b8-8e01-976889157cf8" />

Integration tests
<img width="945" alt="Screenshot 2025-05-27 at 7 43 08 AM" src="https://github.com/user-attachments/assets/4e8d322f-493e-4f16-80c9-5a225d21bcd4" />

