### PR TITLE
Update CAP Java version in plugin to 3.10.3 and fix for deployment issue if leading application is using cap java 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.4.2-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.4.2-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <excluded.generation.package>sdm/generated/</excluded.generation.package>
-        <cds.services.version>3.5.0</cds.services.version>
+        <cds.services.version>3.10.3</cds.services.version>
 
         <generation-folder>src/gen</generation-folder>
 

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -320,10 +320,6 @@
                     <artifactId>resilience4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.sap.cloud.security</groupId>
-                    <artifactId>env</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>


### PR DESCRIPTION
## Describe your changes
In this PR we update the CAP Java version to 3.10.3(LTS) in SDM plugin. Also, if leading application is using latest major version 4, then deployment was failing for the application because we had excluded a library in pom. So, removed this exclusion from pom.xml.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Version update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [N/A] I have  provided sufficient automated/ unit tests for the code.
- [N/A] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="1034" height="102" alt="Screenshot 2025-07-24 at 6 53 54 PM" src="https://github.com/user-attachments/assets/d95094e2-5bae-4b27-81f2-5a9100b6f104" />
<img width="1034" height="102" alt="Screenshot 2025-07-24 at 7 00 18 PM" src="https://github.com/user-attachments/assets/5b27695b-6149-4f85-a32b-2748f36bc6f0" />

https://github.com/cap-java/sdm/actions/runs/16535530258/job/46769153539
