### PR TITLE
fixed mime type validation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.5.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.0.0-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.5.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -46,7 +46,7 @@ public class SDMConstants {
   public static final String USER_NOT_AUTHORISED_ERROR =
       "You do not have the required permissions to upload attachments. Please contact your administrator for access.";
   public static final String MIMETYPE_INVALID_ERROR =
-      "MIME type of the uploaded file is blocked according to your repository configuration.";
+      "MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.";
   public static final String USER_NOT_AUTHORISED_ERROR_LINK =
       "You do not have the required permissions to create links. Please contact your administrator for access.";
   public static final String FILE_NOT_FOUND_ERROR = "Object not found in repository";

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -45,6 +45,8 @@ public class SDMConstants {
   public static final String SDM_CONNECTIONPOOL_PREFIX = "cds.attachments.sdm.http.%s";
   public static final String USER_NOT_AUTHORISED_ERROR =
       "You do not have the required permissions to upload attachments. Please contact your administrator for access.";
+  public static final String MIMETYPE_INVALID_ERROR =
+      "MIME type of the uploaded file is blocked according to your repository configuration.";
   public static final String USER_NOT_AUTHORISED_ERROR_LINK =
       "You do not have the required permissions to create links. Please contact your administrator for access.";
   public static final String FILE_NOT_FOUND_ERROR = "Object not found in repository";

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -46,7 +46,7 @@ public class SDMConstants {
   public static final String USER_NOT_AUTHORISED_ERROR =
       "You do not have the required permissions to upload attachments. Please contact your administrator for access.";
   public static final String MIMETYPE_INVALID_ERROR =
-      "MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.";
+      "This file type is not allowed in this repository. Contact your administrator for assistance.";
   public static final String USER_NOT_AUTHORISED_ERROR_LINK =
       "You do not have the required permissions to create links. Please contact your administrator for access.";
   public static final String FILE_NOT_FOUND_ERROR = "Object not found in repository";

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -312,8 +312,6 @@ public class DocumentUploadService {
         if (responseCode == 409) {
           JSONObject jsonResponse = new JSONObject(responseString);
           String message = jsonResponse.getString("message");
-          JSONObject succinctProperties = jsonResponse.getJSONObject("succinctProperties");
-          objectId = succinctProperties.getString("cmis:objectId");
           if ("Malware Service Exception: Virus found in the file!".equals(message)) {
             status = "virus";
           } else {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -316,7 +316,8 @@ public class DocumentUploadService {
         } else if (responseCode == 409) {
           status = "duplicate";
         } else if (responseCode == 403
-            && "MIME type of the uploaded file is blocked according to your repository configuration.".equals(message)) {
+            && "MIME type of the uploaded file is blocked according to your repository configuration."
+                .equals(message)) {
           status = "blocked";
         } else if (responseCode == 403) {
           status = "unauthorized";

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -320,10 +320,11 @@ public class DocumentUploadService {
         } else if ((responseCode == 403)
             && (responseString.equals("User does not have required scope"))) {
           status = "unauthorized";
-        } else if ((responseCode == 403)
-            && (responseString.equals(
-                "MIME type of the uploaded file is blocked according to your repository configuration."))) {
-          status = "blocked";
+        } else if (responseCode == 403) {
+          JSONObject jsonResponse = new JSONObject(responseString);
+          String message = jsonResponse.getString("message");
+          if ("MIME type of the uploaded file is blocked according to your repository configuration."
+              .equals(message)) status = "blocked";
         } else {
           JSONObject jsonResponse = new JSONObject(responseString);
           String message = jsonResponse.getString("message");

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -315,6 +315,9 @@ public class DocumentUploadService {
           status = "virus";
         } else if (responseCode == 409) {
           status = "duplicate";
+        } else if (responseCode == 403
+            && "MIME type of the uploaded file is blocked according to your repository configuration.".equals(message)) {
+          status = "blocked";
         } else if (responseCode == 403) {
           status = "unauthorized";
         } else {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -321,9 +321,10 @@ public class DocumentUploadService {
             && (responseString.equals("User does not have required scope"))) {
           status = "unauthorized";
         } else if ((responseCode == 403)
-            && (responseString.equals("MIME type of the uploaded file is blocked according to your repository configuration."))) {
+            && (responseString.equals(
+                "MIME type of the uploaded file is blocked according to your repository configuration."))) {
           status = "blocked";
-        }else {
+        } else {
           JSONObject jsonResponse = new JSONObject(responseString);
           String message = jsonResponse.getString("message");
           status = "fail";

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -292,6 +292,8 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       case "fail":
         throw new ServiceException(createResult.get("message").toString());
       case "unauthorized":
+        throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
+      case "blocked":
         throw new ServiceException(SDMConstants.MIMETYPE_INVALID_ERROR);
       default:
         cmisDocument.setObjectId(createResult.get("objectId").toString());

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -292,7 +292,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       case "fail":
         throw new ServiceException(createResult.get("message").toString());
       case "unauthorized":
-        throw new ServiceException(SDMConstants.USER_NOT_AUTHORISED_ERROR);
+        throw new ServiceException(SDMConstants.MIMETYPE_INVALID_ERROR);
       default:
         cmisDocument.setObjectId(createResult.get("objectId").toString());
         dbQuery.addAttachmentToDraft(

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -848,7 +848,7 @@ class IntegrationTest_MultipleFacet {
 
   @Test
   @Order(17)
-  void testUploadBlockedMimeTypeZIP() throws IOException {
+  void testUploadBlockedMimeType() throws IOException {
     System.out.println("Test (17) : Upload blocked mimeType .rtf");
     Boolean testStatus = false;
 
@@ -873,7 +873,7 @@ class IntegrationTest_MultipleFacet {
 
         String actualResponse = createResponse.get(0);
         String expectedJson =
-            "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.\"}}";
+            "{\"error\":{\"code\":\"500\",\"message\":\"This file type is not allowed in this repository. Contact your administrator for assistance.\"}}";
 
         if (!expectedJson.equals(actualResponse)) {
           allBlocked = false;

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -845,8 +845,56 @@ class IntegrationTest_MultipleFacet {
 
   @Test
   @Order(17)
+  void testUploadBlockedMimeTypeZIP_MultiFacet() throws IOException {
+    System.out.println(
+        "Test (17): Upload blocked mimeType .rtf for attachment, reference, and footnote");
+    Boolean testStatus = false;
+
+    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (!"Could not create entity".equals(response)) {
+      entityID2 = response;
+
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(Objects.requireNonNull(classLoader.getResource("sample.rtf")).getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", entityID2);
+      postData.put("mimeType", "application/rtf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      boolean allBlocked = true;
+      for (int i = 0; i < facet.length; i++) {
+        List<String> createResponse =
+            api.createAttachment(appUrl, entityName, facet[i], entityID2, srvpath, postData, file);
+
+        String actualResponse = createResponse.get(0);
+        String expectedJson =
+            "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration.\"}}";
+
+        if (!expectedJson.equals(actualResponse)) {
+          allBlocked = false;
+          System.out.println(
+              "Facet " + facet[i] + " incorrectly accepted blocked mimeType: " + actualResponse);
+        }
+      }
+
+      response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID2);
+      if ("Saved".equals(response) && allBlocked) {
+        testStatus = true;
+      }
+    }
+
+    if (!testStatus) {
+      fail("One or more facets accepted blocked .rtf MIME type");
+    }
+  }
+
+  @Test
+  @Order(18)
   void testDeleteEntity() {
-    System.out.println("Test (17) : Delete entity");
+    System.out.println("Test (18) : Delete entity");
     Boolean testStatus = false;
     String response = api.deleteEntity(appUrl, entityName, entityID);
     String response2 = api.deleteEntity(appUrl, entityName, entityID2);
@@ -855,9 +903,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(18)
+  @Order(19)
   void testUpdateValidSecondaryProperty_beforeEntityIsSaved_single() throws IOException {
-    System.out.println("Test (18) : Rename & Update secondary property before entity is saved");
+    System.out.println("Test (19) : Rename & Update secondary property before entity is saved");
     System.out.println("Creating entity");
 
     Boolean testStatus = false;
@@ -954,9 +1002,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(19)
+  @Order(20)
   void testUpdateValidSecondaryProperty_afterEntityIsSaved_single() {
-    System.out.println("Test (19): Rename & Update secondary property after entity is saved");
+    System.out.println("Test (20): Rename & Update secondary property after entity is saved");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
     System.out.println("Editing entity");
@@ -1022,10 +1070,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(20)
+  @Order(21)
   void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_single() throws IOException {
     System.out.println(
-        "Test (20): Rename & Update invalid secondary property before entity is saved");
+        "Test (21): Rename & Update invalid secondary property before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -1141,10 +1189,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(21)
+  @Order(22)
   void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_single() throws IOException {
     System.out.println(
-        "Test (21): Rename & Update invalid secondary property after entity is saved");
+        "Test (22): Rename & Update invalid secondary property after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
 
@@ -1249,11 +1297,11 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(22)
+  @Order(23)
   void testUpdateValidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (22): Rename & Update valid secondary properties for multiple facets before entity is saved");
+        "Test (23): Rename & Update valid secondary properties for multiple facets before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -1422,10 +1470,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(23)
+  @Order(24)
   void testUpdateValidSecondaryProperty_afterEntityIsSaved_multipleAttachments() {
     System.out.println(
-        "Test (23): Rename & Update  valid secondary properties for multiple facets after entity is saved");
+        "Test (24): Rename & Update  valid secondary properties for multiple facets after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1562,11 +1610,11 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(24)
+  @Order(25)
   void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (24): Rename & Update invalid and valid secondary properties for multiple facets before entity is saved");
+        "Test (25): Rename & Update invalid and valid secondary properties for multiple facets before entity is saved");
     System.out.println("Creating entity");
 
     Boolean testStatus = false;
@@ -1792,11 +1840,11 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(25)
+  @Order(26)
   void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (25): Rename & Update invalid and valid secondary properties for multiple attachments after entity is saved");
+        "Test (26): Rename & Update invalid and valid secondary properties for multiple attachments after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1996,10 +2044,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(26)
+  @Order(27)
   void testNAttachments_NewEntity() throws IOException {
     System.out.println(
-        "Test (26): Creating new entity and checking only max 4 attachments are allowed to be uploaded");
+        "Test (27): Creating new entity and checking only max 4 attachments are allowed to be uploaded");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2113,9 +2161,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(27)
+  @Order(28)
   void testUploadNAttachments() throws IOException {
-    System.out.println("Test (27): Upload maximum 4 attachments in an exsisting entity");
+    System.out.println("Test (28): Upload maximum 4 attachments in an exsisting entity");
 
     ClassLoader classLoader = getClass().getClassLoader();
     File originalFile = new File(classLoader.getResource("sample.exe").getFile());
@@ -2172,9 +2220,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(28)
+  @Order(29)
   void testDiscardDraftWithoutAttachments() {
-    System.out.println("Test (28) : Discard draft without adding attachments");
+    System.out.println("Test (29) : Discard draft without adding attachments");
     Boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2191,9 +2239,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(29)
+  @Order(30)
   void testDiscardDraftWithAttachments() throws IOException {
-    System.out.println("Test (29): Discard draft with attachments, references, and footnotes");
+    System.out.println("Test (30): Discard draft with attachments, references, and footnotes");
     boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2228,9 +2276,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(30)
+  @Order(31)
   void testDraftUpdateUploadTwoDeleteOneAndCreate() throws IOException {
-    System.out.println("Test (30): Upload to all facets, delete one, and create entity");
+    System.out.println("Test (31): Upload to all facets, delete one, and create entity");
 
     boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2298,9 +2346,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(31)
+  @Order(32)
   void testUpdateEntityDraft() throws IOException {
-    System.out.println("Test (31): Update entity draft with new facet content");
+    System.out.println("Test (32): Update entity draft with new facet content");
     boolean testStatus = false;
 
     ClassLoader classLoader = getClass().getClassLoader();
@@ -2343,9 +2391,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(32)
+  @Order(33)
   void testUploadAttachmentWithoutSDMRole() throws IOException {
-    System.out.println("Test (32): Upload attachment across facets without SDM role");
+    System.out.println("Test (33): Upload attachment across facets without SDM role");
     boolean testStatus = true;
 
     String response = apiNoRoles.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2383,9 +2431,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(33)
+  @Order(34)
   void testCopyAttachmentsSuccessNewEntity() throws IOException {
-    System.out.println("Test (33): Copy attachments from one entity to another new entity");
+    System.out.println("Test (34): Copy attachments from one entity to another new entity");
     List<List<String>> attachments = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       attachments.add(new ArrayList<>());
@@ -2507,10 +2555,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(34)
+  @Order(35)
   void testCopyAttachmentsUnsuccessfulNewEntity() throws IOException {
     System.out.println(
-        "Test (34): Copy incorrect attachments from one entity to another new entity");
+        "Test (35): Copy incorrect attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     copyAttachmentTargetEntityEmpty =
@@ -2554,9 +2602,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(35)
+  @Order(36)
   void testCopyAttachmentsSuccessExistingEntity() throws IOException {
-    System.out.println("Test (35): Copy attachments from one entity to another existing entity");
+    System.out.println("Test (36): Copy attachments from one entity to another existing entity");
     List<List<String>> attachments = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       attachments.add(new ArrayList<>());
@@ -2690,9 +2738,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(36)
+  @Order(37)
   void testCopyAttachmentsUnsuccessfulExistingEntity() throws IOException {
-    System.out.println("Test (36): Copy attachments from one entity to another new entity");
+    System.out.println("Test (37): Copy attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     String editResponse2 =

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -849,8 +849,7 @@ class IntegrationTest_MultipleFacet {
   @Test
   @Order(17)
   void testRenameSingleAttachmentWithoutSDMRole() throws IOException {
-    System.out.println(
-        "Test (17) : Rename attachments where user don't have SDM Roles");
+    System.out.println("Test (17) : Rename attachments where user don't have SDM Roles");
     Boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -848,9 +848,9 @@ class IntegrationTest_MultipleFacet {
 
   @Test
   @Order(17)
-  void testUploadBlockedMimeTypeZIP_MultiFacet() throws IOException {
+  void testRenameSingleAttachmentWithoutSDMRole() throws IOException {
     System.out.println(
-        "Test (17): Upload blocked mimeType .rtf for attachment, reference, and footnote");
+        "Test (17) : Rename attachments where user don't have SDM Roles");
     Boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2780,9 +2780,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(37)
+  @Order(38)
   void testCreateLinkSuccess() throws IOException {
-    System.out.println("Test (37): Create link in entity");
+    System.out.println("Test (38): Create link in entity");
     List<String> attachments = new ArrayList<>();
 
     createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2826,9 +2826,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(38)
+  @Order(39)
   void testCreateLinkDifferentEntity() throws IOException {
-    System.out.println("Test (38): Create link with same name in different entity");
+    System.out.println("Test (39): Create link with same name in different entity");
 
     String createLinkDifferentEntity =
         api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2859,9 +2859,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(39)
+  @Order(40)
   void testCreateLinkFailure() throws IOException {
-    System.out.println("Test (39): Create link fails due to invalid URL and name");
+    System.out.println("Test (40): Create link fails due to invalid URL and name");
     String editEntityResponse = api.editEntityDraft(appUrl, entityName, srvpath, createLinkEntity);
     if (editEntityResponse.equals("Could not edit entity")) {
       fail("Could not edit entity");
@@ -2970,9 +2970,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(40)
+  @Order(41)
   void testCreateLinkNoSDMRoles() throws IOException {
-    System.out.println("Test (40): Create link fails due to no SDM roles assigned");
+    System.out.println("Test (41): Create link fails due to no SDM roles assigned");
 
     String createLinkEntityNoSDMRoles =
         apiNoRoles.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -3014,9 +3014,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(41)
+  @Order(42)
   void testDeleteLink() throws IOException {
-    System.out.println("Test (41): Delete link in entity");
+    System.out.println("Test (42): Delete link in entity");
     List<List<String>> attachments = new ArrayList<>();
 
     String createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -3092,9 +3092,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(42)
+  @Order(43)
   void testRenameLinkSuccess() throws IOException {
-    System.out.println("Test (42): Rename link in entity");
+    System.out.println("Test (43): Rename link in entity");
     List<List<String>> attachments = new ArrayList<>();
 
     createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -3154,9 +3154,9 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(43)
+  @Order(44)
   void testRenameLinkDuplicate() throws IOException {
-    System.out.println("Test (43): Rename link in entity fails due to duplicate error");
+    System.out.println("Test (44): Rename link in entity fails due to duplicate error");
     List<String> attachments = new ArrayList<>();
 
     String editEntityResponse = api.editEntityDraft(appUrl, entityName, srvpath, createLinkEntity);
@@ -3224,10 +3224,10 @@ class IntegrationTest_MultipleFacet {
   }
 
   @Test
-  @Order(44)
+  @Order(45)
   void testRenameLinkUnsupportedCharacters() throws IOException {
     System.out.println(
-        "Test (44): Rename link in entity fails due to unsupported characters in name");
+        "Test (45): Rename link in entity fails due to unsupported characters in name");
     List<List<String>> attachments = new ArrayList<>();
 
     createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -889,7 +889,7 @@ class IntegrationTest_MultipleFacet {
     }
 
     if (!testStatus) {
-      fail("One or more facets accepted blocked .rtf MIME type");
+      fail("Attachment got uploaded with blocked .rtf MIME type");
     }
   }
 

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -848,8 +848,8 @@ class IntegrationTest_MultipleFacet {
 
   @Test
   @Order(17)
-  void testRenameSingleAttachmentWithoutSDMRole() throws IOException {
-    System.out.println("Test (17) : Rename attachments where user don't have SDM Roles");
+  void testUploadBlockedMimeTypeZIP() throws IOException {
+    System.out.println("Test (17) : Upload blocked mimeType .rtf");
     Boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -873,7 +873,7 @@ class IntegrationTest_MultipleFacet {
 
         String actualResponse = createResponse.get(0);
         String expectedJson =
-            "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration.\"}}";
+            "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.\"}}";
 
         if (!expectedJson.equals(actualResponse)) {
           allBlocked = false;

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -2208,7 +2208,7 @@ class IntegrationTest_SingleFacet {
       if (check.equals("Attachment created")) {
         response = api.deleteEntityDraft(appUrl, entityName, entityID7);
       }
-      if (response.equals("Entity Deleted")) {
+      if (response.equals("Entity Draft Deleted")) {
         testStatus = true;
       }
     }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -762,7 +762,7 @@ class IntegrationTest_SingleFacet {
   @Test
   @Order(17)
   void testRenameSingleAttachmentWithoutSDMRole() throws IOException {
-    System.out.println("Test (17) : Rename attachments where user don't have SDM-Roles");
+    System.out.println("Test (17) : Rename attachments where user don't have SDM Roles");
     boolean testStatus = false;
     String apiResponse = apiNoRoles.editEntityDraft(appUrl, entityName, srvpath, entityID);
     String name = "sample123";
@@ -2167,7 +2167,7 @@ class IntegrationTest_SingleFacet {
   @Test
   @Order(32)
   void testDiscardDraftWithoutAttachments() {
-    System.out.println("Test (31) : Discard draft without adding attachments");
+    System.out.println("Test (32) : Discard draft without adding attachments");
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
 
@@ -2182,9 +2182,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(32)
+  @Order(33)
   void testDiscardDraftWithAttachments() throws IOException {
-    System.out.println("Test (32) : Discard draft with attachments");
+    System.out.println("Test (33) : Discard draft with attachments");
     boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!response.equals("Could not create entity")) {
@@ -2218,9 +2218,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(33)
+  @Order(34)
   void testCopyAttachmentsSuccessNewEntity() throws IOException {
-    System.out.println("Test (33): Copy attachments from one entity to another new entity");
+    System.out.println("Test (34): Copy attachments from one entity to another new entity");
     List<String> attachments = new ArrayList<>();
     copyAttachmentSourceEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     copyAttachmentTargetEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2313,9 +2313,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(34)
+  @Order(35)
   void testCopyAttachmentsUnsuccessfulNewEntity() throws IOException {
-    System.out.println("Test (34): Copy attachments from one entity to another new entity");
+    System.out.println("Test (35): Copy attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     copyAttachmentTargetEntityEmpty =
@@ -2350,9 +2350,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(35)
+  @Order(36)
   void testCopyAttachmentsSuccessExistingEntity() throws IOException {
-    System.out.println("Test (35): Copy attachments from one entity to another existing entity");
+    System.out.println("Test (36): Copy attachments from one entity to another existing entity");
     List<String> attachments = new ArrayList<>();
     ClassLoader classLoader = getClass().getClassLoader();
     List<File> files = new ArrayList<>();
@@ -2458,9 +2458,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(36)
+  @Order(37)
   void testCopyAttachmentsUnsuccessfulExistingEntity() throws IOException {
-    System.out.println("Test (36): Copy attachments from one entity to another new entity");
+    System.out.println("Test (37): Copy attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     String editResponse2 =
@@ -2488,9 +2488,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(37)
+  @Order(38)
   void testCreateLinkSuccess() throws IOException {
-    System.out.println("Test (37): Create link in entity");
+    System.out.println("Test (38): Create link in entity");
     List<String> attachments = new ArrayList<>();
     createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!createLinkEntity.equals("Could not create entity")) {
@@ -2531,9 +2531,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(38)
+  @Order(39)
   void testCreateLinkDifferentEntity() throws IOException {
-    System.out.println("Test (38): Create link with same name in different entity");
+    System.out.println("Test (39): Create link with same name in different entity");
     String createLinkDifferentEntity =
         api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!createLinkDifferentEntity.equals("Could not edit entity")) {
@@ -2559,9 +2559,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(39)
+  @Order(40)
   void testCreateLinkFailure() throws IOException {
-    System.out.println("Test (39): Create link fails due to invalid URL and name");
+    System.out.println("Test (40): Create link fails due to invalid URL and name");
     String editEntityResponse = api.editEntityDraft(appUrl, entityName, srvpath, createLinkEntity);
     if (!editEntityResponse.equals("Could not edit entity")) {
       String linkName = "sample";
@@ -2659,9 +2659,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(40)
+  @Order(41)
   void testCreateLinkNoSDMRoles() throws IOException {
-    System.out.println("Test (40): Create link fails due to no SDM roles assigned");
+    System.out.println("Test (41): Create link fails due to no SDM roles assigned");
     String createLinkEntityNoSDMRoles =
         apiNoRoles.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!createLinkEntityNoSDMRoles.equals("Could not edit entity")) {
@@ -2698,9 +2698,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(41)
+  @Order(42)
   void testDeleteLink() throws IOException {
-    System.out.println("Test (41): Delete link in entity");
+    System.out.println("Test (42): Delete link in entity");
     List<String> attachments = new ArrayList<>();
     String createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!createLinkEntity.equals("Could not create entity")) {
@@ -2757,9 +2757,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(42)
+  @Order(43)
   void testRenameLinkSuccess() throws IOException {
-    System.out.println("Test (42): Rename link in entity");
+    System.out.println("Test (43): Rename link in entity");
     List<String> attachments = new ArrayList<>();
 
     createLinkEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2804,9 +2804,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(43)
+  @Order(44)
   void testRenameLinkDuplicate() throws IOException {
-    System.out.println("Test (43): Rename link in entity fails due to duplicate error");
+    System.out.println("Test (44): Rename link in entity fails due to duplicate error");
     List<String> attachments = new ArrayList<>();
 
     String editEntityResponse = api.editEntityDraft(appUrl, entityName, srvpath, createLinkEntity);
@@ -2856,10 +2856,10 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(44)
+  @Order(45)
   void testRenameLinkUnsupportedCharacters() throws IOException {
     System.out.println(
-        "Test (44): Rename link in entity fails due to unsupported characters in name");
+        "Test (45): Rename link in entity fails due to unsupported characters in name");
     List<String> attachments = new ArrayList<>();
 
     String editEntityResponse = api.editEntityDraft(appUrl, entityName, srvpath, createLinkEntity);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -867,7 +867,7 @@ class IntegrationTest_SingleFacet {
           api.createAttachment(appUrl, entityName, facetName, entityID2, srvpath, postData, file);
       String actualResponse = createResponse.get(0);
       String expectedJson =
-          "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration.\"}}";
+          "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.\"}}";
 
       if (expectedJson.equals(actualResponse)) {
         response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID2);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -846,7 +846,7 @@ class IntegrationTest_SingleFacet {
 
   @Test
   @Order(20)
-  void testUploadBlockedMimeTypeZIP() throws IOException {
+  void testUploadBlockedMimeType() throws IOException {
     System.out.println("Test (20): Upload blocked mimeType .rtf");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -867,7 +867,7 @@ class IntegrationTest_SingleFacet {
           api.createAttachment(appUrl, entityName, facetName, entityID2, srvpath, postData, file);
       String actualResponse = createResponse.get(0);
       String expectedJson =
-          "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration. Please contact your administrator for access.\"}}";
+          "{\"error\":{\"code\":\"500\",\"message\":\"This file type is not allowed in this repository. Contact your administrator for assistance.\"}}";
 
       if (expectedJson.equals(actualResponse)) {
         response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID2);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -842,8 +842,47 @@ class IntegrationTest_SingleFacet {
 
   @Test
   @Order(20)
+  void testUploadBlockedMimeTypeZIP() throws IOException {
+    System.out.println("Test (20): Upload blocked mimeType .rtf");
+    Boolean testStatus = false;
+    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (!"Could not create entity".equals(response)) {
+      entityID2 = response;
+
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(Objects.requireNonNull(classLoader.getResource("sample.rtf")).getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", entityID2);
+      postData.put("mimeType", "application/rtf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse =
+          api.createAttachment(appUrl, entityName, facetName, entityID2, srvpath, postData, file);
+      String actualResponse = createResponse.get(0);
+      String expectedJson =
+          "{\"error\":{\"code\":\"500\",\"message\":\"MIME type of the uploaded file is blocked according to your repository configuration.\"}}";
+
+      if (expectedJson.equals(actualResponse)) {
+        response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID2);
+        if ("Saved".equals(response)) {
+          testStatus = true;
+        }
+      } else {
+        api.saveEntityDraft(appUrl, entityName, srvpath, entityID2);
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment got uploaded with blocked .rtf MIME type");
+    }
+  }
+
+  @Test
+  @Order(21)
   void testDeleteEntity() {
-    System.out.println("Test (20) : Delete entity");
+    System.out.println("Test (21) : Delete entity");
     Boolean testStatus = false;
     String response = api.deleteEntity(appUrl, entityName, entityID);
     String response2 = api.deleteEntity(appUrl, entityName, entityID2);
@@ -856,9 +895,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(21)
+  @Order(22)
   void testUpdateValidSecondaryProperty_beforeEntityIsSaved_singleAttachment() throws IOException {
-    System.out.println("Test (21): Rename & Update secondary property before entity is saved");
+    System.out.println("Test (22): Rename & Update secondary property before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -943,9 +982,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(22)
+  @Order(23)
   void testUpdateValidSecondaryProperty_afterEntityIsSaved_singleAttachment() {
-    System.out.println("Test (22): Rename & Update secondary property after entity is saved");
+    System.out.println("Test (23): Rename & Update secondary property after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1014,11 +1053,11 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(23)
+  @Order(24)
   void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_singleAttachment()
       throws IOException {
     System.out.println(
-        "Test (23): Rename & Update invalid secondary property before entity is saved");
+        "Test (24): Rename & Update invalid secondary property before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -1143,10 +1182,10 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(24)
+  @Order(25)
   void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_singleAttachment() throws IOException {
     System.out.println(
-        "Test (24): Rename & Update invalid secondary property after entity is saved");
+        "Test (25): Rename & Update invalid secondary property after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1241,11 +1280,11 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(25)
+  @Order(26)
   void testUpdateValidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (25): Rename & Update valid secondary properties for multiple attachments before entity is saved");
+        "Test (26): Rename & Update valid secondary properties for multiple attachments before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -1429,10 +1468,10 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(26)
+  @Order(27)
   void testUpdateValidSecondaryProperty_afterEntityIsSaved_multipleAttachments() {
     System.out.println(
-        "Test (26): Rename & Update  valid secondary properties for multiple attachments after entity is saved");
+        "Test (27): Rename & Update  valid secondary properties for multiple attachments after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1561,11 +1600,11 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(27)
+  @Order(28)
   void testUpdateInvalidSecondaryProperty_beforeEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (27): Rename & Update invalid and valid secondary properties for multiple attachments before entity is saved");
+        "Test (28): Rename & Update invalid and valid secondary properties for multiple attachments before entity is saved");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -1782,11 +1821,11 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(28)
+  @Order(29)
   void testUpdateInvalidSecondaryProperty_afterEntityIsSaved_multipleAttachments()
       throws IOException {
     System.out.println(
-        "Test (28): Rename & Update invalid and valid secondary properties for multiple attachments after entity is saved");
+        "Test (29): Rename & Update invalid and valid secondary properties for multiple attachments after entity is saved");
     System.out.println("Editing entity");
     Boolean testStatus = false;
     String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID3);
@@ -1946,10 +1985,10 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(29)
+  @Order(30)
   void testNAttachments_NewEntity() throws IOException {
     System.out.println(
-        "Test (29): Creating new entity and checking only max 4 attachments are allowed to be uploaded");
+        "Test (30): Creating new entity and checking only max 4 attachments are allowed to be uploaded");
     System.out.println("Creating entity");
     Boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2063,9 +2102,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(30)
+  @Order(31)
   void testUploadNAttachments() throws IOException {
-    System.out.println("Test (30): Upload maximum 4 attachments in an exsisting entity");
+    System.out.println("Test (31): Upload maximum 4 attachments in an exsisting entity");
 
     ClassLoader classLoader = getClass().getClassLoader();
     File originalFile = new File(classLoader.getResource("sample.exe").getFile());
@@ -2122,9 +2161,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(31)
+  @Order(32)
   void testDiscardDraftWithoutAttachments() {
-    System.out.println("Test (31) : Discard draft without adding attachments");
+    System.out.println("Test (32) : Discard draft without adding attachments");
     boolean testStatus = false;
 
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2143,9 +2182,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(32)
+  @Order(33)
   void testDiscardDraftWithAttachments() throws IOException {
-    System.out.println("Test (32) : Discard draft with attachments");
+    System.out.println("Test (33) : Discard draft with attachments");
     boolean testStatus = false;
     String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     if (!response.equals("Could not create entity")) {
@@ -2179,9 +2218,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(33)
+  @Order(34)
   void testCopyAttachmentsSuccessNewEntity() throws IOException {
-    System.out.println("Test (33): Copy attachments from one entity to another new entity");
+    System.out.println("Test (34): Copy attachments from one entity to another new entity");
     List<String> attachments = new ArrayList<>();
     copyAttachmentSourceEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
     copyAttachmentTargetEntity = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
@@ -2274,9 +2313,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(34)
+  @Order(35)
   void testCopyAttachmentsUnsuccessfulNewEntity() throws IOException {
-    System.out.println("Test (34): Copy attachments from one entity to another new entity");
+    System.out.println("Test (35): Copy attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     copyAttachmentTargetEntityEmpty =
@@ -2311,9 +2350,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(35)
+  @Order(36)
   void testCopyAttachmentsSuccessExistingEntity() throws IOException {
-    System.out.println("Test (35): Copy attachments from one entity to another existing entity");
+    System.out.println("Test (36): Copy attachments from one entity to another existing entity");
     List<String> attachments = new ArrayList<>();
     ClassLoader classLoader = getClass().getClassLoader();
     List<File> files = new ArrayList<>();
@@ -2419,9 +2458,9 @@ class IntegrationTest_SingleFacet {
   }
 
   @Test
-  @Order(36)
+  @Order(37)
   void testCopyAttachmentsUnsuccessfulExistingEntity() throws IOException {
-    System.out.println("Test (36): Copy attachments from one entity to another new entity");
+    System.out.println("Test (37): Copy attachments from one entity to another new entity");
     String editResponse1 =
         api.editEntityDraft(appUrl, entityName, srvpath, copyAttachmentSourceEntity);
     String editResponse2 =

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -482,6 +482,134 @@ public class SDMAttachmentsServiceHandlerTest {
   }
 
   @Test
+  public void testCreateNonVersionedDIUnauthorized() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    List<Row> nonEmptyRowList = List.of(mock(Row.class));
+    CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsModel mockModel = mock(CdsModel.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+
+    // Set up the JSON response for the "unauthorized" case
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "unauthorized");
+
+    // Mock method calls
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(mockContext.getModel()).thenReturn(mockModel);
+    when(mockModel.findEntity(anyString())).thenReturn(Optional.of(mockDraftEntity));
+    when(mockDraftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+    when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+    when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+    when(parameterInfo.getHeaders()).thenReturn(headers);
+
+    // Mock the behavior of createDocument and other dependencies
+    when(documentUploadService.createDocument(any(), any(), anyBoolean()))
+        .thenReturn(mockCreateResult);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(dbQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+        .thenReturn(mockResult);
+    when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), anyString(), anyString()))
+        .thenReturn(mockResult);
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(sdmService.getFolderId(any(), any(), any(), anyBoolean())).thenReturn("folderid");
+    when(tokenHandler.getSDMCredentials()).thenReturn(mock(SDMCredentials.class));
+
+    try (MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class)) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("10__null");
+
+      // Assert that a ServiceException is thrown and verify its message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
+      assertEquals(SDMConstants.USER_NOT_AUTHORISED_ERROR, thrown.getMessage());
+    }
+  }
+
+  @Test
+  public void testCreateNonVersionedDIBlocked() throws IOException {
+    // Initialization of mocks and setup
+    Map<String, Object> mockAttachmentIds = new HashMap<>();
+    mockAttachmentIds.put("up__ID", "upid");
+    mockAttachmentIds.put("ID", "id");
+    mockAttachmentIds.put("repositoryId", "repo1");
+
+    MediaData mockMediaData = mock(MediaData.class);
+    Result mockResult = mock(Result.class);
+    List<Row> nonEmptyRowList = List.of(mock(Row.class));
+    CdsEntity mockDraftEntity = mock(CdsEntity.class);
+    CdsModel mockModel = mock(CdsModel.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+
+    // Set up the JSON response for the "blocked" case
+    JSONObject mockCreateResult = new JSONObject();
+    mockCreateResult.put("status", "blocked");
+
+    // Mock method calls
+    when(mockContext.getAttachmentIds()).thenReturn(mockAttachmentIds);
+    when(mockContext.getModel()).thenReturn(mockModel);
+    when(mockModel.findEntity(anyString())).thenReturn(Optional.of(mockDraftEntity));
+    when(mockDraftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+    when(sdmService.checkRepositoryType(anyString(), anyString())).thenReturn("Non Versioned");
+    when(mockContext.getData()).thenReturn(mockMediaData);
+    when(mockContext.getAttachmentEntity()).thenReturn(mockDraftEntity);
+    when(mockDraftEntity.getQualifiedName()).thenReturn("some.qualified.name");
+    when(mockContext.getParameterInfo()).thenReturn(parameterInfo);
+    when(parameterInfo.getHeaders()).thenReturn(headers);
+
+    // Mock the behavior of createDocument and other dependencies
+    when(documentUploadService.createDocument(any(), any(), anyBoolean()))
+        .thenReturn(mockCreateResult);
+    doReturn(false).when(handlerSpy).duplicateCheck(any(), any(), any());
+    when(dbQuery.getAttachmentsForUPID(any(), any(), anyString(), anyString()))
+        .thenReturn(mockResult);
+    when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), anyString(), anyString()))
+        .thenReturn(mockResult);
+    when(mockResult.list()).thenReturn(nonEmptyRowList);
+    when(sdmService.getFolderId(any(), any(), any(), anyBoolean())).thenReturn("folderid");
+    when(tokenHandler.getSDMCredentials()).thenReturn(mock(SDMCredentials.class));
+
+    try (MockedStatic<SDMUtils> sdmUtilsMockedStatic = mockStatic(SDMUtils.class)) {
+      sdmUtilsMockedStatic
+          .when(() -> SDMUtils.getAttachmentCountAndMessage(anyList(), any()))
+          .thenReturn("10__null");
+
+      // Assert that a ServiceException is thrown and verify its message
+      ServiceException thrown =
+          assertThrows(
+              ServiceException.class,
+              () -> {
+                handlerSpy.createAttachment(mockContext);
+              });
+      assertEquals(SDMConstants.MIMETYPE_INVALID_ERROR, thrown.getMessage());
+    }
+  }
+
+  @Test
   public void testCreateNonVersionedDISuccess() throws IOException {
     // Initialization of mocks and setup
     Map<String, Object> mockAttachmentIds = new HashMap<>();

--- a/sdm/src/test/resources/sample.rtf
+++ b/sdm/src/test/resources/sample.rtf
@@ -1,0 +1,8 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2822
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww26320\viewh18980\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Test.rtf file}


### PR DESCRIPTION
## Describe your changes

This update fixes the issue where blocked MIME type uploads were showing a generic “unauthorized” error. Now, when the document service returns a 403 for a blocked MIME type, it is handled as a separate blocked status and shows the correct message: "MIME type of the uploaded file is blocked according to your repository configuration." This makes the error clearer for users while keeping the existing unauthorized flow unchanged.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

upload Attachment when .rtf mime type is blocked

provider account
<img width="753" height="310" alt="Screenshot 2025-09-28 at 9 40 42 PM" src="https://github.com/user-attachments/assets/f6843cfe-2708-456a-b6b2-ddf3411eba71" />

consumer account 1

<img width="961" height="440" alt="Screenshot 2025-09-29 at 9 35 33 AM" src="https://github.com/user-attachments/assets/ca253c89-9202-4c58-992a-8fd36915848a" />

consumer account 2

<img width="930" height="288" alt="Screenshot 2025-09-29 at 9 38 14 AM" src="https://github.com/user-attachments/assets/451bca8a-5306-46d7-a272-483274036272" />

upload attachment when noSDM role is assigned and get **you are not authorized error**

<img width="2056" height="1329" alt="Screenshot 2025-09-02 at 10 25 38 PM" src="https://github.com/user-attachments/assets/c1de954d-af0a-436c-a2c8-9d3de454dbff" />

mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests

<img width="1138" height="157" alt="Screenshot 2025-09-25 at 11 59 05 PM" src="https://github.com/user-attachments/assets/40d0485e-5123-434f-85f7-84e48abe4996" />



mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests

<img width="1468" height="201" alt="Screenshot 2025-09-26 at 12 12 27 AM" src="https://github.com/user-attachments/assets/d013ff63-2f0d-4caa-8677-a3840cfceeed" />


mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=single -DskipUnitTests

<img width="885" height="144" alt="Screenshot 2025-09-26 at 12 22 07 AM" src="https://github.com/user-attachments/assets/80d9d4ff-1185-4dc2-ac8f-f25c88581203" />


mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=single -DskipUnitTests

<img width="1387" height="200" alt="Screenshot 2025-09-26 at 12 30 33 AM" src="https://github.com/user-attachments/assets/6da4ed2f-dc07-4ca7-9b57-fa5b2a949a30" />

mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests

<img width="1158" height="240" alt="Screenshot 2025-09-26 at 1 19 36 AM" src="https://github.com/user-attachments/assets/79db4821-e231-4e61-8fff-17f08ad92e94" />


mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests

<img width="1184" height="181" alt="Screenshot 2025-09-26 at 1 27 52 AM" src="https://github.com/user-attachments/assets/db800401-dbd7-4589-a5b8-a68c933755b3" />







