### PR TITLE
Fixing copyAttachments api for Projection entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.5.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.5.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -85,6 +85,13 @@ public class SDMConstants {
   public static final String FAILED_TO_FETCH_UP_ID = "Failed to fetch up_id";
   public static final String FAILED_TO_FETCH_FACET =
       "Invalid facet format, unable to extract required information.";
+  public static final String PARENT_ENTITY_NOT_FOUND_ERROR = "Unable to find parent entity: %s";
+  public static final String COMPOSITION_NOT_FOUND_ERROR =
+      "Unable to find composition '%s' in entity: %s";
+  public static final String TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR =
+      "Unable to find target attachment entity: %s";
+  public static final String INVALID_FACET_FORMAT_ERROR =
+      "Invalid facet format. Expected: Service.Entity.Composition, got: %s";
 
   public static String nameConstraintMessage(
       List<String> fileNameWithRestrictedCharacters, String operation) {

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentInput.java
@@ -4,14 +4,11 @@ import java.util.List;
 
 /**
  * The class {@link CopyAttachmentInput} is used to store the input for copying attachments. This
- * model supports both regular entities and projection entities by using parent entity and
- * composition navigation patterns.
+ * model supports both regular entities and projection entities by using facet-based navigation.
  *
  * @param upId The key of the parent entity instance
- * @param parentEntity The qualified name of the parent entity that defines the attachments
- *     composition
- * @param compositionName The name of the composition property linking parent to attachment entity
+ * @param facet The full facet path (e.g., "Service.Entity.composition") that will be internally
+ *     parsed to determine parent entity and composition name
  * @param objectIds The list of attachment object IDs to be copied
  */
-public record CopyAttachmentInput(
-    String upId, String parentEntity, String compositionName, List<String> objectIds) {}
+public record CopyAttachmentInput(String upId, String facet, List<String> objectIds) {}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentInput.java
@@ -3,10 +3,15 @@ package com.sap.cds.sdm.model;
 import java.util.List;
 
 /**
- * The class {@link CopyAttachmentInput} is used to store the input for creating an attachment.
+ * The class {@link CopyAttachmentInput} is used to store the input for copying attachments. This
+ * model supports both regular entities and projection entities by using parent entity and
+ * composition navigation patterns.
  *
- * @param upId The keys for the attachment entity
- * @param facet
- * @param objectIds
+ * @param upId The key of the parent entity instance
+ * @param parentEntity The qualified name of the parent entity that defines the attachments
+ *     composition
+ * @param compositionName The name of the composition property linking parent to attachment entity
+ * @param objectIds The list of attachment object IDs to be copied
  */
-public record CopyAttachmentInput(String upId, String facet, List<String> objectIds) {}
+public record CopyAttachmentInput(
+    String upId, String parentEntity, String compositionName, List<String> objectIds) {}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentsRequest.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentsRequest.java
@@ -1,0 +1,110 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
+import java.util.List;
+
+/**
+ * Parameter object for copyAttachmentsToSDM method to reduce parameter count and improve code
+ * maintainability.
+ */
+public class CopyAttachmentsRequest {
+  private final AttachmentCopyEventContext context;
+  private final List<String> objectIds;
+  private final String folderId;
+  private final String repositoryId;
+  private final SDMCredentials sdmCredentials;
+  private final Boolean isSystemUser;
+  private final boolean folderExists;
+
+  private CopyAttachmentsRequest(Builder builder) {
+    this.context = builder.context;
+    this.objectIds = builder.objectIds;
+    this.folderId = builder.folderId;
+    this.repositoryId = builder.repositoryId;
+    this.sdmCredentials = builder.sdmCredentials;
+    this.isSystemUser = builder.isSystemUser;
+    this.folderExists = builder.folderExists;
+  }
+
+  // Getters
+  public AttachmentCopyEventContext getContext() {
+    return context;
+  }
+
+  public List<String> getObjectIds() {
+    return objectIds;
+  }
+
+  public String getFolderId() {
+    return folderId;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public SDMCredentials getSdmCredentials() {
+    return sdmCredentials;
+  }
+
+  public Boolean getIsSystemUser() {
+    return isSystemUser;
+  }
+
+  public boolean isFolderExists() {
+    return folderExists;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private AttachmentCopyEventContext context;
+    private List<String> objectIds;
+    private String folderId;
+    private String repositoryId;
+    private SDMCredentials sdmCredentials;
+    private Boolean isSystemUser;
+    private boolean folderExists;
+
+    public Builder context(AttachmentCopyEventContext context) {
+      this.context = context;
+      return this;
+    }
+
+    public Builder objectIds(List<String> objectIds) {
+      this.objectIds = objectIds;
+      return this;
+    }
+
+    public Builder folderId(String folderId) {
+      this.folderId = folderId;
+      return this;
+    }
+
+    public Builder repositoryId(String repositoryId) {
+      this.repositoryId = repositoryId;
+      return this;
+    }
+
+    public Builder sdmCredentials(SDMCredentials sdmCredentials) {
+      this.sdmCredentials = sdmCredentials;
+      return this;
+    }
+
+    public Builder isSystemUser(Boolean isSystemUser) {
+      this.isSystemUser = isSystemUser;
+      return this;
+    }
+
+    public Builder folderExists(boolean folderExists) {
+      this.folderExists = folderExists;
+      return this;
+    }
+
+    public CopyAttachmentsRequest build() {
+      return new CopyAttachmentsRequest(this);
+    }
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CreateDraftEntriesRequest.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CreateDraftEntriesRequest.java
@@ -1,0 +1,121 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+
+/**
+ * Parameter object for createDraftEntries method to reduce parameter count and improve code
+ * maintainability.
+ */
+public class CreateDraftEntriesRequest {
+  private final List<List<String>> attachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+  private final String parentEntity;
+  private final String compositionName;
+  private final String upID;
+  private final String upIdKey;
+  private final String repositoryId;
+  private final String folderId;
+
+  private CreateDraftEntriesRequest(Builder builder) {
+    this.attachmentsMetadata = builder.attachmentsMetadata;
+    this.populatedDocuments = builder.populatedDocuments;
+    this.parentEntity = builder.parentEntity;
+    this.compositionName = builder.compositionName;
+    this.upID = builder.upID;
+    this.upIdKey = builder.upIdKey;
+    this.repositoryId = builder.repositoryId;
+    this.folderId = builder.folderId;
+  }
+
+  // Getters
+  public List<List<String>> getAttachmentsMetadata() {
+    return attachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+
+  public String getParentEntity() {
+    return parentEntity;
+  }
+
+  public String getCompositionName() {
+    return compositionName;
+  }
+
+  public String getUpID() {
+    return upID;
+  }
+
+  public String getUpIdKey() {
+    return upIdKey;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public String getFolderId() {
+    return folderId;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<List<String>> attachmentsMetadata;
+    private List<CmisDocument> populatedDocuments;
+    private String parentEntity;
+    private String compositionName;
+    private String upID;
+    private String upIdKey;
+    private String repositoryId;
+    private String folderId;
+
+    public Builder attachmentsMetadata(List<List<String>> attachmentsMetadata) {
+      this.attachmentsMetadata = attachmentsMetadata;
+      return this;
+    }
+
+    public Builder populatedDocuments(List<CmisDocument> populatedDocuments) {
+      this.populatedDocuments = populatedDocuments;
+      return this;
+    }
+
+    public Builder parentEntity(String parentEntity) {
+      this.parentEntity = parentEntity;
+      return this;
+    }
+
+    public Builder compositionName(String compositionName) {
+      this.compositionName = compositionName;
+      return this;
+    }
+
+    public Builder upID(String upID) {
+      this.upID = upID;
+      return this;
+    }
+
+    public Builder upIdKey(String upIdKey) {
+      this.upIdKey = upIdKey;
+      return this;
+    }
+
+    public Builder repositoryId(String repositoryId) {
+      this.repositoryId = repositoryId;
+      return this;
+    }
+
+    public Builder folderId(String folderId) {
+      this.folderId = folderId;
+      return this;
+    }
+
+    public CreateDraftEntriesRequest build() {
+      return new CreateDraftEntriesRequest(this);
+    }
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -7,10 +7,14 @@ import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.ql.cqn.CqnUpdate;
+import com.sap.cds.reflect.CdsAssociationType;
+import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
+import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.util.*;
 
@@ -65,13 +69,44 @@ public class DBQuery {
 
   public CmisDocument getAttachmentForObjectID(
       PersistenceService persistenceService, String id, AttachmentCopyEventContext context) {
-    Optional<CdsEntity> attachmentEntity = context.getModel().findEntity(context.getFacet());
+
+    // Use the new API to resolve the target attachment entity
+    String parentEntity = context.getParentEntity();
+    String compositionName = context.getCompositionName();
+    CdsModel model = context.getModel();
+
+    // Find the parent entity
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      throw new ServiceException("Unable to find parent entity: " + parentEntity);
+    }
+
+    // Find the composition element in the parent entity
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(compositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      throw new ServiceException(
+          "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
+    }
+
+    // Get the target entity of the composition
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+
+    // Find the target attachment entity
+    Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    if (attachmentEntity.isEmpty()) {
+      throw new ServiceException("Unable to find target attachment entity: " + targetEntityName);
+    }
+
+    // Search in active entity first
     CqnSelect q =
         Select.from(attachmentEntity.get())
             .columns("linkUrl", "type")
             .where(doc -> doc.get("objectId").eq(id));
     Result result = persistenceService.run(q);
     Optional<Row> res = result.first();
+
     CmisDocument cmisDocument = new CmisDocument();
     if (res.isPresent()) {
       Row row = res.get();
@@ -79,17 +114,19 @@ public class DBQuery {
       cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
     } else {
       // Check in draft table as well
-      attachmentEntity = context.getModel().findEntity(context.getFacet() + "_drafts");
-      q =
-          Select.from(attachmentEntity.get())
-              .columns("linkUrl", "type")
-              .where(doc -> doc.get("objectId").eq(id));
-      result = persistenceService.run(q);
-      res = result.first();
-      if (res.isPresent()) {
-        Row row = res.get();
-        cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
-        cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+      Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+      if (attachmentDraftEntity.isPresent()) {
+        q =
+            Select.from(attachmentDraftEntity.get())
+                .columns("linkUrl", "type")
+                .where(doc -> doc.get("objectId").eq(id));
+        result = persistenceService.run(q);
+        res = result.first();
+        if (res.isPresent()) {
+          Row row = res.get();
+          cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
+          cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+        }
       }
     }
     return cmisDocument;

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -72,41 +72,30 @@ public class DBQuery {
 
     // Use the new API to resolve the target attachment entity
     String parentEntity = context.getParentEntity();
-    System.out.println("Parent Entity: " + parentEntity);
     String compositionName = context.getCompositionName();
-    System.out.println("Composition Name: " + compositionName);
     CdsModel model = context.getModel();
-    System.out.println("model: " + model);
 
     // Find the parent entity
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
-    System.out.println("optionalParentEntity: " + optionalParentEntity);
     if (optionalParentEntity.isEmpty()) {
-      System.out.println("optionalParentEntity is empty");
       throw new ServiceException("Unable to find parent entity: " + parentEntity);
     }
 
     // Find the composition element in the parent entity
     Optional<CdsElement> compositionElement =
         optionalParentEntity.get().findElement(compositionName);
-    System.out.println("compositionElement: " + compositionElement);
     if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
-      System.out.println("compositionElement is empty or not an association");
       throw new ServiceException(
           "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
     }
 
     // Get the target entity of the composition
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
-    System.out.println("assocType: " + assocType);
     String targetEntityName = assocType.getTarget().getQualifiedName();
-    System.out.println("targetEntityName: " + targetEntityName);
 
     // Find the target attachment entity
     Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
-    System.out.println("attachmentEntity: " + attachmentEntity);
     if (attachmentEntity.isEmpty()) {
-      System.out.println("attachmentEntity is empty");
       throw new ServiceException("Unable to find target attachment entity: " + targetEntityName);
     }
 
@@ -116,41 +105,30 @@ public class DBQuery {
             .columns("linkUrl", "type")
             .where(doc -> doc.get("objectId").eq(id));
     Result result = persistenceService.run(q);
-    System.out.println("result: " + result);
     Optional<Row> res = result.first();
-    System.out.println("res: " + res);
 
     CmisDocument cmisDocument = new CmisDocument();
     if (res.isPresent()) {
       Row row = res.get();
-      System.out.println("row: " + row);
       cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
       cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
     } else {
       // Check in draft table as well
-      System.out.println("Inside else");
       Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
-      System.out.println("attachmentDraftEntity: " + attachmentDraftEntity);
       if (attachmentDraftEntity.isPresent()) {
-        System.out.println("attachmentDraftEntity is present");
         q =
             Select.from(attachmentDraftEntity.get())
                 .columns("linkUrl", "type")
                 .where(doc -> doc.get("objectId").eq(id));
         result = persistenceService.run(q);
-        System.out.println("result: " + result);
         res = result.first();
-        System.out.println("res: " + res);
         if (res.isPresent()) {
-          System.out.println("res is present");
           Row row = res.get();
-          System.out.println("row: " + row);
           cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
           cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
         }
       }
     }
-    System.out.println("cmisDocument: " + cmisDocument);
     return cmisDocument;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -78,7 +78,8 @@ public class DBQuery {
     // Find the parent entity
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
     if (optionalParentEntity.isEmpty()) {
-      throw new ServiceException("Unable to find parent entity: " + parentEntity);
+      throw new ServiceException(
+          String.format(SDMConstants.PARENT_ENTITY_NOT_FOUND_ERROR, parentEntity));
     }
 
     // Find the composition element in the parent entity
@@ -86,7 +87,7 @@ public class DBQuery {
         optionalParentEntity.get().findElement(compositionName);
     if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
       throw new ServiceException(
-          "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
+          String.format(SDMConstants.COMPOSITION_NOT_FOUND_ERROR, compositionName, parentEntity));
     }
 
     // Get the target entity of the composition
@@ -96,7 +97,8 @@ public class DBQuery {
     // Find the target attachment entity
     Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
     if (attachmentEntity.isEmpty()) {
-      throw new ServiceException("Unable to find target attachment entity: " + targetEntityName);
+      throw new ServiceException(
+          String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
     }
 
     // Search in active entity first

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -72,30 +72,41 @@ public class DBQuery {
 
     // Use the new API to resolve the target attachment entity
     String parentEntity = context.getParentEntity();
+    System.out.println("Parent Entity: " + parentEntity);
     String compositionName = context.getCompositionName();
+    System.out.println("Composition Name: " + compositionName);
     CdsModel model = context.getModel();
+    System.out.println("model: " + model);
 
     // Find the parent entity
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    System.out.println("optionalParentEntity: " + optionalParentEntity);
     if (optionalParentEntity.isEmpty()) {
+      System.out.println("optionalParentEntity is empty");
       throw new ServiceException("Unable to find parent entity: " + parentEntity);
     }
 
     // Find the composition element in the parent entity
     Optional<CdsElement> compositionElement =
         optionalParentEntity.get().findElement(compositionName);
+    System.out.println("compositionElement: " + compositionElement);
     if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      System.out.println("compositionElement is empty or not an association");
       throw new ServiceException(
           "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
     }
 
     // Get the target entity of the composition
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    System.out.println("assocType: " + assocType);
     String targetEntityName = assocType.getTarget().getQualifiedName();
+    System.out.println("targetEntityName: " + targetEntityName);
 
     // Find the target attachment entity
     Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    System.out.println("attachmentEntity: " + attachmentEntity);
     if (attachmentEntity.isEmpty()) {
+      System.out.println("attachmentEntity is empty");
       throw new ServiceException("Unable to find target attachment entity: " + targetEntityName);
     }
 
@@ -105,30 +116,41 @@ public class DBQuery {
             .columns("linkUrl", "type")
             .where(doc -> doc.get("objectId").eq(id));
     Result result = persistenceService.run(q);
+    System.out.println("result: " + result);
     Optional<Row> res = result.first();
+    System.out.println("res: " + res);
 
     CmisDocument cmisDocument = new CmisDocument();
     if (res.isPresent()) {
       Row row = res.get();
+      System.out.println("row: " + row);
       cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
       cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
     } else {
       // Check in draft table as well
+      System.out.println("Inside else");
       Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+      System.out.println("attachmentDraftEntity: " + attachmentDraftEntity);
       if (attachmentDraftEntity.isPresent()) {
+        System.out.println("attachmentDraftEntity is present");
         q =
             Select.from(attachmentDraftEntity.get())
                 .columns("linkUrl", "type")
                 .where(doc -> doc.get("objectId").eq(id));
         result = persistenceService.run(q);
+        System.out.println("result: " + result);
         res = result.first();
+        System.out.println("res: " + res);
         if (res.isPresent()) {
+          System.out.println("res is present");
           Row row = res.get();
+          System.out.println("row: " + row);
           cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
           cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
         }
       }
     }
+    System.out.println("cmisDocument: " + cmisDocument);
     return cmisDocument;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
@@ -7,5 +7,13 @@ public interface RegisterService extends Service {
   String SDM_NAME = "SDMAttachmentService$Default";
   String EVENT_COPY_ATTACHMENT = "COPY_ATTACHMENT";
 
+  /**
+   * Copies attachments using the new parent entity and composition approach. This method supports
+   * both regular entities and projection entities.
+   *
+   * @param input The copy attachment input containing parent entity, composition name, and object
+   *     IDs
+   * @param isSystemUser Whether to use system user flow
+   */
   public void copyAttachments(CopyAttachmentInput input, boolean isSystemUser);
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
@@ -8,11 +8,11 @@ public interface RegisterService extends Service {
   String EVENT_COPY_ATTACHMENT = "COPY_ATTACHMENT";
 
   /**
-   * Copies attachments using the new parent entity and composition approach. This method supports
-   * both regular entities and projection entities.
+   * Copies attachments using the facet-based approach. This method supports both regular entities
+   * and projection entities by internally parsing the facet to determine parent entity and
+   * composition name.
    *
-   * @param input The copy attachment input containing parent entity, composition name, and object
-   *     IDs
+   * @param input The copy attachment input containing facet and object IDs
    * @param isSystemUser Whether to use system user flow
    */
   public void copyAttachments(CopyAttachmentInput input, boolean isSystemUser);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -10,6 +10,7 @@ import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMa
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentReadEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentRestoreEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.DeletionUserInfo;
+import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CopyAttachmentInput;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
 import com.sap.cds.services.ServiceDelegator;
@@ -40,7 +41,7 @@ public class SDMAttachmentsService extends ServiceDelegator
     String[] facetParts = input.facet().split("\\.");
     if (facetParts.length < 3) {
       throw new IllegalArgumentException(
-          "Invalid facet format. Expected: Service.Entity.Composition, got: " + input.facet());
+          String.format(SDMConstants.INVALID_FACET_FORMAT_ERROR, input.facet()));
     }
 
     String parentEntity = facetParts[0] + "." + facetParts[1]; // Service.Entity

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -30,14 +30,16 @@ public class SDMAttachmentsService extends ServiceDelegator
   @Override
   public void copyAttachments(CopyAttachmentInput input, boolean isSystemUser) {
     logger.info(
-        "Copying attachments for upId: {}, facet: {}, objectIds: {}, isSystemUser: {}",
+        "Copying attachments for upId: {}, parentEntity: {}, compositionName: {}, objectIds: {}, isSystemUser: {}",
         input.upId(),
-        input.facet(),
+        input.parentEntity(),
+        input.compositionName(),
         input.objectIds(),
         isSystemUser);
     var copyContext = AttachmentCopyEventContext.create();
     copyContext.setUpId(input.upId());
-    copyContext.setFacet(input.facet());
+    copyContext.setParentEntity(input.parentEntity());
+    copyContext.setCompositionName(input.compositionName());
     copyContext.setObjectIds(input.objectIds());
     copyContext.setSystemUser(isSystemUser);
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -30,16 +30,26 @@ public class SDMAttachmentsService extends ServiceDelegator
   @Override
   public void copyAttachments(CopyAttachmentInput input, boolean isSystemUser) {
     logger.info(
-        "Copying attachments for upId: {}, parentEntity: {}, compositionName: {}, objectIds: {}, isSystemUser: {}",
+        "Copying attachments for upId: {}, facet: {}, objectIds: {}, isSystemUser: {}",
         input.upId(),
-        input.parentEntity(),
-        input.compositionName(),
+        input.facet(),
         input.objectIds(),
         isSystemUser);
+
+    // Parse facet to extract parent entity and composition name
+    String[] facetParts = input.facet().split("\\.");
+    if (facetParts.length < 3) {
+      throw new IllegalArgumentException(
+          "Invalid facet format. Expected: Service.Entity.Composition, got: " + input.facet());
+    }
+
+    String parentEntity = facetParts[0] + "." + facetParts[1]; // Service.Entity
+    String compositionName = facetParts[2]; // composition name
+
     var copyContext = AttachmentCopyEventContext.create();
     copyContext.setUpId(input.upId());
-    copyContext.setParentEntity(input.parentEntity());
-    copyContext.setCompositionName(input.compositionName());
+    copyContext.setParentEntity(parentEntity);
+    copyContext.setCompositionName(compositionName);
     copyContext.setObjectIds(input.objectIds());
     copyContext.setSystemUser(isSystemUser);
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentCopyEventContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentCopyEventContext.java
@@ -10,8 +10,12 @@ import com.sap.cds.services.EventName;
 import java.util.List;
 
 /**
- * The {@link AttachmentCopyEventContext} is used to store the context of the create attachment
- * event.
+ * The {@link AttachmentCopyEventContext} is used to store the context of the copy attachment event.
+ * This interface provides methods to handle attachment copying for both regular entities and
+ * projection entities by working with parent entities and their composition relationships.
+ *
+ * <p>For projection entities, the API uses the parent entity that defines the attachments
+ * composition and the composition name to properly navigate the relationship hierarchy.
  */
 @EventName(RegisterService.EVENT_COPY_ATTACHMENT)
 public interface AttachmentCopyEventContext extends AttachmentCreateEventContext {
@@ -27,48 +31,85 @@ public interface AttachmentCopyEventContext extends AttachmentCreateEventContext
   }
 
   /**
-   * @return The id of the attachment storage entity or {@code null} if no id was specified
+   * Gets the ID of the parent entity instance for which attachments are being copied. This
+   * represents the key values of the entity that contains the attachment composition.
+   *
+   * @return The id of the parent entity instance or {@code null} if no id was specified
    */
   String getUpId();
 
   /**
-   * Sets the ID of the content for the attachment storage
+   * Sets the ID of the parent entity instance for which attachments are being copied. This should
+   * be the key value of the entity that contains the attachment composition.
    *
-   * @param upId The key of the content
+   * @param upId The key of the parent entity instance
    */
   void setUpId(String upId);
 
-  String getFacet();
-
   /**
-   * Sets the ID of the content for the attachment storage
+   * Gets the qualified name of the parent entity that defines the attachments composition. This is
+   * the entity that contains the composition relationship to the attachment entity.
    *
-   * @param facet The key of the content
+   * @return The qualified name of the parent entity or {@code null} if not specified
    */
-  void setFacet(String facet);
+  String getParentEntity();
 
   /**
-   * @return The IDs of the attachment storage entity or {@code Collections.emptyMap} if no id was
+   * Sets the qualified name of the parent entity that defines the attachments composition. This
+   * entity should contain the composition relationship to the attachment entity.
+   *
+   * @param parentEntity The qualified name of the parent entity (e.g., "Service.Entity")
+   */
+  void setParentEntity(String parentEntity);
+
+  /**
+   * Gets the name of the composition property that links the parent entity to the attachment
+   * entity. This is the property name used in the composition relationship.
+   *
+   * <p>Examples: "attachments", "references"
+   *
+   * @return The name of the composition property or {@code null} if not specified
+   */
+  String getCompositionName();
+
+  /**
+   * Sets the name of the composition property that links the parent entity to the attachment
+   * entity. This should match the property name defined in the CDS model.
+   *
+   * @param compositionName The name of the composition property (e.g., "references")
+   */
+  void setCompositionName(String compositionName);
+
+  /**
+   * Gets the list of object IDs representing the attachments to be copied. These are typically the
+   * IDs of existing attachment records that should be duplicated.
+   *
+   * @return The list of attachment object IDs or {@code Collections.emptyList()} if no IDs were
    *     specified
    */
   List<String> getObjectIds();
 
   /**
-   * Sets the id af the attachment entity for the attachment storage
+   * Sets the list of object IDs representing the attachments to be copied. Each ID should
+   * correspond to an existing attachment record.
    *
-   * @param ids The key of the attachment entity which defines the content field
+   * @param ids The list of attachment object IDs to be copied
    */
   void setObjectIds(List<String> ids);
 
   /**
-   * @return {@code true} if the user flow is used, {@code false} otherwise
+   * Gets whether the system user flow is being used for the copy operation. System user flow
+   * typically bypasses certain authorization checks and user-specific logic.
+   *
+   * @return {@code true} if the system user flow is used, {@code false} for regular user flow
    */
   Boolean getSystemUser();
 
   /**
-   * Sets whether the system user flow is used.
+   * Sets whether the system user flow should be used for the copy operation. Use system user flow
+   * when the operation should bypass user-specific authorization or logic.
    *
-   * @param systemUser {@code true} if the system user flow is used, {@code false} otherwise
+   * @param systemUser {@code true} to use system user flow, {@code false} for regular user flow
    */
   void setSystemUser(boolean systemUser);
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -69,19 +69,12 @@ public class SDMCustomServiceHandler {
   @On(event = RegisterService.EVENT_COPY_ATTACHMENT)
   public void copyAttachments(AttachmentCopyEventContext context) throws IOException {
 
-    System.out.println("Inside copyAttachments handler of SDMCustomServiceHandler");
     String parentEntity = context.getParentEntity();
-    System.out.println("parentEntity: " + parentEntity);
     String compositionName = context.getCompositionName();
-    System.out.println("compositionName: " + compositionName);
     String upID = context.getUpId();
-    System.out.println("upID: " + upID);
     String folderName = upID + "__" + compositionName;
-    System.out.println("folderName: " + folderName);
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    System.out.println("repositoryId: " + repositoryId);
     Boolean isSystemUser = context.getSystemUser();
-    System.out.println("isSystemUser: " + isSystemUser);
 
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
     // Check if folder exists before trying to create it
@@ -91,7 +84,6 @@ public class SDMCustomServiceHandler {
     String folderId = ensureFolderExists(folderName, repositoryId, sdmCredentials, isSystemUser);
 
     List<String> objectIds = context.getObjectIds();
-    System.out.println("objectIds: " + objectIds);
 
     CopyAttachmentsResult copyResult =
         copyAttachmentsToSDM(
@@ -99,10 +91,8 @@ public class SDMCustomServiceHandler {
 
     List<List<String>> attachmentsMetadata = copyResult.getAttachmentsMetadata();
     List<CmisDocument> populatedDocuments = copyResult.getPopulatedDocuments();
-    System.out.println("attachmentsMetadata: " + attachmentsMetadata);
 
     String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
-    System.out.println("upIdKey: " + upIdKey);
     createDraftEntries(
         attachmentsMetadata,
         populatedDocuments,
@@ -121,7 +111,6 @@ public class SDMCustomServiceHandler {
       throws IOException {
     String folderId =
         sdmService.getFolderIdByPath(folderName, repositoryId, sdmCredentials, isSystemUser);
-    System.out.println("folderId: " + folderId);
     if (folderId == null) {
       folderId =
           sdmService.createFolder(
@@ -129,7 +118,6 @@ public class SDMCustomServiceHandler {
       JSONObject jsonObject = new JSONObject(folderId);
       JSONObject succinctProperties = jsonObject.getJSONObject("succinctProperties");
       folderId = succinctProperties.getString("cmis:objectId");
-      System.out.println("Created new folder with folderId: " + folderId);
     }
     return folderId;
   }
@@ -149,7 +137,6 @@ public class SDMCustomServiceHandler {
     for (String objectId : objectIds) {
       CmisDocument cmisDocument =
           dbQuery.getAttachmentForObjectID(persistenceService, objectId, context);
-      System.out.println("cmisDocument: " + cmisDocument);
       cmisDocument.setObjectId(objectId);
       cmisDocument.setRepositoryId(repositoryId);
       cmisDocument.setFolderId(folderId);
@@ -179,10 +166,8 @@ public class SDMCustomServiceHandler {
       ServiceException e)
       throws IOException {
     if (!folderExists) {
-      System.out.println("Exception occurred, deleting created folder with folderId: " + folderId);
       sdmService.deleteDocument("deleteTree", folderId, context.getUserInfo().getName());
     } else {
-      System.out.println("Exception occurred, deleting copied attachments");
       for (List<String> attachmentMetadata : attachmentsMetadata) {
         sdmService.deleteDocument(
             "delete", attachmentMetadata.get(2), context.getUserInfo().getName());
@@ -195,38 +180,28 @@ public class SDMCustomServiceHandler {
       AttachmentCopyEventContext context, String parentEntity, String compositionName) {
     CdsModel model = context.getModel();
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
-    System.out.println("optionalParentEntity: " + optionalParentEntity);
     if (optionalParentEntity.isEmpty()) {
       throw new ServiceException("Unable to find parent entity: " + parentEntity);
     }
 
     Optional<CdsElement> compositionElement =
         optionalParentEntity.get().findElement(compositionName);
-    System.out.println("compositionElement: " + compositionElement);
     if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
       throw new ServiceException(
           "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
     }
 
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
-    System.out.println("assocType: " + assocType);
     String targetEntityName = assocType.getTarget().getQualifiedName();
-    System.out.println("targetEntityName: " + targetEntityName);
 
     Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
-    System.out.println("attachmentDraftEntity: " + attachmentDraftEntity);
     if (attachmentDraftEntity.isPresent()) {
       Optional<CdsElement> upAssociation = attachmentDraftEntity.get().findAssociation("up_");
-      System.out.println("upAssociation: " + upAssociation);
       if (upAssociation.isPresent()) {
         CdsElement association = upAssociation.get();
-        System.out.println("association: " + association);
         CdsAssociationType upAssocType = association.getType();
-        System.out.println("upAssocType: " + upAssocType);
         List<String> fkElements = upAssocType.refs().map(ref -> "up__" + ref.path()).toList();
-        System.out.println("fkElements: " + fkElements);
         String upIdKey = fkElements.get(0);
-        System.out.println("upIdKey: " + upIdKey);
         return upIdKey;
       }
     }
@@ -249,9 +224,7 @@ public class SDMCustomServiceHandler {
       Map<String, Object> updatedFields = new HashMap<>();
 
       String fileName = attachmentMetadata.get(0);
-      System.out.println("fileName: " + fileName);
       String mimeType = attachmentMetadata.get(1);
-      System.out.println("mimeType: " + mimeType);
       if (mimeType.equalsIgnoreCase("application/internet-shortcut")) {
         int dotIndex = fileName.lastIndexOf('.');
         fileName = fileName.substring(0, dotIndex);
@@ -280,14 +253,11 @@ public class SDMCustomServiceHandler {
               + ":"
               + mimeType);
       updatedFields.put(upIdKey, upID);
-      System.out.println("updatedFields: " + updatedFields);
 
       String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
       var insert =
           Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
               .entry(updatedFields);
-      System.out.println("Insert: " + insert);
-      System.out.println("Using baseKeyField: " + baseKeyField + " for filter");
 
       DraftService matchingService =
           draftService.stream()
@@ -296,7 +266,6 @@ public class SDMCustomServiceHandler {
               .orElse(null);
 
       if (matchingService != null) {
-        System.out.println("Using DraftService: " + matchingService.getName());
         matchingService.newDraft(insert);
       } else {
         throw new ServiceException("No suitable service found for entity: " + parentEntity);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -248,6 +248,7 @@ public class SDMCustomServiceHandler {
               + ":"
               + mimeType);
       updatedFields.put(upIdKey, upID);
+      System.out.println("updatedFields: " + updatedFields);
 
       String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
       var insert =

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -62,14 +62,43 @@ public class SDMCustomServiceHandler {
     System.out.println("repositoryId: " + repositoryId);
     Boolean isSystemUser = context.getSystemUser();
     System.out.println("isSystemUser: " + isSystemUser);
-    boolean folderExists = true;
 
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
+    // Check if folder exists before trying to create it
+    boolean folderExists =
+        sdmService.getFolderIdByPath(folderName, repositoryId, sdmCredentials, isSystemUser)
+            != null;
+    String folderId = ensureFolderExists(folderName, repositoryId, sdmCredentials, isSystemUser);
+
+    CmisDocument cmisDocument = new CmisDocument();
+    List<String> objectIds = context.getObjectIds();
+    System.out.println("objectIds: " + objectIds);
+
+    List<List<String>> attachmentsMetadata =
+        copyAttachmentsToSDM(
+            context, objectIds, folderId, repositoryId, sdmCredentials, isSystemUser, folderExists);
+
+    String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
+    createDraftEntries(
+        attachmentsMetadata,
+        parentEntity,
+        compositionName,
+        upID,
+        upIdKey,
+        repositoryId,
+        folderId,
+        cmisDocument);
+
+    context.setCompleted();
+  }
+
+  private String ensureFolderExists(
+      String folderName, String repositoryId, SDMCredentials sdmCredentials, Boolean isSystemUser)
+      throws IOException {
     String folderId =
         sdmService.getFolderIdByPath(folderName, repositoryId, sdmCredentials, isSystemUser);
     System.out.println("folderId: " + folderId);
     if (folderId == null) {
-      folderExists = false;
       folderId =
           sdmService.createFolder(
               folderName, SDMConstants.REPOSITORY_ID, sdmCredentials, isSystemUser);
@@ -78,51 +107,67 @@ public class SDMCustomServiceHandler {
       folderId = succinctProperties.getString("cmis:objectId");
       System.out.println("Created new folder with folderId: " + folderId);
     }
-    CmisDocument cmisDocument = new CmisDocument();
+    return folderId;
+  }
 
-    List<String> objectIds = context.getObjectIds();
-    System.out.println("objectIds: " + objectIds);
+  private List<List<String>> copyAttachmentsToSDM(
+      AttachmentCopyEventContext context,
+      List<String> objectIds,
+      String folderId,
+      String repositoryId,
+      SDMCredentials sdmCredentials,
+      Boolean isSystemUser,
+      boolean folderExists)
+      throws IOException {
     List<List<String>> attachmentsMetadata = new ArrayList<>();
+
     for (String objectId : objectIds) {
-      // get Link Url from objectId and set to cmisDocument
-      cmisDocument = dbQuery.getAttachmentForObjectID(persistenceService, objectId, context);
+      CmisDocument cmisDocument =
+          dbQuery.getAttachmentForObjectID(persistenceService, objectId, context);
       System.out.println("cmisDocument: " + cmisDocument);
       cmisDocument.setObjectId(objectId);
       cmisDocument.setRepositoryId(repositoryId);
       cmisDocument.setFolderId(folderId);
+
       try {
         attachmentsMetadata.add(
             sdmService.copyAttachment(cmisDocument, sdmCredentials, isSystemUser));
       } catch (ServiceException e) {
-        if (!folderExists) {
-          // deleteFolder
-          System.out.println(
-              "Exception occurred, deleting created folder with folderId: " + folderId);
-          sdmService.deleteDocument("deleteTree", folderId, context.getUserInfo().getName());
-          throw new ServiceException(e.getMessage());
-        } else {
-          System.out.println("Exception occurred, deleting copied attachments");
-          for (List<String> attachmentMetadata : attachmentsMetadata) {
-            // delete the copied attachments
-            sdmService.deleteDocument(
-                "delete", attachmentMetadata.get(2), context.getUserInfo().getName());
-          }
-          throw new ServiceException(e.getMessage());
-        }
+        handleCopyFailure(context, folderId, folderExists, attachmentsMetadata, e);
       }
     }
+    return attachmentsMetadata;
+  }
 
-    // Find the parent entity's draft table and composition
-    String upIdKey = null;
+  private void handleCopyFailure(
+      AttachmentCopyEventContext context,
+      String folderId,
+      boolean folderExists,
+      List<List<String>> attachmentsMetadata,
+      ServiceException e)
+      throws IOException {
+    if (!folderExists) {
+      System.out.println("Exception occurred, deleting created folder with folderId: " + folderId);
+      sdmService.deleteDocument("deleteTree", folderId, context.getUserInfo().getName());
+    } else {
+      System.out.println("Exception occurred, deleting copied attachments");
+      for (List<String> attachmentMetadata : attachmentsMetadata) {
+        sdmService.deleteDocument(
+            "delete", attachmentMetadata.get(2), context.getUserInfo().getName());
+      }
+    }
+    throw new ServiceException(e.getMessage());
+  }
+
+  private String resolveUpIdKey(
+      AttachmentCopyEventContext context, String parentEntity, String compositionName) {
     CdsModel model = context.getModel();
-
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
     System.out.println("optionalParentEntity: " + optionalParentEntity);
     if (optionalParentEntity.isEmpty()) {
       throw new ServiceException("Unable to find parent entity: " + parentEntity);
     }
 
-    // Find the composition element in the parent draft entity
     Optional<CdsElement> compositionElement =
         optionalParentEntity.get().findElement(compositionName);
     System.out.println("compositionElement: " + compositionElement);
@@ -131,13 +176,11 @@ public class SDMCustomServiceHandler {
           "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
     }
 
-    // Get the target entity of the composition
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
     System.out.println("assocType: " + assocType);
     String targetEntityName = assocType.getTarget().getQualifiedName();
     System.out.println("targetEntityName: " + targetEntityName);
 
-    // Find the target entity's draft table to get upIdKey
     Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
     System.out.println("attachmentDraftEntity: " + attachmentDraftEntity);
     if (attachmentDraftEntity.isPresent()) {
@@ -150,15 +193,25 @@ public class SDMCustomServiceHandler {
         System.out.println("upAssocType: " + upAssocType);
         List<String> fkElements = upAssocType.refs().map(ref -> "up__" + ref.path()).toList();
         System.out.println("fkElements: " + fkElements);
-        upIdKey = fkElements.get(0);
+        String upIdKey = fkElements.get(0);
         System.out.println("upIdKey: " + upIdKey);
+        return upIdKey;
       }
     }
+    return null;
+  }
 
-    final String finalUpIdKey = upIdKey;
-
-    // Process attachments with new Insert pattern
+  private void createDraftEntries(
+      List<List<String>> attachmentsMetadata,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      String upIdKey,
+      String repositoryId,
+      String folderId,
+      CmisDocument cmisDocument) {
     Map<String, Object> updatedFields = new HashMap<>();
+
     for (List<String> attachmentMetadata : attachmentsMetadata) {
       String fileName = attachmentMetadata.get(0);
       System.out.println("fileName: " + fileName);
@@ -193,16 +246,13 @@ public class SDMCustomServiceHandler {
               + mimeType);
       updatedFields.put(upIdKey, upID);
 
-      // Use the recommended Insert pattern for projection entities
-      // Remove "up__" prefix from finalUpIdKey for the filter condition
-      String baseKeyField = finalUpIdKey != null ? finalUpIdKey.replace("up__", "") : "ID";
+      String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
       var insert =
           Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
               .entry(updatedFields);
       System.out.println("Insert: " + insert);
       System.out.println("Using baseKeyField: " + baseKeyField + " for filter");
 
-      // Use DraftService with fallback to PersistenceService
       DraftService matchingService =
           draftService.stream()
               .filter(ds -> parentEntity.contains(ds.getName()))
@@ -216,6 +266,5 @@ public class SDMCustomServiceHandler {
         throw new ServiceException("No suitable service found for entity: " + parentEntity);
       }
     }
-    context.setCompleted();
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -78,7 +78,10 @@ public class SDMCustomServiceHandler {
         copyAttachmentsToSDM(
             context, objectIds, folderId, repositoryId, sdmCredentials, isSystemUser, folderExists);
 
+    System.out.println("attachmentsMetadata: " + attachmentsMetadata);
+
     String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
+    System.out.println("upIdKey: " + upIdKey);
     createDraftEntries(
         attachmentsMetadata,
         parentEntity,

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -33,6 +33,26 @@ public class SDMCustomServiceHandler {
   private final TokenHandler tokenHandler;
   private final PersistenceService persistenceService;
 
+  // Result class for copyAttachmentsToSDM method
+  private static class CopyAttachmentsResult {
+    private final List<List<String>> attachmentsMetadata;
+    private final List<CmisDocument> populatedDocuments;
+
+    public CopyAttachmentsResult(
+        List<List<String>> attachmentsMetadata, List<CmisDocument> populatedDocuments) {
+      this.attachmentsMetadata = attachmentsMetadata;
+      this.populatedDocuments = populatedDocuments;
+    }
+
+    public List<List<String>> getAttachmentsMetadata() {
+      return attachmentsMetadata;
+    }
+
+    public List<CmisDocument> getPopulatedDocuments() {
+      return populatedDocuments;
+    }
+  }
+
   public SDMCustomServiceHandler(
       SDMService sdmService,
       List<DraftService> draftService,
@@ -70,27 +90,28 @@ public class SDMCustomServiceHandler {
             != null;
     String folderId = ensureFolderExists(folderName, repositoryId, sdmCredentials, isSystemUser);
 
-    CmisDocument cmisDocument = new CmisDocument();
     List<String> objectIds = context.getObjectIds();
     System.out.println("objectIds: " + objectIds);
 
-    List<List<String>> attachmentsMetadata =
+    CopyAttachmentsResult copyResult =
         copyAttachmentsToSDM(
             context, objectIds, folderId, repositoryId, sdmCredentials, isSystemUser, folderExists);
 
+    List<List<String>> attachmentsMetadata = copyResult.getAttachmentsMetadata();
+    List<CmisDocument> populatedDocuments = copyResult.getPopulatedDocuments();
     System.out.println("attachmentsMetadata: " + attachmentsMetadata);
 
     String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
     System.out.println("upIdKey: " + upIdKey);
     createDraftEntries(
         attachmentsMetadata,
+        populatedDocuments,
         parentEntity,
         compositionName,
         upID,
         upIdKey,
         repositoryId,
-        folderId,
-        cmisDocument);
+        folderId);
 
     context.setCompleted();
   }
@@ -113,7 +134,7 @@ public class SDMCustomServiceHandler {
     return folderId;
   }
 
-  private List<List<String>> copyAttachmentsToSDM(
+  private CopyAttachmentsResult copyAttachmentsToSDM(
       AttachmentCopyEventContext context,
       List<String> objectIds,
       String folderId,
@@ -123,6 +144,7 @@ public class SDMCustomServiceHandler {
       boolean folderExists)
       throws IOException {
     List<List<String>> attachmentsMetadata = new ArrayList<>();
+    List<CmisDocument> populatedDocuments = new ArrayList<>();
 
     for (String objectId : objectIds) {
       CmisDocument cmisDocument =
@@ -132,6 +154,12 @@ public class SDMCustomServiceHandler {
       cmisDocument.setRepositoryId(repositoryId);
       cmisDocument.setFolderId(folderId);
 
+      // Create individual document for each attachment with its own type and linkUrl
+      CmisDocument populatedDocument = new CmisDocument();
+      populatedDocument.setType(cmisDocument.getType());
+      populatedDocument.setUrl(cmisDocument.getUrl());
+      populatedDocuments.add(populatedDocument);
+
       try {
         attachmentsMetadata.add(
             sdmService.copyAttachment(cmisDocument, sdmCredentials, isSystemUser));
@@ -139,7 +167,8 @@ public class SDMCustomServiceHandler {
         handleCopyFailure(context, folderId, folderExists, attachmentsMetadata, e);
       }
     }
-    return attachmentsMetadata;
+
+    return new CopyAttachmentsResult(attachmentsMetadata, populatedDocuments);
   }
 
   private void handleCopyFailure(
@@ -206,16 +235,19 @@ public class SDMCustomServiceHandler {
 
   private void createDraftEntries(
       List<List<String>> attachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
       String parentEntity,
       String compositionName,
       String upID,
       String upIdKey,
       String repositoryId,
-      String folderId,
-      CmisDocument cmisDocument) {
-    Map<String, Object> updatedFields = new HashMap<>();
+      String folderId) {
 
-    for (List<String> attachmentMetadata : attachmentsMetadata) {
+    for (int i = 0; i < attachmentsMetadata.size(); i++) {
+      List<String> attachmentMetadata = attachmentsMetadata.get(i);
+      CmisDocument cmisDocument = populatedDocuments.get(i);
+      Map<String, Object> updatedFields = new HashMap<>();
+
       String fileName = attachmentMetadata.get(0);
       System.out.println("fileName: " + fileName);
       String mimeType = attachmentMetadata.get(1);
@@ -231,11 +263,11 @@ public class SDMCustomServiceHandler {
       updatedFields.put("folderId", folderId);
       updatedFields.put("status", "Clean");
       updatedFields.put("mimeType", mimeType);
-      updatedFields.put("type", cmisDocument.getType());
+      updatedFields.put("type", cmisDocument.getType()); // Individual type for each attachment
       updatedFields.put("fileName", fileName);
       updatedFields.put("HasDraftEntity", false);
       updatedFields.put("HasActiveEntity", false);
-      updatedFields.put("linkUrl", cmisDocument.getUrl());
+      updatedFields.put("linkUrl", cmisDocument.getUrl()); // Individual linkUrl for each attachment
       updatedFields.put(
           "contentId",
           newObjectId

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -8,6 +8,8 @@ import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
+import com.sap.cds.sdm.model.CopyAttachmentsRequest;
+import com.sap.cds.sdm.model.CreateDraftEntriesRequest;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.RegisterService;
@@ -85,23 +87,37 @@ public class SDMCustomServiceHandler {
 
     List<String> objectIds = context.getObjectIds();
 
-    CopyAttachmentsResult copyResult =
-        copyAttachmentsToSDM(
-            context, objectIds, folderId, repositoryId, sdmCredentials, isSystemUser, folderExists);
+    CopyAttachmentsRequest request =
+        CopyAttachmentsRequest.builder()
+            .context(context)
+            .objectIds(objectIds)
+            .folderId(folderId)
+            .repositoryId(repositoryId)
+            .sdmCredentials(sdmCredentials)
+            .isSystemUser(isSystemUser)
+            .folderExists(folderExists)
+            .build();
+
+    CopyAttachmentsResult copyResult = copyAttachmentsToSDM(request);
 
     List<List<String>> attachmentsMetadata = copyResult.getAttachmentsMetadata();
     List<CmisDocument> populatedDocuments = copyResult.getPopulatedDocuments();
 
     String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
-    createDraftEntries(
-        attachmentsMetadata,
-        populatedDocuments,
-        parentEntity,
-        compositionName,
-        upID,
-        upIdKey,
-        repositoryId,
-        folderId);
+
+    CreateDraftEntriesRequest draftRequest =
+        CreateDraftEntriesRequest.builder()
+            .attachmentsMetadata(attachmentsMetadata)
+            .populatedDocuments(populatedDocuments)
+            .parentEntity(parentEntity)
+            .compositionName(compositionName)
+            .upID(upID)
+            .upIdKey(upIdKey)
+            .repositoryId(repositoryId)
+            .folderId(folderId)
+            .build();
+
+    createDraftEntries(draftRequest);
 
     context.setCompleted();
   }
@@ -122,24 +138,17 @@ public class SDMCustomServiceHandler {
     return folderId;
   }
 
-  private CopyAttachmentsResult copyAttachmentsToSDM(
-      AttachmentCopyEventContext context,
-      List<String> objectIds,
-      String folderId,
-      String repositoryId,
-      SDMCredentials sdmCredentials,
-      Boolean isSystemUser,
-      boolean folderExists)
+  private CopyAttachmentsResult copyAttachmentsToSDM(CopyAttachmentsRequest request)
       throws IOException {
     List<List<String>> attachmentsMetadata = new ArrayList<>();
     List<CmisDocument> populatedDocuments = new ArrayList<>();
 
-    for (String objectId : objectIds) {
+    for (String objectId : request.getObjectIds()) {
       CmisDocument cmisDocument =
-          dbQuery.getAttachmentForObjectID(persistenceService, objectId, context);
+          dbQuery.getAttachmentForObjectID(persistenceService, objectId, request.getContext());
       cmisDocument.setObjectId(objectId);
-      cmisDocument.setRepositoryId(repositoryId);
-      cmisDocument.setFolderId(folderId);
+      cmisDocument.setRepositoryId(request.getRepositoryId());
+      cmisDocument.setFolderId(request.getFolderId());
 
       // Create individual document for each attachment with its own type and linkUrl
       CmisDocument populatedDocument = new CmisDocument();
@@ -149,9 +158,15 @@ public class SDMCustomServiceHandler {
 
       try {
         attachmentsMetadata.add(
-            sdmService.copyAttachment(cmisDocument, sdmCredentials, isSystemUser));
+            sdmService.copyAttachment(
+                cmisDocument, request.getSdmCredentials(), request.getIsSystemUser()));
       } catch (ServiceException e) {
-        handleCopyFailure(context, folderId, folderExists, attachmentsMetadata, e);
+        handleCopyFailure(
+            request.getContext(),
+            request.getFolderId(),
+            request.isFolderExists(),
+            attachmentsMetadata,
+            e);
       }
     }
 
@@ -208,19 +223,11 @@ public class SDMCustomServiceHandler {
     return null;
   }
 
-  private void createDraftEntries(
-      List<List<String>> attachmentsMetadata,
-      List<CmisDocument> populatedDocuments,
-      String parentEntity,
-      String compositionName,
-      String upID,
-      String upIdKey,
-      String repositoryId,
-      String folderId) {
+  private void createDraftEntries(CreateDraftEntriesRequest request) {
 
-    for (int i = 0; i < attachmentsMetadata.size(); i++) {
-      List<String> attachmentMetadata = attachmentsMetadata.get(i);
-      CmisDocument cmisDocument = populatedDocuments.get(i);
+    for (int i = 0; i < request.getAttachmentsMetadata().size(); i++) {
+      List<String> attachmentMetadata = request.getAttachmentsMetadata().get(i);
+      CmisDocument cmisDocument = request.getPopulatedDocuments().get(i);
       Map<String, Object> updatedFields = new HashMap<>();
 
       String fileName = attachmentMetadata.get(0);
@@ -232,8 +239,8 @@ public class SDMCustomServiceHandler {
       String newObjectId = attachmentMetadata.get(2);
 
       updatedFields.put("objectId", newObjectId);
-      updatedFields.put("repositoryId", repositoryId);
-      updatedFields.put("folderId", folderId);
+      updatedFields.put("repositoryId", request.getRepositoryId());
+      updatedFields.put("folderId", request.getFolderId());
       updatedFields.put("status", "Clean");
       updatedFields.put("mimeType", mimeType);
       updatedFields.put("type", cmisDocument.getType()); // Individual type for each attachment
@@ -245,30 +252,36 @@ public class SDMCustomServiceHandler {
           "contentId",
           newObjectId
               + ":"
-              + folderId
+              + request.getFolderId()
               + ":"
-              + parentEntity
+              + request.getParentEntity()
               + "."
-              + compositionName
+              + request.getCompositionName()
               + ":"
               + mimeType);
-      updatedFields.put(upIdKey, upID);
+      updatedFields.put(request.getUpIdKey(), request.getUpID());
 
-      String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
+      String baseKeyField =
+          request.getUpIdKey() != null ? request.getUpIdKey().replace("up__", "") : "ID";
       var insert =
-          Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
+          Insert.into(
+                  request.getParentEntity(),
+                  e ->
+                      e.filter(e.get(baseKeyField).eq(request.getUpID()))
+                          .to(request.getCompositionName()))
               .entry(updatedFields);
 
       DraftService matchingService =
           draftService.stream()
-              .filter(ds -> parentEntity.contains(ds.getName()))
+              .filter(ds -> request.getParentEntity().contains(ds.getName()))
               .findFirst()
               .orElse(null);
 
       if (matchingService != null) {
         matchingService.newDraft(insert);
       } else {
-        throw new ServiceException("No suitable service found for entity: " + parentEntity);
+        throw new ServiceException(
+            "No suitable service found for entity: " + request.getParentEntity());
       }
     }
   }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -48,20 +48,26 @@ public class SDMCustomServiceHandler {
 
   @On(event = RegisterService.EVENT_COPY_ATTACHMENT)
   public void copyAttachments(AttachmentCopyEventContext context) throws IOException {
-    String[] splitFacet = context.getFacet().split("\\.");
-    if (splitFacet.length < 3) {
-      throw new ServiceException(SDMConstants.FAILED_TO_FETCH_FACET);
-    }
-    String facet = splitFacet[2];
+
+    System.out.println("Inside copyAttachments handler of SDMCustomServiceHandler");
+    String parentEntity = context.getParentEntity();
+    System.out.println("parentEntity: " + parentEntity);
+    String compositionName = context.getCompositionName();
+    System.out.println("compositionName: " + compositionName);
     String upID = context.getUpId();
-    String folderName = upID + "__" + facet;
+    System.out.println("upID: " + upID);
+    String folderName = upID + "__" + compositionName;
+    System.out.println("folderName: " + folderName);
     String repositoryId = SDMConstants.REPOSITORY_ID;
+    System.out.println("repositoryId: " + repositoryId);
     Boolean isSystemUser = context.getSystemUser();
+    System.out.println("isSystemUser: " + isSystemUser);
     boolean folderExists = true;
 
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
     String folderId =
         sdmService.getFolderIdByPath(folderName, repositoryId, sdmCredentials, isSystemUser);
+    System.out.println("folderId: " + folderId);
     if (folderId == null) {
       folderExists = false;
       folderId =
@@ -70,14 +76,17 @@ public class SDMCustomServiceHandler {
       JSONObject jsonObject = new JSONObject(folderId);
       JSONObject succinctProperties = jsonObject.getJSONObject("succinctProperties");
       folderId = succinctProperties.getString("cmis:objectId");
+      System.out.println("Created new folder with folderId: " + folderId);
     }
     CmisDocument cmisDocument = new CmisDocument();
 
     List<String> objectIds = context.getObjectIds();
+    System.out.println("objectIds: " + objectIds);
     List<List<String>> attachmentsMetadata = new ArrayList<>();
     for (String objectId : objectIds) {
       // get Link Url from objectId and set to cmisDocument
       cmisDocument = dbQuery.getAttachmentForObjectID(persistenceService, objectId, context);
+      System.out.println("cmisDocument: " + cmisDocument);
       cmisDocument.setObjectId(objectId);
       cmisDocument.setRepositoryId(repositoryId);
       cmisDocument.setFolderId(folderId);
@@ -87,9 +96,12 @@ public class SDMCustomServiceHandler {
       } catch (ServiceException e) {
         if (!folderExists) {
           // deleteFolder
+          System.out.println(
+              "Exception occurred, deleting created folder with folderId: " + folderId);
           sdmService.deleteDocument("deleteTree", folderId, context.getUserInfo().getName());
           throw new ServiceException(e.getMessage());
         } else {
+          System.out.println("Exception occurred, deleting copied attachments");
           for (List<String> attachmentMetadata : attachmentsMetadata) {
             // delete the copied attachments
             sdmService.deleteDocument(
@@ -100,25 +112,64 @@ public class SDMCustomServiceHandler {
       }
     }
 
-    String upIdKey = "";
+    // Find the parent entity's draft table and composition
+    String upIdKey = null;
     CdsModel model = context.getModel();
-    Optional<CdsEntity> attachmentDraftEntity = model.findEntity(context.getFacet() + "_drafts");
-    Optional<CdsElement> upAssociation = attachmentDraftEntity.get().findAssociation("up_");
-    if (upAssociation.isPresent()) {
-      CdsElement association = upAssociation.get();
-      CdsAssociationType assocType = association.getType();
-      List<String> fkElements = assocType.refs().map(ref -> "up__" + ref.path()).toList();
-      upIdKey = fkElements.get(0);
+
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    System.out.println("optionalParentEntity: " + optionalParentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      throw new ServiceException("Unable to find parent entity: " + parentEntity);
     }
+
+    // Find the composition element in the parent draft entity
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(compositionName);
+    System.out.println("compositionElement: " + compositionElement);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      throw new ServiceException(
+          "Unable to find composition '" + compositionName + "' in entity: " + parentEntity);
+    }
+
+    // Get the target entity of the composition
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    System.out.println("assocType: " + assocType);
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+    System.out.println("targetEntityName: " + targetEntityName);
+
+    // Find the target entity's draft table to get upIdKey
+    Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+    System.out.println("attachmentDraftEntity: " + attachmentDraftEntity);
+    if (attachmentDraftEntity.isPresent()) {
+      Optional<CdsElement> upAssociation = attachmentDraftEntity.get().findAssociation("up_");
+      System.out.println("upAssociation: " + upAssociation);
+      if (upAssociation.isPresent()) {
+        CdsElement association = upAssociation.get();
+        System.out.println("association: " + association);
+        CdsAssociationType upAssocType = association.getType();
+        System.out.println("upAssocType: " + upAssocType);
+        List<String> fkElements = upAssocType.refs().map(ref -> "up__" + ref.path()).toList();
+        System.out.println("fkElements: " + fkElements);
+        upIdKey = fkElements.get(0);
+        System.out.println("upIdKey: " + upIdKey);
+      }
+    }
+
+    final String finalUpIdKey = upIdKey;
+
+    // Process attachments with new Insert pattern
     Map<String, Object> updatedFields = new HashMap<>();
     for (List<String> attachmentMetadata : attachmentsMetadata) {
       String fileName = attachmentMetadata.get(0);
+      System.out.println("fileName: " + fileName);
       String mimeType = attachmentMetadata.get(1);
+      System.out.println("mimeType: " + mimeType);
       if (mimeType.equalsIgnoreCase("application/internet-shortcut")) {
         int dotIndex = fileName.lastIndexOf('.');
         fileName = fileName.substring(0, dotIndex);
       }
       String newObjectId = attachmentMetadata.get(2);
+
       updatedFields.put("objectId", newObjectId);
       updatedFields.put("repositoryId", repositoryId);
       updatedFields.put("folderId", folderId);
@@ -130,15 +181,39 @@ public class SDMCustomServiceHandler {
       updatedFields.put("HasActiveEntity", false);
       updatedFields.put("linkUrl", cmisDocument.getUrl());
       updatedFields.put(
-          "contentId", newObjectId + ":" + folderId + ":" + context.getFacet() + ":" + mimeType);
+          "contentId",
+          newObjectId
+              + ":"
+              + folderId
+              + ":"
+              + parentEntity
+              + "."
+              + compositionName
+              + ":"
+              + mimeType);
       updatedFields.put(upIdKey, upID);
 
-      var insert = Insert.into(context.getFacet()).entry(updatedFields);
-      for (DraftService draftS : draftService) {
-        // Check if the draft service name matches the context facet
-        if (context.getFacet().contains(draftS.getName())) {
-          draftS.newDraft(insert);
-        }
+      // Use the recommended Insert pattern for projection entities
+      // Remove "up__" prefix from finalUpIdKey for the filter condition
+      String baseKeyField = finalUpIdKey != null ? finalUpIdKey.replace("up__", "") : "ID";
+      var insert =
+          Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
+              .entry(updatedFields);
+      System.out.println("Insert: " + insert);
+      System.out.println("Using baseKeyField: " + baseKeyField + " for filter");
+
+      // Use DraftService with fallback to PersistenceService
+      DraftService matchingService =
+          draftService.stream()
+              .filter(ds -> parentEntity.contains(ds.getName()))
+              .findFirst()
+              .orElse(null);
+
+      if (matchingService != null) {
+        System.out.println("Using DraftService: " + matchingService.getName());
+        matchingService.newDraft(insert);
+      } else {
+        throw new ServiceException("No suitable service found for entity: " + parentEntity);
       }
     }
     context.setCompleted();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -113,20 +113,26 @@ public class SDMServiceGenericHandler implements EventHandler {
     CqnAnalyzer cqnAnalyzer = CqnAnalyzer.create(cdsModel);
     Optional<CdsEntity> attachmentEntity =
         cdsModel.findEntity(context.getTarget().getQualifiedName() + "_drafts");
+    System.out.println("attachmentEntity: " + attachmentEntity);
     Map<String, Object> targetKeys =
         cqnAnalyzer.analyze((CqnSelect) context.get("cqn")).targetKeyValues();
     // get the objectId against the Id
     String id = targetKeys.get("ID").toString();
+    System.out.println("id: " + id);
     CmisDocument cmisDocument =
         dbQuery.getObjectIdForAttachmentID(attachmentEntity.get(), persistenceService, id);
+    System.out.println("cmisDocument: " + cmisDocument);
 
     if (cmisDocument.getFileName() == null || cmisDocument.getFileName().isEmpty()) {
       // open attachment is triggered on non-draft entity
       attachmentEntity = cdsModel.findEntity(context.getTarget().getQualifiedName());
       cmisDocument =
           dbQuery.getObjectIdForAttachmentID(attachmentEntity.get(), persistenceService, id);
+      System.out.println("cmisDocument (non-draft): " + cmisDocument);
     }
     if (cmisDocument.getMimeType().equalsIgnoreCase("application/internet-shortcut")) {
+      System.out.println("Link detected, fetching URL");
+      System.out.println("cmisDocument before fetching URL: " + cmisDocument.getUrl());
       context.setResult(cmisDocument.getUrl());
     } else {
       context.setResult("None");

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -67,10 +67,30 @@ public class SDMServiceGenericHandler implements EventHandler {
   @On(event = "copyAttachments")
   public void copyAttachments(EventContext context) throws IOException {
     String upID = context.get("up__ID").toString();
+    System.out.println("upID: " + upID);
     String objectIdsString = context.get("objectIds").toString();
+    System.out.println("objectIdsString: " + objectIdsString);
     List<String> objectIds = Arrays.stream(objectIdsString.split(",")).map(String::trim).toList();
-    var copyEventInput =
-        new CopyAttachmentInput(upID, context.getTarget().getQualifiedName(), objectIds);
+
+    // Extract parent entity and composition from target
+    String targetQualifiedName = context.getTarget().getQualifiedName();
+    System.out.println("targetQualifiedName: " + targetQualifiedName);
+    String[] targetParts = targetQualifiedName.split("\\.");
+    System.out.println("targetParts: " + Arrays.toString(targetParts));
+
+    if (targetParts.length < 3) {
+      throw new ServiceException(
+          "Invalid target format. Expected: Service.Entity.Composition, got: "
+              + targetQualifiedName);
+    }
+
+    String parentEntity = targetParts[0] + "." + targetParts[1]; // Service.Entity
+    System.out.println("parentEntity: " + parentEntity);
+    String compositionName = targetParts[2]; // composition name
+    System.out.println("compositionName: " + compositionName);
+
+    var copyEventInput = new CopyAttachmentInput(upID, parentEntity, compositionName, objectIds);
+
     attachmentService.copyAttachments(copyEventInput, context.getUserInfo().isSystemUser());
     context.setCompleted();
   }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -72,24 +72,11 @@ public class SDMServiceGenericHandler implements EventHandler {
     System.out.println("objectIdsString: " + objectIdsString);
     List<String> objectIds = Arrays.stream(objectIdsString.split(",")).map(String::trim).toList();
 
-    // Extract parent entity and composition from target
-    String targetQualifiedName = context.getTarget().getQualifiedName();
-    System.out.println("targetQualifiedName: " + targetQualifiedName);
-    String[] targetParts = targetQualifiedName.split("\\.");
-    System.out.println("targetParts: " + Arrays.toString(targetParts));
+    // Use the full target qualified name as the facet
+    String facet = context.getTarget().getQualifiedName();
+    System.out.println("facet: " + facet);
 
-    if (targetParts.length < 3) {
-      throw new ServiceException(
-          "Invalid target format. Expected: Service.Entity.Composition, got: "
-              + targetQualifiedName);
-    }
-
-    String parentEntity = targetParts[0] + "." + targetParts[1]; // Service.Entity
-    System.out.println("parentEntity: " + parentEntity);
-    String compositionName = targetParts[2]; // composition name
-    System.out.println("compositionName: " + compositionName);
-
-    var copyEventInput = new CopyAttachmentInput(upID, parentEntity, compositionName, objectIds);
+    var copyEventInput = new CopyAttachmentInput(upID, facet, objectIds);
 
     attachmentService.copyAttachments(copyEventInput, context.getUserInfo().isSystemUser());
     context.setCompleted();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -67,14 +67,11 @@ public class SDMServiceGenericHandler implements EventHandler {
   @On(event = "copyAttachments")
   public void copyAttachments(EventContext context) throws IOException {
     String upID = context.get("up__ID").toString();
-    System.out.println("upID: " + upID);
     String objectIdsString = context.get("objectIds").toString();
-    System.out.println("objectIdsString: " + objectIdsString);
     List<String> objectIds = Arrays.stream(objectIdsString.split(",")).map(String::trim).toList();
 
     // Use the full target qualified name as the facet
     String facet = context.getTarget().getQualifiedName();
-    System.out.println("facet: " + facet);
 
     var copyEventInput = new CopyAttachmentInput(upID, facet, objectIds);
 
@@ -100,26 +97,20 @@ public class SDMServiceGenericHandler implements EventHandler {
     CqnAnalyzer cqnAnalyzer = CqnAnalyzer.create(cdsModel);
     Optional<CdsEntity> attachmentEntity =
         cdsModel.findEntity(context.getTarget().getQualifiedName() + "_drafts");
-    System.out.println("attachmentEntity: " + attachmentEntity);
     Map<String, Object> targetKeys =
         cqnAnalyzer.analyze((CqnSelect) context.get("cqn")).targetKeyValues();
     // get the objectId against the Id
     String id = targetKeys.get("ID").toString();
-    System.out.println("id: " + id);
     CmisDocument cmisDocument =
         dbQuery.getObjectIdForAttachmentID(attachmentEntity.get(), persistenceService, id);
-    System.out.println("cmisDocument: " + cmisDocument);
 
     if (cmisDocument.getFileName() == null || cmisDocument.getFileName().isEmpty()) {
       // open attachment is triggered on non-draft entity
       attachmentEntity = cdsModel.findEntity(context.getTarget().getQualifiedName());
       cmisDocument =
           dbQuery.getObjectIdForAttachmentID(attachmentEntity.get(), persistenceService, id);
-      System.out.println("cmisDocument (non-draft): " + cmisDocument);
     }
     if (cmisDocument.getMimeType().equalsIgnoreCase("application/internet-shortcut")) {
-      System.out.println("Link detected, fetching URL");
-      System.out.println("cmisDocument before fetching URL: " + cmisDocument.getUrl());
       context.setResult(cmisDocument.getUrl());
     } else {
       context.setResult("None");

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/CopyAttachmentInputTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/CopyAttachmentInputTest.java
@@ -1,0 +1,65 @@
+package unit.com.sap.cds.sdm.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sap.cds.sdm.model.CopyAttachmentInput;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CopyAttachmentInputTest {
+
+  @Test
+  void testFacetBasedInput() {
+    // Test the new 3-parameter approach
+    String upId = "123";
+    String facet = "SourcingEventService.TermDefinitionsServiceEntity.references";
+    List<String> objectIds = List.of("obj1", "obj2", "obj3");
+
+    CopyAttachmentInput input = new CopyAttachmentInput(upId, facet, objectIds);
+
+    assertEquals("123", input.upId());
+    assertEquals("SourcingEventService.TermDefinitionsServiceEntity.references", input.facet());
+    assertEquals(List.of("obj1", "obj2", "obj3"), input.objectIds());
+  }
+
+  @Test
+  void testFacetParsing() {
+    // This test shows how the facet should be parsed
+    String facet = "SourcingEventService.TermDefinitionsServiceEntity.references";
+    String[] parts = facet.split("\\.");
+
+    assertEquals(3, parts.length);
+    assertEquals("SourcingEventService", parts[0]);
+    assertEquals("TermDefinitionsServiceEntity", parts[1]);
+    assertEquals("references", parts[2]);
+
+    String parentEntity = parts[0] + "." + parts[1];
+    String compositionName = parts[2];
+
+    assertEquals("SourcingEventService.TermDefinitionsServiceEntity", parentEntity);
+    assertEquals("references", compositionName);
+  }
+
+  @Test
+  void testProjectionEntityFacet() {
+    // Test with a projection entity facet - should parse the same way
+    String projectionFacet = "MyService.MyProjectionEntity.attachments";
+    String[] parts = projectionFacet.split("\\.");
+
+    assertEquals(3, parts.length);
+    String parentEntity = parts[0] + "." + parts[1];
+    String compositionName = parts[2];
+
+    assertEquals("MyService.MyProjectionEntity", parentEntity);
+    assertEquals("attachments", compositionName);
+  }
+
+  @Test
+  void testInvalidFacetFormat() {
+    // Test error handling for invalid facet formats
+    String invalidFacet = "Service.Entity"; // Missing composition
+    String[] parts = invalidFacet.split("\\.");
+
+    assertTrue(parts.length < 3, "Should detect invalid facet format");
+  }
+}

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
@@ -127,21 +127,6 @@ public class SDMCustomServiceHandlerTest {
   }
 
   @Test
-  void testCopyAttachments_InvalidFacetFormat_ThrowsException() throws IOException {
-    AttachmentCopyEventContext context = mock(AttachmentCopyEventContext.class);
-    when(context.getFacet()).thenReturn("invalid.facet"); // Only 2 parts
-    // Other mocks not needed as exception is thrown before they're used
-
-    ServiceException ex =
-        assertThrows(
-            ServiceException.class,
-            () -> {
-              sdmCustomServiceHandler.copyAttachments(context);
-            });
-    assertTrue(ex.getMessage().contains("Invalid facet format"));
-  }
-
-  @Test
   void testCopyAttachments_FolderDoesNotExist() throws IOException {
     // Mock SDMCredentials
     SDMCredentials sdmCredentials = mock(SDMCredentials.class);
@@ -203,14 +188,25 @@ public class SDMCustomServiceHandlerTest {
 
     // Mock context
     AttachmentCopyEventContext context = createMockContext();
-    context.setObjectIds(List.of(OBJECT_ID, "mockObjectId2"));
+    // Override the getObjectIds mock to return multiple objects for this test
+    when(context.getObjectIds()).thenReturn(List.of(OBJECT_ID, "mockObjectId2"));
+
+    // Mock UserInfo for cleanup operations
+    UserInfo userInfo = mock(UserInfo.class);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.getName()).thenReturn("testUser");
 
     // Act & Assert
-    try {
-      sdmCustomServiceHandler.copyAttachments(context);
-    } catch (ServiceException e) {
-      verify(sdmService, times(1)).deleteDocument(any(String.class), any(String.class), any());
-    }
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> {
+              sdmCustomServiceHandler.copyAttachments(context);
+            });
+
+    // Verify that deleteDocument was called for cleanup of the first successful attachment
+    verify(sdmService, times(1)).deleteDocument(eq("delete"), eq(OBJECT_ID), eq("testUser"));
+    assertTrue(exception.getMessage().contains("Copy failed"));
   }
 
   @Test
@@ -291,19 +287,36 @@ public class SDMCustomServiceHandlerTest {
     CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
     CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
 
-    when(context.getFacet()).thenReturn("prefix.someIdentifier." + FACET);
+    when(context.getParentEntity()).thenReturn("prefix.someIdentifier." + FACET);
+    when(context.getCompositionName()).thenReturn(FACET);
     when(context.getUpId()).thenReturn(UP_ID);
     when(context.getSystemUser()).thenReturn(true);
     when(context.getObjectIds()).thenReturn(List.of(OBJECT_ID));
 
     // Mock CdsModel and relevant entities and associations
     CdsModel model = mock(CdsModel.class);
-    CdsEntity entity = mock(CdsEntity.class);
+    CdsEntity parentEntity = mock(CdsEntity.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
 
-    // Setup expected behavior
+    // Mock composition element and its type
+    CdsElement compositionElement = mock(CdsElement.class);
+    CdsAssociationType compositionType = mock(CdsAssociationType.class);
+
+    // Setup expected behavior for model and parent entity
     when(context.getModel()).thenReturn(model);
-    when(model.findEntity(any(String.class))).thenReturn(Optional.of(entity));
-    when(entity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(model.findEntity("prefix.someIdentifier." + FACET)).thenReturn(Optional.of(parentEntity));
+    when(model.findEntity(endsWith("_drafts"))).thenReturn(Optional.of(draftEntity));
+
+    // Mock the composition element in parent entity
+    when(parentEntity.findElement(FACET)).thenReturn(Optional.of(compositionElement));
+    when(compositionElement.getType()).thenReturn(compositionType);
+    when(compositionType.isAssociation()).thenReturn(true);
+    when(compositionType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("target.entity.name");
+
+    // Mock the draft entity's up_ association
+    when(draftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
     when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
     when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
     when(mockCqnElementRef.path()).thenReturn("ID");

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -111,6 +111,7 @@ public class SDMServiceGenericHandlerTest {
     verify(attachmentService, times(1)).copyAttachments(captor.capture(), eq(false));
     CopyAttachmentInput input = captor.getValue();
     assert input.upId().equals("123");
+    assert input.facet().equals("MyService.MyEntity.attachments");
     assert input.objectIds().equals(List.of("abc", "xyz"));
     verify(mockContext, times(1)).setCompleted();
   }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -111,7 +111,6 @@ public class SDMServiceGenericHandlerTest {
     verify(attachmentService, times(1)).copyAttachments(captor.capture(), eq(false));
     CopyAttachmentInput input = captor.getValue();
     assert input.upId().equals("123");
-    assert input.facet().equals("MyService.MyEntity.attachments");
     assert input.objectIds().equals(List.of("abc", "xyz"));
     verify(mockContext, times(1)).setCompleted();
   }
@@ -153,6 +152,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -244,6 +244,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -260,7 +261,8 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(any(CqnSelect.class))).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "123"));
 
-    // when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
+    //
+    when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
     when(draftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
     when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
     when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
@@ -300,6 +302,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -316,7 +319,8 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(any(CqnSelect.class))).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "123"));
 
-    // when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
+    //
+    when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
     when(draftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
     when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
     when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
@@ -356,6 +360,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -372,7 +377,8 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(any(CqnSelect.class))).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "123"));
 
-    // when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
+    //
+    when(cdsModel.findEntity("MyService.MyEntity_drafts")).thenReturn(Optional.of(draftEntity));
     when(draftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
     when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
     when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
@@ -414,6 +420,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -474,6 +481,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -541,6 +549,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -609,6 +618,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);
@@ -676,6 +686,7 @@ public class SDMServiceGenericHandlerTest {
     when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
     when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
         .thenReturn(Optional.of(draftEntity));
+
     when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
     when(mockContext.getEvent()).thenReturn("createLink");
     CqnSelect cqnSelect = mock(CqnSelect.class);


### PR DESCRIPTION
## Describe your changes
This PR fixes copyAttachments API for Projection Entities. Earlier copyAttachments() was working only for non-projection entities and was failing for projection entities with 401 "Not authorized to send event 'DRAFT_NEW' to <Projection Entity>". I raised this issue with CAP team and as per the suggestion I have incorporated this fix.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single tenant Integration Test: https://github.com/cap-java/sdm/actions/runs/18746444994
Multi tenant Integration Test: https://github.com/cap-java/sdm/actions/runs/18748340988
