### PR TITLE
Hide linkURL field from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ annotate my.Books.attachments with @UI: {
 {
   note       @(title: '{i18n>Note}');
   type       @(title: '{i18n>Type}');
-  linkUrl       @(title: '{i18n>LinkURL}');
+  linkUrl       @UI.Hidden;
   fileName  @(title: '{i18n>Filename}');
   modifiedAt @(odata.etag: null);
   content
@@ -836,7 +836,7 @@ annotate my.Books.attachments with @UI: {
 {
   note       @(title: '{i18n>Note}');
   type       @(title: '{i18n>Type}');
-  linkUrl       @(title: '{i18n>LinkURL}');
+  linkUrl       @UI.Hidden;
   fileName  @(title: '{i18n>Filename}');
   modifiedAt @(odata.etag: null);
   content

--- a/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
+++ b/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
@@ -33,6 +33,7 @@ annotate Attachments with @UI: {
     objectId  @UI.Hidden ;
     mimeType @UI.Hidden;
     status @UI.Hidden;
+    linkUrl @UI.Hidden;
 }
 annotate Attachments with @Common: {SideEffects #ContentChanged: {
     SourceProperties: [content],


### PR DESCRIPTION
This PR makes linkURL a mandatorily hidden field

<img width="637" height="604" alt="image" src="https://github.com/user-attachments/assets/14679fbe-5306-4773-aca7-8701baec601d" />
