### PR TITLE
Fix for incorrect filename if copying attachments after renaming the source attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.5.1-SNAPSHOTT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.5.1-SNAPSHOTT</revision>
+        <revision>1.5.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.5.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -529,7 +529,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <configuration>
                     <excludes>
                         <exclude>

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -687,7 +687,7 @@ public class SDMServiceImpl implements SDMService {
 
         JSONObject jsonObject = new JSONObject(responseBody);
         JSONObject props = jsonObject.getJSONObject("succinctProperties");
-        String fileName = props.optString("cmis:contentStreamFileName");
+        String fileName = props.optString("cmis:name");
         String mimeType = props.optString("cmis:contentStreamMimeType");
         String objectId = props.optString("cmis:objectId");
         return List.of(fileName, mimeType, objectId);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -231,10 +231,6 @@ public class SDMCustomServiceHandler {
 
       String fileName = attachmentMetadata.get(0);
       String mimeType = attachmentMetadata.get(1);
-      if (mimeType.equalsIgnoreCase("application/internet-shortcut")) {
-        int dotIndex = fileName.lastIndexOf('.');
-        fileName = fileName.substring(0, dotIndex);
-      }
       String newObjectId = attachmentMetadata.get(2);
 
       updatedFields.put("objectId", newObjectId);

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -1498,7 +1498,7 @@ public class SDMServiceImplTest {
     // Prepare mock response JSON
     String responseBody =
         "{\"succinctProperties\":{"
-            + "\"cmis:contentStreamFileName\":\"file1.pdf\","
+            + "\"cmis:name\":\"file1.pdf\","
             + "\"cmis:contentStreamMimeType\":\"application/pdf\","
             + "\"cmis:objectId\":\"obj123\"}}";
 


### PR DESCRIPTION
## Describe your changes
In copyAttachments method after copying the attachments to target entity, we need to update the draft tables metadata with  newly copied attachments in target entity. To update the filename, we were reading "cmis:contentStreamFileName" property of response, which doesn't changes if we are renaming the attachments. So, on UI always the initial name was showing. Updated "cmis:contentStreamFileName" with "cmis:name" which will be updated with every name update.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description
Create an entity and upload an attachment, Save. Edit entity, rename attachment, Save. Create another entity and Copy the attachment from 1st entity. Attachment copied with the updated name.

Create an entity and create a link, Save. Edit entity, rename link, Save. Create another entity and Copy the link from 1st entity. Link copied with the updated name.

Single-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/18935195679
Multi-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/18936619831
