### PR TITLE
dependabot security fix for Release 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <generation-folder>src/gen</generation-folder>
 
         <test-spring-boot-version>3.2.5</test-spring-boot-version>
-        <sdk-bom-version>5.15.0</sdk-bom-version>
+        <sdk-bom-version>5.21.0</sdk-bom-version>
         <mockito-bom-version>5.15.2</mockito-bom-version>
         <assertj-core-version>3.27.3</assertj-core-version>
         <mockito-core-version>5.15.2</mockito-core-version>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -308,12 +308,19 @@
                 <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
                 <artifactId>connectivity-oauth</artifactId>
             </exclusion>
+            <exclusion>
+                <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+                <artifactId>cloudplatform-core</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+            <artifactId>cloudplatform-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
             <artifactId>connectivity-oauth</artifactId>
-            <version>5.17.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sap.cloud.sdk.cloudplatform</groupId>


### PR DESCRIPTION
## Describe your changes
In this PR we are updating connectivity-oauth version to 5.21.0 as 5.17.0 has commons-lang3 version 3.17.0 which has security vulnerability. I have also excluded commons-lang3 in connectivity-oauth & commons-codec and added the commons-lang3 library as direct dependency as it is being used in our project.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Security Fix in transitive library

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="1005" height="275" alt="Screenshot 2025-08-12 at 1 04 41 PM" src="https://github.com/user-attachments/assets/23b7cc8f-3fa7-4d2b-b607-fac3bea411aa" />
<img width="1005" height="275" alt="Screenshot 2025-08-12 at 1 15 06 PM" src="https://github.com/user-attachments/assets/6644ab24-111c-42dd-a755-aa6c61650111" />


