### PR TITLE
Revert discard link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.6.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.6.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -12,6 +12,7 @@ public class SDMConstants {
   }
 
   public static final String REPOSITORY_ID = System.getenv("REPOSITORY_ID");
+  public static final String MIMETYPE_INTERNET_SHORTCUT = "application/internet-shortcut";
   public static final String SYSTEM_USER = "system-internal";
   public static final String DESTINATION_EXCEPTION =
       "Unable to get the destination for sdm service binding";

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -139,8 +139,7 @@ public class SDMServiceGenericHandler implements EventHandler {
           .forEach(
               composition -> {
                 try {
-                  processNestedEntityComposition(
-                      context, composition);
+                  processNestedEntityComposition(context, composition);
                 } catch (IOException e) {
                   throw new RuntimeException(e);
                 }
@@ -149,9 +148,7 @@ public class SDMServiceGenericHandler implements EventHandler {
   }
 
   private void processNestedEntityComposition(
-      DraftCancelEventContext context,
-      CdsElement composition)
-      throws IOException {
+      DraftCancelEventContext context, CdsElement composition) throws IOException {
 
     CdsAssociationType associationType = (CdsAssociationType) composition.getType();
     String targetEntityName = associationType.getTarget().getQualifiedName();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -140,7 +140,7 @@ public class SDMServiceGenericHandler implements EventHandler {
               composition -> {
                 try {
                   processNestedEntityComposition(
-                      context, parentId, composition, parentActiveEntity);
+                      context, composition);
                 } catch (IOException e) {
                   throw new RuntimeException(e);
                 }
@@ -150,9 +150,7 @@ public class SDMServiceGenericHandler implements EventHandler {
 
   private void processNestedEntityComposition(
       DraftCancelEventContext context,
-      Object parentId,
-      CdsElement composition,
-      CdsEntity parentEntity)
+      CdsElement composition)
       throws IOException {
 
     CdsAssociationType associationType = (CdsAssociationType) composition.getType();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -5,8 +5,10 @@ import static com.sap.cds.sdm.constants.SDMConstants.ATTACHMENT_MAXCOUNT_ERROR_M
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.cds.Result;
+import com.sap.cds.Row;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.Insert;
+import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.CqnAnalyzer;
 import com.sap.cds.ql.cqn.CqnSelect;
@@ -16,6 +18,7 @@ import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
+import com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils;
 import com.sap.cds.sdm.model.*;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.DocumentUploadService;
@@ -24,8 +27,10 @@ import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
+import com.sap.cds.services.draft.DraftCancelEventContext;
 import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.Before;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
@@ -93,6 +98,125 @@ public class SDMServiceGenericHandler implements EventHandler {
   public void edit(EventContext context) throws IOException {
     logger.info("Handling event " + context.getEvent());
     editLink(context);
+  }
+
+  @Before(event = DraftService.EVENT_DRAFT_CANCEL)
+  public void handleDraftDiscardForLinks(DraftCancelEventContext context) throws IOException {
+    CdsEntity parentDraftEntity = context.getTarget();
+    CqnAnalyzer analyzer = CqnAnalyzer.create(context.getModel());
+    Map<String, Object> parentKeys = analyzer.analyze(context.getCqn()).rootKeys();
+    String parentEntityName = parentDraftEntity.getQualifiedName().replace("_drafts", "");
+
+    Optional<CdsEntity> parentActiveEntityOpt = context.getModel().findEntity(parentEntityName);
+    Map<String, String> compositionPathMapping =
+        parentActiveEntityOpt
+            .map(
+                cdsEntity ->
+                    AttachmentsHandlerUtils.getAttachmentPathMapping(
+                        context.getModel(), cdsEntity, persistenceService))
+            .orElse(new HashMap<>());
+
+    for (Map.Entry<String, String> entry : compositionPathMapping.entrySet()) {
+      String attachmentCompositionDefinition = entry.getKey();
+      String attachmentCompositionName = entry.getValue();
+      revertLinksForComposition(
+          context, parentKeys, attachmentCompositionDefinition, attachmentCompositionName);
+    }
+  }
+
+  private void revertLinksForComposition(
+      DraftCancelEventContext context,
+      Map<String, Object> parentKeys,
+      String attachmentCompositionDefinition,
+      String attachmentCompositionName)
+      throws IOException {
+
+    CdsModel model = context.getModel();
+    String draftEntityName = attachmentCompositionDefinition + "_drafts";
+    CdsEntity draftEntity = model.findEntity(draftEntityName).get();
+    CdsEntity activeEntity = model.findEntity(attachmentCompositionDefinition).get();
+
+    String upIdKey = getUpIdKey(draftEntity);
+    String parentKeyName = upIdKey.replaceFirst("^up__", "");
+    Object parentId = parentKeys.get(parentKeyName);
+
+    CqnSelect selectDraftLinks =
+        Select.from(draftEntity)
+            .where(
+                a ->
+                    a.get(upIdKey)
+                        .eq(parentId)
+                        .and(a.get("mimeType").eq("application/internet-shortcut"))
+                        .and(a.get("IsActiveEntity").eq(false)));
+
+    Result draftLinks = persistenceService.run(selectDraftLinks);
+    SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
+    Boolean isSystemUser = context.getUserInfo().isSystemUser();
+
+    for (Map<String, Object> draftLink :
+        draftLinks.listOf(Map.class).stream()
+            .map(
+                m -> {
+                  @SuppressWarnings("unchecked")
+                  Map<String, Object> typedMap = (Map<String, Object>) m;
+                  return typedMap;
+                })
+            .toList()) {
+      String attachmentId = (String) draftLink.get("ID");
+      String draftLinkUrl = (String) draftLink.get("linkUrl");
+      String objectId = (String) draftLink.get("objectId");
+      String filename = (String) draftLink.get("fileName");
+
+      String originalUrl =
+          getOriginalUrlFromActiveTable(activeEntity, attachmentId, parentId, upIdKey);
+
+      if (originalUrl != null && !originalUrl.equals(draftLinkUrl)) {
+        revertLinkInSDM(objectId, filename, originalUrl, sdmCredentials, isSystemUser);
+      }
+    }
+  }
+
+  private String getOriginalUrlFromActiveTable(
+      CdsEntity activeEntity, String attachmentId, Object parentId, String upIdKey) {
+    CqnSelect selectActiveLink =
+        Select.from(activeEntity)
+            .columns("linkUrl")
+            .where(
+                a ->
+                    a.get("ID")
+                        .eq(attachmentId)
+                        .and(a.get(upIdKey).eq(parentId))
+                        .and(a.get("IsActiveEntity").eq(true))
+                        .and(a.get("mimeType").eq("application/internet-shortcut")));
+
+    Result activeResult = persistenceService.run(selectActiveLink);
+
+    if (activeResult.rowCount() > 0) {
+      Row activeRow = activeResult.single();
+      String originalUrl =
+          activeRow.get("linkUrl") != null ? activeRow.get("linkUrl").toString() : null;
+      return originalUrl;
+    } else {
+      return null;
+    }
+  }
+
+  private void revertLinkInSDM(
+      String objectId,
+      String filename,
+      String originalUrl,
+      SDMCredentials sdmCredentials,
+      Boolean isSystemUser)
+      throws IOException {
+
+    CmisDocument cmisDocToRevert = new CmisDocument();
+    cmisDocToRevert.setObjectId(objectId);
+    cmisDocToRevert.setFileName(filename);
+
+    cmisDocToRevert.setUrl(originalUrl);
+    cmisDocToRevert.setRepositoryId(SDMConstants.REPOSITORY_ID);
+    sdmService.editLink(cmisDocToRevert, sdmCredentials, isSystemUser);
+
   }
 
   @On(event = "openAttachment")

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -120,6 +120,35 @@ public class SDMServiceGenericHandler implements EventHandler {
       String attachmentCompositionDefinition = entry.getKey();
       revertLinksForComposition(context, parentKeys, attachmentCompositionDefinition);
     }
+    revertNestedEntityLinks(context, parentKeys.get("ID"));
+  }
+
+  private void revertNestedEntityLinks(DraftCancelEventContext context, Object parentId)
+      throws IOException {
+    if (parentId == null) return;
+    String[] nestedEntityTypes = {"Chapters", "Pages"};
+
+    for (String entityType : nestedEntityTypes) {
+      String entityName = "AdminService." + entityType + "_drafts";
+      Optional<CdsEntity> nestedEntity = context.getModel().findEntity(entityName);
+
+      if (nestedEntity.isPresent()) {
+        Result nestedRecords =
+            persistenceService.run(
+                Select.from(nestedEntity.get())
+                    .columns("ID")
+                    .where(
+                        e -> e.get("book_ID").eq(parentId).and(e.get("IsActiveEntity").eq(false))));
+
+        for (Row nestedRecord : nestedRecords) {
+          Object nestedEntityId = nestedRecord.get("ID");
+          Map<String, Object> nestedEntityKeys = new HashMap<>();
+          nestedEntityKeys.put("ID", nestedEntityId);
+          String attachmentPath = "AdminService." + entityType + ".attachments";
+          revertLinksForComposition(context, nestedEntityKeys, attachmentPath);
+        }
+      }
+    }
   }
 
   private void revertLinksForComposition(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -126,26 +126,65 @@ public class SDMServiceGenericHandler implements EventHandler {
 
   private void revertNestedEntityLinks(DraftCancelEventContext context, Object parentId)
       throws IOException {
-    if (parentId == null) return;
-    String[] nestedEntityTypes = {"Chapters", "Pages"};
 
-    for (String entityType : nestedEntityTypes) {
-      String entityName = "AdminService." + entityType + "_drafts";
-      Optional<CdsEntity> nestedEntity = context.getModel().findEntity(entityName);
+    CdsEntity parentDraftEntity = context.getTarget();
+    String parentEntityName = parentDraftEntity.getQualifiedName().replace("_drafts", "");
+    Optional<CdsEntity> parentActiveEntityOpt = context.getModel().findEntity(parentEntityName);
 
-      if (nestedEntity.isPresent()) {
-        Result nestedRecords =
-            persistenceService.run(
-                Select.from(nestedEntity.get())
-                    .columns("ID")
-                    .where(
-                        e -> e.get("book_ID").eq(parentId).and(e.get("IsActiveEntity").eq(false))));
+    if (parentActiveEntityOpt.isPresent()) {
+      CdsEntity parentActiveEntity = parentActiveEntityOpt.get();
 
-        for (Row nestedRecord : nestedRecords) {
-          Object nestedEntityId = nestedRecord.get("ID");
-          Map<String, Object> nestedEntityKeys = new HashMap<>();
-          nestedEntityKeys.put("ID", nestedEntityId);
-          String attachmentPath = "AdminService." + entityType + ".attachments";
+      parentActiveEntity
+          .compositions()
+          .forEach(
+              composition -> {
+                try {
+                  processNestedEntityComposition(
+                      context, parentId, composition, parentActiveEntity);
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    }
+  }
+
+  private void processNestedEntityComposition(
+      DraftCancelEventContext context,
+      Object parentId,
+      CdsElement composition,
+      CdsEntity parentEntity)
+      throws IOException {
+
+    CdsAssociationType associationType = (CdsAssociationType) composition.getType();
+    String targetEntityName = associationType.getTarget().getQualifiedName();
+    String draftTargetEntityName = targetEntityName + "_drafts";
+
+    Optional<CdsEntity> nestedDraftEntity = context.getModel().findEntity(draftTargetEntityName);
+
+    if (nestedDraftEntity.isPresent()) {
+      Map<String, String> nestedAttachmentMapping =
+          AttachmentsHandlerUtils.getAttachmentPathMapping(
+              context.getModel(), associationType.getTarget(), persistenceService);
+
+      if (nestedAttachmentMapping.isEmpty()) {
+        return;
+      }
+
+      Result nestedRecords =
+          persistenceService.run(
+              Select.from(nestedDraftEntity.get())
+                  .columns("ID")
+                  .where(e -> e.get("IsActiveEntity").eq(false)));
+
+      for (Row nestedRecord : nestedRecords) {
+        Object nestedEntityId = nestedRecord.get("ID");
+
+        Map<String, Object> nestedEntityKeys = new HashMap<>();
+        nestedEntityKeys.put("ID", nestedEntityId);
+        nestedEntityKeys.put("IsActiveEntity", false);
+
+        for (Map.Entry<String, String> entry : nestedAttachmentMapping.entrySet()) {
+          String attachmentPath = entry.getKey();
           revertLinksForComposition(context, nestedEntityKeys, attachmentPath);
         }
       }
@@ -180,15 +219,12 @@ public class SDMServiceGenericHandler implements EventHandler {
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
     Boolean isSystemUser = context.getUserInfo().isSystemUser();
 
-    for (Map<String, Object> draftLink :
-        draftLinks.listOf(Map.class).stream()
-            .map(
-                m -> {
-                  @SuppressWarnings("unchecked")
-                  Map<String, Object> typedMap = (Map<String, Object>) m;
-                  return typedMap;
-                })
-            .toList()) {
+    for (Row draftLinkRow : draftLinks) {
+      Map<String, Object> draftLink = new HashMap<>();
+      draftLink.put("ID", draftLinkRow.get("ID"));
+      draftLink.put("linkUrl", draftLinkRow.get("linkUrl"));
+      draftLink.put("objectId", draftLinkRow.get("objectId"));
+      draftLink.put("fileName", draftLinkRow.get("fileName"));
       String attachmentId = (String) draftLink.get("ID");
       String draftLinkUrl = (String) draftLink.get("linkUrl");
       String objectId = (String) draftLink.get("objectId");

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -27,8 +27,8 @@ import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
-import com.sap.cds.services.draft.DraftCancelEventContext;
 import com.sap.cds.services.cds.ApplicationService;
+import com.sap.cds.services.draft.DraftCancelEventContext;
 import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.Before;
@@ -541,7 +541,6 @@ public class SDMServiceGenericHandler implements EventHandler {
       }
       return upID;
     } catch (Exception e) {
-      // Log and rethrow as ServiceException
       logger.error(SDMConstants.ENTITY_PROCESSING_ERROR_LINK, e);
       throw new ServiceException(SDMConstants.ENTITY_PROCESSING_ERROR_LINK, e);
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -121,10 +121,10 @@ public class SDMServiceGenericHandler implements EventHandler {
       String attachmentCompositionDefinition = entry.getKey();
       revertLinksForComposition(context, parentKeys, attachmentCompositionDefinition);
     }
-    revertNestedEntityLinks(context, parentKeys.get("ID"));
+    revertNestedEntityLinks(context);
   }
 
-  private void revertNestedEntityLinks(DraftCancelEventContext context, Object parentId)
+  private void revertNestedEntityLinks(DraftCancelEventContext context)
       throws IOException {
 
     CdsEntity parentDraftEntity = context.getTarget();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -537,6 +537,7 @@ public class SDMServiceGenericHandler implements EventHandler {
       }
       return upID;
     } catch (Exception e) {
+      // Log and rethrow as ServiceException
       logger.error(SDMConstants.ENTITY_PROCESSING_ERROR_LINK, e);
       throw new ServiceException(SDMConstants.ENTITY_PROCESSING_ERROR_LINK, e);
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -118,17 +118,14 @@ public class SDMServiceGenericHandler implements EventHandler {
 
     for (Map.Entry<String, String> entry : compositionPathMapping.entrySet()) {
       String attachmentCompositionDefinition = entry.getKey();
-      String attachmentCompositionName = entry.getValue();
-      revertLinksForComposition(
-          context, parentKeys, attachmentCompositionDefinition, attachmentCompositionName);
+      revertLinksForComposition(context, parentKeys, attachmentCompositionDefinition);
     }
   }
 
   private void revertLinksForComposition(
       DraftCancelEventContext context,
       Map<String, Object> parentKeys,
-      String attachmentCompositionDefinition,
-      String attachmentCompositionName)
+      String attachmentCompositionDefinition)
       throws IOException {
 
     CdsModel model = context.getModel();
@@ -216,7 +213,6 @@ public class SDMServiceGenericHandler implements EventHandler {
     cmisDocToRevert.setUrl(originalUrl);
     cmisDocToRevert.setRepositoryId(SDMConstants.REPOSITORY_ID);
     sdmService.editLink(cmisDocToRevert, sdmCredentials, isSystemUser);
-
   }
 
   @On(event = "openAttachment")

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -206,7 +206,7 @@ public class SDMServiceGenericHandler implements EventHandler {
                 a ->
                     a.get(upIdKey)
                         .eq(parentId)
-                        .and(a.get("mimeType").eq("application/internet-shortcut"))
+                        .and(a.get("mimeType").eq(SDMConstants.MIMETYPE_INTERNET_SHORTCUT))
                         .and(a.get("IsActiveEntity").eq(false)));
 
     Result draftLinks = persistenceService.run(selectDraftLinks);
@@ -244,7 +244,7 @@ public class SDMServiceGenericHandler implements EventHandler {
                         .eq(attachmentId)
                         .and(a.get(upIdKey).eq(parentId))
                         .and(a.get("IsActiveEntity").eq(true))
-                        .and(a.get("mimeType").eq("application/internet-shortcut")));
+                        .and(a.get("mimeType").eq(SDMConstants.MIMETYPE_INTERNET_SHORTCUT)));
 
     Result activeResult = persistenceService.run(selectActiveLink);
 
@@ -294,7 +294,7 @@ public class SDMServiceGenericHandler implements EventHandler {
       cmisDocument =
           dbQuery.getObjectIdForAttachmentID(attachmentEntity.get(), persistenceService, id);
     }
-    if (cmisDocument.getMimeType().equalsIgnoreCase("application/internet-shortcut")) {
+    if (cmisDocument.getMimeType().equalsIgnoreCase(SDMConstants.MIMETYPE_INTERNET_SHORTCUT)) {
       context.setResult(cmisDocument.getUrl());
     } else {
       context.setResult("None");
@@ -348,7 +348,7 @@ public class SDMServiceGenericHandler implements EventHandler {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setFolderId(folderId);
     cmisDocument.setFileName(filenameInRequest);
-    cmisDocument.setMimeType("application/internet-shortcut");
+    cmisDocument.setMimeType(SDMConstants.MIMETYPE_INTERNET_SHORTCUT);
     cmisDocument.setRepositoryId(repositoryId);
     cmisDocument.setUrl(context.get("url").toString());
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -124,8 +124,7 @@ public class SDMServiceGenericHandler implements EventHandler {
     revertNestedEntityLinks(context);
   }
 
-  private void revertNestedEntityLinks(DraftCancelEventContext context)
-      throws IOException {
+  private void revertNestedEntityLinks(DraftCancelEventContext context) throws IOException {
 
     CdsEntity parentDraftEntity = context.getTarget();
     String parentEntityName = parentDraftEntity.getQualifiedName().replace("_drafts", "");

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -557,28 +557,31 @@ public class SDMAttachmentsServiceHandlerTest {
   }
 
   @Test
-void testCopyAttachments_invalidFacetFormat() {
+  void testCopyAttachments_invalidFacetFormat() {
     SDMAttachmentsService service = new SDMAttachmentsService();
     CopyAttachmentInput input = mock(CopyAttachmentInput.class);
     when(input.facet()).thenReturn("invalidfacet");
     when(input.upId()).thenReturn("upId");
     when(input.objectIds()).thenReturn(List.of("obj1"));
-    Exception ex = assertThrows(IllegalArgumentException.class, () -> {
-        service.copyAttachments(input, false);
-    });
+    Exception ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              service.copyAttachments(input, false);
+            });
     assertTrue(ex.getMessage().contains("Invalid facet format"));
-}
+  }
 
-@Test
-void testReadAttachment_emitsContext() {
+  @Test
+  void testReadAttachment_emitsContext() {
     SDMAttachmentsService service = spy(new SDMAttachmentsService());
     doNothing().when(service).emit(any());
     InputStream result = service.readAttachment("docId");
     assertNull(result);
-}
+  }
 
-@Test
-void testCreateAttachment_emitsContextAndReturnsResult() {
+  @Test
+  void testCreateAttachment_emitsContextAndReturnsResult() {
     SDMAttachmentsService service = spy(new SDMAttachmentsService());
     doNothing().when(service).emit(any());
     CreateAttachmentInput input = mock(CreateAttachmentInput.class);
@@ -590,10 +593,10 @@ void testCreateAttachment_emitsContextAndReturnsResult() {
     when(input.content()).thenReturn(new ByteArrayInputStream(new byte[0]));
     AttachmentModificationResult result = service.createAttachment(input);
     assertNotNull(result);
-}
+  }
 
-@Test
-void testMarkAttachmentAsDeleted_emitsContext() {
+  @Test
+  void testMarkAttachmentAsDeleted_emitsContext() {
     SDMAttachmentsService service = spy(new SDMAttachmentsService());
     doNothing().when(service).emit(any());
     MarkAsDeletedInput input = mock(MarkAsDeletedInput.class);
@@ -602,14 +605,14 @@ void testMarkAttachmentAsDeleted_emitsContext() {
     when(userInfo.getName()).thenReturn("user");
     when(input.userInfo()).thenReturn(userInfo);
     service.markAttachmentAsDeleted(input);
-}
+  }
 
-@Test
-void testRestoreAttachment_emitsContext() {
+  @Test
+  void testRestoreAttachment_emitsContext() {
     SDMAttachmentsService service = spy(new SDMAttachmentsService());
     doNothing().when(service).emit(any());
     service.restoreAttachment(Instant.now());
-}
+  }
 
   @Test
   public void testCreateNonVersionedDIOther() throws IOException {

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -1,11 +1,14 @@
 package unit.com.sap.cds.sdm.service.handler;
 
 import static com.sap.cds.sdm.constants.SDMConstants.ATTACHMENT_MAXCOUNT_ERROR_MSG;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +19,9 @@ import com.sap.cds.CdsData;
 import com.sap.cds.Result;
 import com.sap.cds.Row;
 import com.sap.cds.feature.attachments.generated.cds4j.sap.attachments.MediaData;
+import com.sap.cds.feature.attachments.service.model.service.AttachmentModificationResult;
+import com.sap.cds.feature.attachments.service.model.service.CreateAttachmentInput;
+import com.sap.cds.feature.attachments.service.model.service.MarkAsDeletedInput;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentReadEventContext;
@@ -30,10 +36,12 @@ import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils;
 import com.sap.cds.sdm.model.CmisDocument;
+import com.sap.cds.sdm.model.CopyAttachmentInput;
 import com.sap.cds.sdm.model.RepoValue;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.DocumentUploadService;
+import com.sap.cds.sdm.service.SDMAttachmentsService;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.service.SDMServiceImpl;
 import com.sap.cds.sdm.service.handler.SDMAttachmentsServiceHandler;
@@ -50,6 +58,7 @@ import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
 import org.json.JSONObject;
@@ -546,6 +555,61 @@ public class SDMAttachmentsServiceHandlerTest {
       assertEquals(SDMConstants.getVirusFilesError("sample.pdf"), thrown.getMessage());
     }
   }
+
+  @Test
+void testCopyAttachments_invalidFacetFormat() {
+    SDMAttachmentsService service = new SDMAttachmentsService();
+    CopyAttachmentInput input = mock(CopyAttachmentInput.class);
+    when(input.facet()).thenReturn("invalidfacet");
+    when(input.upId()).thenReturn("upId");
+    when(input.objectIds()).thenReturn(List.of("obj1"));
+    Exception ex = assertThrows(IllegalArgumentException.class, () -> {
+        service.copyAttachments(input, false);
+    });
+    assertTrue(ex.getMessage().contains("Invalid facet format"));
+}
+
+@Test
+void testReadAttachment_emitsContext() {
+    SDMAttachmentsService service = spy(new SDMAttachmentsService());
+    doNothing().when(service).emit(any());
+    InputStream result = service.readAttachment("docId");
+    assertNull(result);
+}
+
+@Test
+void testCreateAttachment_emitsContextAndReturnsResult() {
+    SDMAttachmentsService service = spy(new SDMAttachmentsService());
+    doNothing().when(service).emit(any());
+    CreateAttachmentInput input = mock(CreateAttachmentInput.class);
+    MediaData mediaData = MediaData.create();
+    when(input.attachmentIds()).thenReturn(new HashMap<>());
+    when(input.attachmentEntity()).thenReturn(mock(com.sap.cds.reflect.CdsEntity.class));
+    when(input.fileName()).thenReturn("file.txt");
+    when(input.mimeType()).thenReturn("text/plain");
+    when(input.content()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    AttachmentModificationResult result = service.createAttachment(input);
+    assertNotNull(result);
+}
+
+@Test
+void testMarkAttachmentAsDeleted_emitsContext() {
+    SDMAttachmentsService service = spy(new SDMAttachmentsService());
+    doNothing().when(service).emit(any());
+    MarkAsDeletedInput input = mock(MarkAsDeletedInput.class);
+    when(input.contentId()).thenReturn("docId");
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.getName()).thenReturn("user");
+    when(input.userInfo()).thenReturn(userInfo);
+    service.markAttachmentAsDeleted(input);
+}
+
+@Test
+void testRestoreAttachment_emitsContext() {
+    SDMAttachmentsService service = spy(new SDMAttachmentsService());
+    doNothing().when(service).emit(any());
+    service.restoreAttachment(Instant.now());
+}
 
   @Test
   public void testCreateNonVersionedDIOther() throws IOException {

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -1382,7 +1382,6 @@ public class SDMServiceGenericHandlerTest {
       when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
       when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
       assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
-
     }
   }
 

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -10,6 +10,7 @@ import com.sap.cds.ql.Insert;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.AnalysisResult;
 import com.sap.cds.ql.cqn.CqnAnalyzer;
+import com.sap.cds.ql.cqn.CqnDelete;
 import com.sap.cds.ql.cqn.CqnElementRef;
 import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.reflect.CdsAssociationType;
@@ -27,6 +28,7 @@ import com.sap.cds.sdm.service.handler.SDMServiceGenericHandler;
 import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
+import com.sap.cds.services.draft.DraftCancelEventContext;
 import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.request.ParameterInfo;
@@ -1348,5 +1350,163 @@ public class SDMServiceGenericHandlerTest {
     assertThrows(ServiceException.class, () -> sdmServiceGenericHandler.edit(mockContext));
     verify(persistenceService, never()).run(any(Update.class));
     verify(mockContext, never()).setCompleted();
+  }
+
+  @Test
+  void testHandleDraftDiscardForLinks_CallsRevertNestedEntityLinks() throws IOException {
+
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils
+                      .getAttachmentPathMapping(any(), any(), any()))
+          .thenReturn(new HashMap<>());
+
+      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
+
+      sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
+
+      verify(cdsModel).findEntity("AdminService.Chapters_drafts");
+      verify(cdsModel).findEntity("AdminService.Pages_drafts");
+    }
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_WithNullParentId() throws IOException {
+
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    // Create map with null value using HashMap since Map.of() doesn't allow null values
+    Map<String, Object> rootKeys = new HashMap<>();
+    rootKeys.put("ID", null);
+    when(analysisResult.rootKeys()).thenReturn(rootKeys);
+
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils
+                      .getAttachmentPathMapping(any(), any(), any()))
+          .thenReturn(new HashMap<>());
+
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
+      verify(cdsModel, never()).findEntity("AdminService.Chapters_drafts");
+      verify(cdsModel, never()).findEntity("AdminService.Pages_drafts");
+    }
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_VerifyEntityTypesProcessed() throws IOException {
+
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "validBookId"));
+
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils
+                      .getAttachmentPathMapping(any(), any(), any()))
+          .thenReturn(new HashMap<>());
+
+      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
+
+      sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
+
+      verify(cdsModel).findEntity("AdminService.Chapters_drafts");
+      verify(cdsModel).findEntity("AdminService.Pages_drafts");
+    }
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_ExceptionHandling() throws IOException {
+
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils
+                      .getAttachmentPathMapping(any(), any(), any()))
+          .thenReturn(new HashMap<>());
+
+      when(cdsModel.findEntity("AdminService.Chapters_drafts"))
+          .thenThrow(new RuntimeException("Database error"));
+
+      assertThrows(
+          RuntimeException.class,
+          () -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext),
+          "Database error");
+    }
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -60,7 +60,6 @@ public class SDMServiceGenericHandlerTest {
   private CmisDocument cmisDocument;
   private SDMCredentials sdmCredentials;
   private SDMServiceGenericHandler sdmServiceGenericHandler;
-  private static final String MOCK_ENTITY = "MyService.MyEntity.attachments";
 
   private MockedStatic<CqnAnalyzer> cqnAnalyzerMock;
   private MockedStatic<SDMUtils> sdmUtilsMock;
@@ -70,7 +69,7 @@ public class SDMServiceGenericHandlerTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
     // Prepare a real list with the mock DraftService
-    when(draftService.getName()).thenReturn(MOCK_ENTITY);
+    when(draftService.getName()).thenReturn("MyService.MyEntity.attachments");
     when(draftService.newDraft(any(Insert.class))).thenReturn(mock(Result.class));
     List<DraftService> draftServiceList = List.of(draftService);
 
@@ -1359,7 +1358,6 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
-    CdsEntity parentActiveEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1369,8 +1367,7 @@ public class SDMServiceGenericHandlerTest {
     cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
-    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
 
     try (var attachmentUtilsMock =
         mockStatic(
@@ -1382,10 +1379,10 @@ public class SDMServiceGenericHandlerTest {
                       .getAttachmentPathMapping(any(), any(), any()))
           .thenReturn(new HashMap<>());
 
-      sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
+      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
 
-      verify(cdsModel, times(2)).findEntity("AdminService.Books");
-      verify(parentActiveEntity).compositions();
     }
   }
 
@@ -1436,7 +1433,6 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
-    CdsEntity parentActiveEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1447,8 +1443,7 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "validBookId"));
 
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
-    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
 
     try (var attachmentUtilsMock =
         mockStatic(
@@ -1460,10 +1455,25 @@ public class SDMServiceGenericHandlerTest {
                       .getAttachmentPathMapping(any(), any(), any()))
           .thenReturn(new HashMap<>());
 
-      sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
+      // Mock dynamic compositions for parentDraftEntity
+      CdsElement mockComposition1 = mock(CdsElement.class);
+      CdsElement mockComposition2 = mock(CdsElement.class);
+      CdsAssociationType mockAssociationType1 = mock(CdsAssociationType.class);
+      CdsAssociationType mockAssociationType2 = mock(CdsAssociationType.class);
+      CdsEntity mockTargetEntity1 = mock(CdsEntity.class);
+      CdsEntity mockTargetEntity2 = mock(CdsEntity.class);
+      when(parentDraftEntity.compositions())
+          .thenReturn(Stream.of(mockComposition1, mockComposition2));
+      when(mockComposition1.getType()).thenReturn(mockAssociationType1);
+      when(mockComposition2.getType()).thenReturn(mockAssociationType2);
+      when(mockAssociationType1.getTarget()).thenReturn(mockTargetEntity1);
+      when(mockAssociationType2.getTarget()).thenReturn(mockTargetEntity2);
+      when(mockTargetEntity1.getQualifiedName()).thenReturn("AdminService.Chapters");
+      when(mockTargetEntity2.getQualifiedName()).thenReturn("AdminService.Pages");
+      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
 
-      verify(cdsModel, times(2)).findEntity("AdminService.Books");
-      verify(parentActiveEntity).compositions();
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
     }
   }
 
@@ -1475,10 +1485,6 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
-    CdsEntity parentActiveEntity = mock(CdsEntity.class);
-    CdsElement composition = mock(CdsElement.class);
-    CdsAssociationType associationType = mock(CdsAssociationType.class);
-    CdsEntity targetEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1489,11 +1495,7 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
 
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
-    when(parentActiveEntity.compositions()).thenReturn(Stream.of(composition));
-    when(composition.getType()).thenReturn(associationType);
-    when(associationType.getTarget()).thenReturn(targetEntity);
-    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
 
     try (var attachmentUtilsMock =
         mockStatic(
@@ -1505,13 +1507,12 @@ public class SDMServiceGenericHandlerTest {
                       .getAttachmentPathMapping(any(), any(), any()))
           .thenReturn(new HashMap<>());
 
-      when(cdsModel.findEntity("AdminService.Chapters_drafts"))
+      when(cdsModel.findEntity("AdminService.Books"))
           .thenThrow(new RuntimeException("Database error"));
 
       assertThrows(
           RuntimeException.class,
-          () -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext),
-          "Database error");
+          () -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
     }
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -1359,6 +1359,7 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1368,7 +1369,8 @@ public class SDMServiceGenericHandlerTest {
     cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
 
     try (var attachmentUtilsMock =
         mockStatic(
@@ -1380,13 +1382,10 @@ public class SDMServiceGenericHandlerTest {
                       .getAttachmentPathMapping(any(), any(), any()))
           .thenReturn(new HashMap<>());
 
-      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
-      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
-
       sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
 
-      verify(cdsModel).findEntity("AdminService.Chapters_drafts");
-      verify(cdsModel).findEntity("AdminService.Pages_drafts");
+      verify(cdsModel, times(2)).findEntity("AdminService.Books");
+      verify(parentActiveEntity).compositions();
     }
   }
 
@@ -1437,6 +1436,7 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1447,7 +1447,8 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "validBookId"));
 
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
 
     try (var attachmentUtilsMock =
         mockStatic(
@@ -1459,13 +1460,10 @@ public class SDMServiceGenericHandlerTest {
                       .getAttachmentPathMapping(any(), any(), any()))
           .thenReturn(new HashMap<>());
 
-      when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
-      when(cdsModel.findEntity("AdminService.Pages_drafts")).thenReturn(Optional.empty());
-
       sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
 
-      verify(cdsModel).findEntity("AdminService.Chapters_drafts");
-      verify(cdsModel).findEntity("AdminService.Pages_drafts");
+      verify(cdsModel, times(2)).findEntity("AdminService.Books");
+      verify(parentActiveEntity).compositions();
     }
   }
 
@@ -1477,6 +1475,10 @@ public class SDMServiceGenericHandlerTest {
     CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
     AnalysisResult analysisResult = mock(AnalysisResult.class);
     CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
 
     when(draftContext.getTarget()).thenReturn(parentDraftEntity);
     when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
@@ -1487,7 +1489,11 @@ public class SDMServiceGenericHandlerTest {
     when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
     when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
 
-    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.of(composition));
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
 
     try (var attachmentUtilsMock =
         mockStatic(

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.sap.cds.Result;
+import com.sap.cds.Row;
 import com.sap.cds.feature.attachments.service.AttachmentService;
 import com.sap.cds.ql.Insert;
 import com.sap.cds.ql.Update;
@@ -19,6 +20,7 @@ import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
+import com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils;
 import com.sap.cds.sdm.model.*;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.DocumentUploadService;
@@ -35,6 +37,7 @@ import com.sap.cds.services.request.ParameterInfo;
 import com.sap.cds.services.request.UserInfo;
 import com.sap.cds.services.runtime.CdsRuntime;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Stream;
 import org.json.JSONObject;
@@ -1512,6 +1515,1539 @@ public class SDMServiceGenericHandlerTest {
       assertThrows(
           RuntimeException.class,
           () -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
+    }
+  }
+
+  @Test
+  void testRevertLinksForComposition() throws Exception {
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    Map<String, Object> parentKeys = new HashMap<>();
+    parentKeys.put("ID", "parent123");
+    String attachmentCompositionDefinition = "AdminService.Attachments";
+
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity activeEntity = mock(CdsEntity.class);
+
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+    when(model.findEntity("AdminService.Attachments")).thenReturn(Optional.of(activeEntity));
+
+    CdsElement upElement = mock(CdsElement.class);
+    when(draftEntity.elements()).thenReturn(Stream.of(upElement));
+    when(upElement.getName()).thenReturn("up__ID");
+
+    Result draftLinksResult = mock(Result.class);
+    Row draftLinkRow = mock(Row.class);
+    when(draftLinksResult.iterator()).thenReturn(Arrays.asList(draftLinkRow).iterator());
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(draftLinksResult);
+
+    when(draftLinkRow.get("ID")).thenReturn("attachment123");
+    when(draftLinkRow.get("linkUrl")).thenReturn("http://draft-url.com");
+    when(draftLinkRow.get("objectId")).thenReturn("object123");
+    when(draftLinkRow.get("fileName")).thenReturn("test.url");
+
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+    when(activeResult.iterator()).thenReturn(Arrays.asList(activeRow).iterator());
+    when(activeRow.get("linkUrl")).thenReturn("http://original-url.com");
+
+    when(persistenceService.run(any(CqnSelect.class)))
+        .thenReturn(draftLinksResult)
+        .thenReturn(activeResult);
+
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinksForComposition", DraftCancelEventContext.class, Map.class, String.class);
+    method.setAccessible(true);
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler, context, parentKeys, attachmentCompositionDefinition);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    verify(persistenceService, atLeast(1)).run(any(CqnSelect.class));
+    verify(tokenHandler, times(1)).getSDMCredentials();
+    verify(context, times(1)).getUserInfo();
+  }
+
+  @Test
+  void testRevertLinksForComposition_NoLinksToRevert() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    Map<String, Object> parentKeys = new HashMap<>();
+    parentKeys.put("ID", "parent123");
+    String attachmentCompositionDefinition = "AdminService.Attachments";
+
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity activeEntity = mock(CdsEntity.class);
+
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+    when(model.findEntity("AdminService.Attachments")).thenReturn(Optional.of(activeEntity));
+
+    CdsElement upElement = mock(CdsElement.class);
+    when(draftEntity.elements()).thenReturn(Stream.of(upElement));
+    when(upElement.getName()).thenReturn("up__ID");
+
+    Result emptyResult = mock(Result.class);
+    when(emptyResult.iterator()).thenReturn(Collections.emptyIterator());
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(emptyResult);
+
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(true);
+
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinksForComposition", DraftCancelEventContext.class, Map.class, String.class);
+    method.setAccessible(true);
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler, context, parentKeys, attachmentCompositionDefinition);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+    verify(tokenHandler, times(1)).getSDMCredentials();
+    verify(context, times(1)).getUserInfo();
+  }
+
+  @Test
+  void testRevertLinksForComposition_SameUrls() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    Map<String, Object> parentKeys = new HashMap<>();
+    parentKeys.put("ID", "parent123");
+    String attachmentCompositionDefinition = "AdminService.Attachments";
+
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity activeEntity = mock(CdsEntity.class);
+
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+    when(model.findEntity("AdminService.Attachments")).thenReturn(Optional.of(activeEntity));
+
+    CdsElement upElement = mock(CdsElement.class);
+    when(draftEntity.elements()).thenReturn(Stream.of(upElement));
+    when(upElement.getName()).thenReturn("up__ID");
+
+    Result draftLinksResult = mock(Result.class);
+    Row draftLinkRow = mock(Row.class);
+    when(draftLinksResult.iterator()).thenReturn(Arrays.asList(draftLinkRow).iterator());
+
+    when(draftLinkRow.get("ID")).thenReturn("attachment123");
+    when(draftLinkRow.get("linkUrl")).thenReturn("http://same-url.com");
+    when(draftLinkRow.get("objectId")).thenReturn("object123");
+    when(draftLinkRow.get("fileName")).thenReturn("test.url");
+
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+    when(activeResult.iterator()).thenReturn(Arrays.asList(activeRow).iterator());
+    when(activeRow.get("linkUrl")).thenReturn("http://same-url.com");
+
+    when(persistenceService.run(any(CqnSelect.class)))
+        .thenReturn(draftLinksResult)
+        .thenReturn(activeResult);
+
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinksForComposition", DraftCancelEventContext.class, Map.class, String.class);
+    method.setAccessible(true);
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler, context, parentKeys, attachmentCompositionDefinition);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    verify(persistenceService, times(2)).run(any(CqnSelect.class));
+    verify(tokenHandler, times(1)).getSDMCredentials();
+    verify(context, times(1)).getUserInfo();
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_MainFlow() throws Exception {
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsElement composition1 = mock(CdsElement.class);
+    CdsElement composition2 = mock(CdsElement.class);
+
+    when(context.getTarget()).thenReturn(parentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(model.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+
+    when(parentActiveEntity.compositions()).thenReturn(Stream.of(composition1, composition2));
+
+    CdsAssociationType associationType1 = mock(CdsAssociationType.class);
+    CdsAssociationType associationType2 = mock(CdsAssociationType.class);
+    CdsEntity targetEntity1 = mock(CdsEntity.class);
+    CdsEntity targetEntity2 = mock(CdsEntity.class);
+
+    when(composition1.getType()).thenReturn(associationType1);
+    when(composition2.getType()).thenReturn(associationType2);
+    when(associationType1.getTarget()).thenReturn(targetEntity1);
+    when(associationType2.getTarget()).thenReturn(targetEntity2);
+    when(targetEntity1.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(targetEntity2.getQualifiedName()).thenReturn("AdminService.Reviews");
+
+    CdsEntity nestedDraftEntity1 = mock(CdsEntity.class);
+    CdsEntity nestedDraftEntity2 = mock(CdsEntity.class);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity1));
+    when(model.findEntity("AdminService.Reviews_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity2));
+
+    Result emptyResult1 = mock(Result.class);
+    Result emptyResult2 = mock(Result.class);
+    when(emptyResult1.iterator()).thenReturn(Collections.emptyIterator());
+    when(emptyResult2.iterator()).thenReturn(Collections.emptyIterator());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity1), eq(persistenceService)))
+          .thenReturn(new HashMap<>());
+
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity2), eq(persistenceService)))
+          .thenReturn(new HashMap<>());
+
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "revertNestedEntityLinks", DraftCancelEventContext.class);
+      method.setAccessible(true);
+
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      verify(parentDraftEntity).getQualifiedName();
+      verify(model).findEntity("AdminService.Books");
+      verify(parentActiveEntity).compositions();
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity1), eq(persistenceService)),
+          times(1));
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity2), eq(persistenceService)),
+          times(1));
+    }
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_MissingActiveEntity() throws Exception {
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+
+    when(context.getTarget()).thenReturn(parentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(model.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertNestedEntityLinks", DraftCancelEventContext.class);
+    method.setAccessible(true);
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(sdmServiceGenericHandler, context);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    verify(parentDraftEntity).getQualifiedName();
+    verify(model).findEntity("AdminService.Books");
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_EmptyCompositions() throws Exception {
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+
+    when(context.getTarget()).thenReturn(parentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(model.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
+
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertNestedEntityLinks", DraftCancelEventContext.class);
+    method.setAccessible(true);
+
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(sdmServiceGenericHandler, context);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    verify(parentDraftEntity).getQualifiedName();
+    verify(model).findEntity("AdminService.Books");
+    verify(parentActiveEntity).compositions();
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_ComplexAttachments() throws Exception {
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsElement composition = mock(CdsElement.class);
+
+    when(context.getTarget()).thenReturn(parentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(model.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.of(composition));
+
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+
+    CdsEntity nestedDraftEntity = mock(CdsEntity.class);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity));
+
+    Result nestedRecordsResult = mock(Result.class);
+    Row nestedRecord = mock(Row.class);
+    when(nestedRecordsResult.iterator()).thenReturn(Arrays.asList(nestedRecord).iterator());
+    when(nestedRecord.get("ID")).thenReturn("chapter1");
+
+    Map<String, String> attachmentMapping = new HashMap<>();
+    attachmentMapping.put("AdminService.Attachments", "path1");
+
+    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity = mock(CdsEntity.class);
+
+    when(model.findEntity("AdminService.Attachments_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity));
+    when(model.findEntity("AdminService.Attachments"))
+        .thenReturn(Optional.of(attachmentActiveEntity));
+
+    CdsElement upElement = mock(CdsElement.class);
+    when(attachmentDraftEntity.elements()).thenReturn(Stream.of(upElement));
+    when(upElement.getName()).thenReturn("up__ID");
+
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Result emptyDraftLinksResult = mock(Result.class);
+    when(emptyDraftLinksResult.iterator()).thenReturn(Collections.emptyIterator());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity), eq(persistenceService)))
+          .thenReturn(attachmentMapping);
+
+      when(persistenceService.run(any(CqnSelect.class)))
+          .thenReturn(nestedRecordsResult)
+          .thenReturn(emptyDraftLinksResult);
+
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "revertNestedEntityLinks", DraftCancelEventContext.class);
+      method.setAccessible(true);
+
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      // Verify interactions
+      verify(parentDraftEntity).getQualifiedName();
+      verify(model).findEntity("AdminService.Books");
+      verify(parentActiveEntity).compositions();
+      verify(persistenceService, times(2)).run(any(CqnSelect.class));
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity), eq(persistenceService)),
+          times(1));
+    }
+  }
+
+  @Test
+  void testRevertNestedEntityLinks_ExceptionInProcessing() throws Exception {
+    // Mock context and entities
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsElement composition = mock(CdsElement.class);
+
+    when(context.getTarget()).thenReturn(parentDraftEntity);
+    when(context.getModel()).thenReturn(model);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(model.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+
+    // Mock composition that throws exception
+    when(parentActiveEntity.compositions()).thenReturn(Stream.of(composition));
+    when(composition.getType()).thenThrow(new RuntimeException("Processing error"));
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertNestedEntityLinks", DraftCancelEventContext.class);
+    method.setAccessible(true);
+
+    // Execute the test and expect RuntimeException to be thrown
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          try {
+            method.invoke(sdmServiceGenericHandler, context);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  void testRevertLinkInSDM() throws Exception {
+    // Mock parameters
+    String objectId = "test-object-id";
+    String filename = "test-document.lnk";
+    String originalUrl = "https://original-url.com";
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    Boolean isSystemUser = false;
+
+    // Mock the SDM service call
+    JSONObject successResponse = new JSONObject();
+    successResponse.put("status", "success");
+    when(sdmService.editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser)))
+        .thenReturn(successResponse);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinkInSDM",
+            String.class,
+            String.class,
+            String.class,
+            SDMCredentials.class,
+            Boolean.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler,
+                objectId,
+                filename,
+                originalUrl,
+                sdmCredentials,
+                isSystemUser);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify interactions
+    ArgumentCaptor<CmisDocument> cmisDocumentCaptor = ArgumentCaptor.forClass(CmisDocument.class);
+    verify(sdmService, times(1))
+        .editLink(cmisDocumentCaptor.capture(), eq(sdmCredentials), eq(isSystemUser));
+
+    // Verify the CmisDocument properties
+    CmisDocument capturedDoc = cmisDocumentCaptor.getValue();
+    assertEquals(objectId, capturedDoc.getObjectId());
+    assertEquals(filename, capturedDoc.getFileName());
+    assertEquals(originalUrl, capturedDoc.getUrl());
+    assertEquals(SDMConstants.REPOSITORY_ID, capturedDoc.getRepositoryId());
+  }
+
+  @Test
+  void testRevertLinkInSDM_WithNullUrl() throws Exception {
+    // Mock parameters with null URL
+    String objectId = "test-object-id";
+    String filename = "test-document.lnk";
+    String originalUrl = null;
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    Boolean isSystemUser = true;
+
+    // Mock the SDM service call
+    JSONObject successResponse = new JSONObject();
+    successResponse.put("status", "success");
+    when(sdmService.editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser)))
+        .thenReturn(successResponse);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinkInSDM",
+            String.class,
+            String.class,
+            String.class,
+            SDMCredentials.class,
+            Boolean.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler,
+                objectId,
+                filename,
+                originalUrl,
+                sdmCredentials,
+                isSystemUser);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify interactions
+    ArgumentCaptor<CmisDocument> cmisDocumentCaptor = ArgumentCaptor.forClass(CmisDocument.class);
+    verify(sdmService, times(1))
+        .editLink(cmisDocumentCaptor.capture(), eq(sdmCredentials), eq(isSystemUser));
+
+    // Verify the CmisDocument properties
+    CmisDocument capturedDoc = cmisDocumentCaptor.getValue();
+    assertEquals(objectId, capturedDoc.getObjectId());
+    assertEquals(filename, capturedDoc.getFileName());
+    assertNull(capturedDoc.getUrl());
+    assertEquals(SDMConstants.REPOSITORY_ID, capturedDoc.getRepositoryId());
+  }
+
+  @Test
+  void testRevertLinkInSDM_WithEmptyFilename() throws Exception {
+    // Mock parameters with empty filename
+    String objectId = "test-object-id";
+    String filename = "";
+    String originalUrl = "https://example.com";
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    Boolean isSystemUser = false;
+
+    // Mock the SDM service call
+    JSONObject successResponse = new JSONObject();
+    successResponse.put("status", "success");
+    when(sdmService.editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser)))
+        .thenReturn(successResponse);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinkInSDM",
+            String.class,
+            String.class,
+            String.class,
+            SDMCredentials.class,
+            Boolean.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler,
+                objectId,
+                filename,
+                originalUrl,
+                sdmCredentials,
+                isSystemUser);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify interactions
+    ArgumentCaptor<CmisDocument> cmisDocumentCaptor = ArgumentCaptor.forClass(CmisDocument.class);
+    verify(sdmService, times(1))
+        .editLink(cmisDocumentCaptor.capture(), eq(sdmCredentials), eq(isSystemUser));
+
+    // Verify the CmisDocument properties
+    CmisDocument capturedDoc = cmisDocumentCaptor.getValue();
+    assertEquals(objectId, capturedDoc.getObjectId());
+    assertEquals(filename, capturedDoc.getFileName());
+    assertEquals(originalUrl, capturedDoc.getUrl());
+    assertEquals(SDMConstants.REPOSITORY_ID, capturedDoc.getRepositoryId());
+  }
+
+  @Test
+  void testRevertLinkInSDM_ServiceException() throws Exception {
+    // Mock parameters
+    String objectId = "test-object-id";
+    String filename = "test-document.lnk";
+    String originalUrl = "https://original-url.com";
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    Boolean isSystemUser = false;
+
+    // Mock the SDM service to throw an exception
+    when(sdmService.editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser)))
+        .thenThrow(new IOException("Service unavailable"));
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinkInSDM",
+            String.class,
+            String.class,
+            String.class,
+            SDMCredentials.class,
+            Boolean.class);
+    method.setAccessible(true);
+
+    // Execute the test and expect IOException to be thrown
+    assertThrows(
+        IOException.class,
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler,
+                objectId,
+                filename,
+                originalUrl,
+                sdmCredentials,
+                isSystemUser);
+          } catch (Exception e) {
+            if (e.getCause() instanceof IOException) {
+              throw (IOException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify the service was called
+    verify(sdmService, times(1))
+        .editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser));
+  }
+
+  @Test
+  void testRevertLinkInSDM_SystemUserTrue() throws Exception {
+    // Mock parameters with system user = true
+    String objectId = "system-object-id";
+    String filename = "system-document.lnk";
+    String originalUrl = "https://system-url.com";
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    Boolean isSystemUser = true;
+
+    // Mock the SDM service call
+    JSONObject successResponse = new JSONObject();
+    successResponse.put("status", "success");
+    when(sdmService.editLink(any(CmisDocument.class), eq(sdmCredentials), eq(isSystemUser)))
+        .thenReturn(successResponse);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "revertLinkInSDM",
+            String.class,
+            String.class,
+            String.class,
+            SDMCredentials.class,
+            Boolean.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(
+                sdmServiceGenericHandler,
+                objectId,
+                filename,
+                originalUrl,
+                sdmCredentials,
+                isSystemUser);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify interactions with system user flag
+    ArgumentCaptor<CmisDocument> cmisDocumentCaptor = ArgumentCaptor.forClass(CmisDocument.class);
+    verify(sdmService, times(1))
+        .editLink(cmisDocumentCaptor.capture(), eq(sdmCredentials), eq(true));
+
+    // Verify the CmisDocument properties
+    CmisDocument capturedDoc = cmisDocumentCaptor.getValue();
+    assertEquals(objectId, capturedDoc.getObjectId());
+    assertEquals(filename, capturedDoc.getFileName());
+    assertEquals(originalUrl, capturedDoc.getUrl());
+    assertEquals(SDMConstants.REPOSITORY_ID, capturedDoc.getRepositoryId());
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable() throws Exception {
+    // Mock parameters
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-123";
+    Object parentId = "parent-456";
+    String upIdKey = "up__ID";
+
+    // Mock result with a single row
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+
+    when(activeResult.rowCount()).thenReturn(1L);
+    when(activeResult.single()).thenReturn(activeRow);
+    when(activeRow.get("linkUrl")).thenReturn("https://example.com/original-link");
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertEquals("https://example.com/original-link", url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify persistence service was called
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+    verify(activeResult, times(1)).rowCount();
+    verify(activeResult, times(1)).single();
+    verify(activeRow, times(2)).get("linkUrl"); // Called twice: null check and toString()
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable_NoRows() throws Exception {
+    // Mock parameters
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-123";
+    Object parentId = "parent-456";
+    String upIdKey = "up__ID";
+
+    // Mock empty result
+    Result activeResult = mock(Result.class);
+    when(activeResult.rowCount()).thenReturn(0L);
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertNull(url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify persistence service was called
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+    verify(activeResult, times(1)).rowCount();
+    verify(activeResult, never()).single(); // Should not call single() when no rows
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable_NullLinkUrl() throws Exception {
+    // Mock parameters
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-123";
+    Object parentId = "parent-456";
+    String upIdKey = "up__ID";
+
+    // Mock result with a single row that has null linkUrl
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+
+    when(activeResult.rowCount()).thenReturn(1L);
+    when(activeResult.single()).thenReturn(activeRow);
+    when(activeRow.get("linkUrl")).thenReturn(null);
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertNull(url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify interactions
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+    verify(activeResult, times(1)).rowCount();
+    verify(activeResult, times(1)).single();
+    verify(activeRow, times(1)).get("linkUrl");
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable_DifferentUpIdKey() throws Exception {
+    // Mock parameters with different upIdKey
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-789";
+    Object parentId = "parent-012";
+    String upIdKey = "up__parentEntityID";
+
+    // Mock result with a single row
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+
+    when(activeResult.rowCount()).thenReturn(1L);
+    when(activeResult.single()).thenReturn(activeRow);
+    when(activeRow.get("linkUrl")).thenReturn("https://different-url.com");
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertEquals("https://different-url.com", url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify persistence service was called
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable_NumericParentId() throws Exception {
+    // Mock parameters with numeric parent ID
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-456";
+    Object parentId = 12345L; // Numeric parent ID
+    String upIdKey = "up__ID";
+
+    // Mock result with a single row
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+
+    when(activeResult.rowCount()).thenReturn(1L);
+    when(activeResult.single()).thenReturn(activeRow);
+    when(activeRow.get("linkUrl")).thenReturn("https://numeric-parent.com");
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertEquals("https://numeric-parent.com", url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify persistence service was called
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+  }
+
+  @Test
+  void testGetOriginalUrlFromActiveTable_MultipleRowsReturnsFirst() throws Exception {
+    // Mock parameters
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    String attachmentId = "attachment-789";
+    Object parentId = "parent-abc";
+    String upIdKey = "up__ID";
+
+    // Mock result with multiple rows (edge case)
+    Result activeResult = mock(Result.class);
+    Row activeRow = mock(Row.class);
+
+    when(activeResult.rowCount()).thenReturn(3L); // Multiple rows
+    when(activeResult.single()).thenReturn(activeRow);
+    when(activeRow.get("linkUrl")).thenReturn("https://first-result.com");
+
+    // Mock persistence service
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(activeResult);
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "getOriginalUrlFromActiveTable",
+            CdsEntity.class,
+            String.class,
+            Object.class,
+            String.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            String url =
+                (String)
+                    method.invoke(
+                        sdmServiceGenericHandler, activeEntity, attachmentId, parentId, upIdKey);
+            assertEquals("https://first-result.com", url);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify persistence service was called
+    verify(persistenceService, times(1)).run(any(CqnSelect.class));
+    verify(activeResult, times(1)).rowCount();
+    verify(activeResult, times(1)).single();
+  }
+
+  @Test
+  void testProcessNestedEntityComposition() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsEntity nestedDraftEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity));
+
+    // Mock nested records
+    Result nestedRecordsResult = mock(Result.class);
+    Row nestedRecord1 = mock(Row.class);
+    Row nestedRecord2 = mock(Row.class);
+    when(nestedRecordsResult.iterator())
+        .thenReturn(Arrays.asList(nestedRecord1, nestedRecord2).iterator());
+    when(nestedRecord1.get("ID")).thenReturn("chapter1");
+    when(nestedRecord2.get("ID")).thenReturn("chapter2");
+
+    // Mock attachment path mapping
+    Map<String, String> attachmentMapping = new HashMap<>();
+    attachmentMapping.put("AdminService.Attachments1", "path1");
+    attachmentMapping.put("AdminService.Attachments2", "path2");
+
+    // Mock entities for revertLinksForComposition calls
+    CdsEntity attachmentDraftEntity1 = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity1 = mock(CdsEntity.class);
+    CdsEntity attachmentDraftEntity2 = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity2 = mock(CdsEntity.class);
+
+    when(model.findEntity("AdminService.Attachments1_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity1));
+    when(model.findEntity("AdminService.Attachments1"))
+        .thenReturn(Optional.of(attachmentActiveEntity1));
+    when(model.findEntity("AdminService.Attachments2_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity2));
+    when(model.findEntity("AdminService.Attachments2"))
+        .thenReturn(Optional.of(attachmentActiveEntity2));
+
+    // Mock upId key extraction for attachment entities
+    CdsElement upElement1 = mock(CdsElement.class);
+    CdsElement upElement2 = mock(CdsElement.class);
+    when(attachmentDraftEntity1.elements()).thenReturn(Stream.of(upElement1));
+    when(attachmentDraftEntity2.elements()).thenReturn(Stream.of(upElement2));
+    when(upElement1.getName()).thenReturn("up__ID");
+    when(upElement2.getName()).thenReturn("up__ID");
+
+    // Mock SDM credentials and user info for revertLinksForComposition
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    // Mock the static method call
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity), eq(persistenceService)))
+          .thenReturn(attachmentMapping);
+
+      // Mock draft links result for revertLinksForComposition calls
+      Result emptyDraftLinksResult1 = mock(Result.class);
+      Result emptyDraftLinksResult2 = mock(Result.class);
+      Result emptyDraftLinksResult3 = mock(Result.class);
+      Result emptyDraftLinksResult4 = mock(Result.class);
+      when(emptyDraftLinksResult1.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult2.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult3.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult4.iterator()).thenReturn(Collections.emptyIterator());
+
+      // Mock persistence service calls
+      when(persistenceService.run(any(CqnSelect.class)))
+          .thenReturn(nestedRecordsResult) // First call for nested records
+          .thenReturn(emptyDraftLinksResult1) // revertLinksForComposition call 1
+          .thenReturn(emptyDraftLinksResult2) // revertLinksForComposition call 2
+          .thenReturn(emptyDraftLinksResult3) // revertLinksForComposition call 3
+          .thenReturn(emptyDraftLinksResult4); // revertLinksForComposition call 4
+
+      // Use reflection to invoke the private method
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+      method.setAccessible(true);
+
+      // Execute the test
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context, composition);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      // Verify interactions
+      verify(persistenceService, atLeast(1)).run(any(CqnSelect.class));
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity), eq(persistenceService)),
+          times(1));
+    }
+  }
+
+  @Test
+  void testProcessNestedEntityComposition_NoDraftEntity() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+    method.setAccessible(true);
+
+    // Execute the test
+    assertDoesNotThrow(
+        () -> {
+          try {
+            method.invoke(sdmServiceGenericHandler, context, composition);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify no persistence calls were made since no draft entity exists
+    verify(persistenceService, never()).run(any(CqnSelect.class));
+  }
+
+  @Test
+  void testProcessNestedEntityComposition_EmptyAttachmentMapping() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsEntity nestedDraftEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity));
+
+    // Mock empty attachment path mapping
+    Map<String, String> emptyAttachmentMapping = new HashMap<>();
+
+    // Mock the static method call
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity), eq(persistenceService)))
+          .thenReturn(emptyAttachmentMapping);
+
+      // Use reflection to invoke the private method
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+      method.setAccessible(true);
+
+      // Execute the test
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context, composition);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      // Verify interactions
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity), eq(persistenceService)),
+          times(1));
+      // No persistence calls for nested records since mapping is empty
+      verify(persistenceService, never()).run(any(CqnSelect.class));
+    }
+  }
+
+  @Test
+  void testProcessNestedEntityComposition_NoNestedRecords() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsEntity nestedDraftEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity));
+
+    // Mock empty nested records result
+    Result emptyResult = mock(Result.class);
+    when(emptyResult.iterator()).thenReturn(Collections.emptyIterator());
+
+    // Mock attachment path mapping
+    Map<String, String> attachmentMapping = new HashMap<>();
+    attachmentMapping.put("AdminService.Attachments", "path1");
+
+    // Mock the static method call
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity), eq(persistenceService)))
+          .thenReturn(attachmentMapping);
+
+      when(persistenceService.run(any(CqnSelect.class))).thenReturn(emptyResult);
+
+      // Use reflection to invoke the private method
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+      method.setAccessible(true);
+
+      // Execute the test
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context, composition);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      // Verify interactions
+      verify(persistenceService, times(1))
+          .run(any(CqnSelect.class)); // Only one call for nested records
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity), eq(persistenceService)),
+          times(1));
+    }
+  }
+
+  @Test
+  void testProcessNestedEntityComposition_ExceptionHandling() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenThrow(new RuntimeException("Database error"));
+
+    // Use reflection to invoke the private method
+    Method method =
+        SDMServiceGenericHandler.class.getDeclaredMethod(
+            "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+    method.setAccessible(true);
+
+    // Execute the test and expect exception
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          try {
+            method.invoke(sdmServiceGenericHandler, context, composition);
+          } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) e.getCause();
+            }
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  void testProcessNestedEntityComposition_MultipleAttachmentPaths() throws Exception {
+    // Setup test data
+    DraftCancelEventContext context = mock(DraftCancelEventContext.class);
+    CdsElement composition = mock(CdsElement.class);
+    CdsAssociationType associationType = mock(CdsAssociationType.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsEntity nestedDraftEntity = mock(CdsEntity.class);
+    CdsModel model = mock(CdsModel.class);
+
+    // Mock composition setup
+    when(composition.getType()).thenReturn(associationType);
+    when(associationType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("AdminService.Chapters_drafts"))
+        .thenReturn(Optional.of(nestedDraftEntity));
+
+    // Mock nested records with single record
+    Result nestedRecordsResult = mock(Result.class);
+    Row nestedRecord = mock(Row.class);
+    when(nestedRecordsResult.iterator()).thenReturn(Arrays.asList(nestedRecord).iterator());
+    when(nestedRecord.get("ID")).thenReturn("chapter1");
+
+    // Mock multiple attachment paths
+    Map<String, String> attachmentMapping = new HashMap<>();
+    attachmentMapping.put("AdminService.ChapterAttachments", "path1");
+    attachmentMapping.put("AdminService.ChapterDocuments", "path2");
+    attachmentMapping.put("AdminService.ChapterImages", "path3");
+
+    // Mock entities for revertLinksForComposition calls
+    CdsEntity attachmentDraftEntity1 = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity1 = mock(CdsEntity.class);
+    CdsEntity attachmentDraftEntity2 = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity2 = mock(CdsEntity.class);
+    CdsEntity attachmentDraftEntity3 = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity3 = mock(CdsEntity.class);
+
+    when(model.findEntity("AdminService.ChapterAttachments_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity1));
+    when(model.findEntity("AdminService.ChapterAttachments"))
+        .thenReturn(Optional.of(attachmentActiveEntity1));
+    when(model.findEntity("AdminService.ChapterDocuments_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity2));
+    when(model.findEntity("AdminService.ChapterDocuments"))
+        .thenReturn(Optional.of(attachmentActiveEntity2));
+    when(model.findEntity("AdminService.ChapterImages_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity3));
+    when(model.findEntity("AdminService.ChapterImages"))
+        .thenReturn(Optional.of(attachmentActiveEntity3));
+
+    // Mock upId key extraction for attachment entities
+    CdsElement upElement1 = mock(CdsElement.class);
+    CdsElement upElement2 = mock(CdsElement.class);
+    CdsElement upElement3 = mock(CdsElement.class);
+    when(attachmentDraftEntity1.elements()).thenReturn(Stream.of(upElement1));
+    when(attachmentDraftEntity2.elements()).thenReturn(Stream.of(upElement2));
+    when(attachmentDraftEntity3.elements()).thenReturn(Stream.of(upElement3));
+    when(upElement1.getName()).thenReturn("up__ID");
+    when(upElement2.getName()).thenReturn("up__ID");
+    when(upElement3.getName()).thenReturn("up__ID");
+
+    // Mock SDM credentials and user info for revertLinksForComposition
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    // Mock the static method call
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () ->
+                  AttachmentsHandlerUtils.getAttachmentPathMapping(
+                      eq(model), eq(targetEntity), eq(persistenceService)))
+          .thenReturn(attachmentMapping);
+
+      // Mock draft links result for revertLinksForComposition calls
+      Result emptyDraftLinksResult1 = mock(Result.class);
+      Result emptyDraftLinksResult2 = mock(Result.class);
+      Result emptyDraftLinksResult3 = mock(Result.class);
+      Result emptyDraftLinksResult4 = mock(Result.class);
+      Result emptyDraftLinksResult5 = mock(Result.class);
+      Result emptyDraftLinksResult6 = mock(Result.class);
+      when(emptyDraftLinksResult1.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult2.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult3.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult4.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult5.iterator()).thenReturn(Collections.emptyIterator());
+      when(emptyDraftLinksResult6.iterator()).thenReturn(Collections.emptyIterator());
+
+      // Mock persistence service calls - first for nested records, then for each
+      // revertLinksForComposition call
+      when(persistenceService.run(any(CqnSelect.class)))
+          .thenReturn(nestedRecordsResult) // First call for nested records
+          .thenReturn(emptyDraftLinksResult1) // revertLinksForComposition call 1
+          .thenReturn(emptyDraftLinksResult2) // revertLinksForComposition call 2
+          .thenReturn(emptyDraftLinksResult3) // revertLinksForComposition call 3
+          .thenReturn(emptyDraftLinksResult4) // revertLinksForComposition call 4
+          .thenReturn(emptyDraftLinksResult5) // revertLinksForComposition call 5
+          .thenReturn(emptyDraftLinksResult6); // revertLinksForComposition call 6
+
+      // Use reflection to invoke the private method
+      Method method =
+          SDMServiceGenericHandler.class.getDeclaredMethod(
+              "processNestedEntityComposition", DraftCancelEventContext.class, CdsElement.class);
+      method.setAccessible(true);
+
+      // Execute the test
+      assertDoesNotThrow(
+          () -> {
+            try {
+              method.invoke(sdmServiceGenericHandler, context, composition);
+            } catch (Exception e) {
+              if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+              }
+              throw new RuntimeException(e);
+            }
+          });
+
+      // Verify interactions
+      verify(persistenceService, atLeast(4))
+          .run(any(CqnSelect.class)); // 1 for nested records + 3 for attachment paths
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(model), eq(targetEntity), eq(persistenceService)),
+          times(1));
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

Problem:
When users created or edited link attachments and then discarded the draft, the changes were properly reverted in the Attachments database but remained stale in the SDM repository. This caused data inconsistency between the frontend (showing original URL) and backend repository (retaining edited URL).
Fixed result:
Draft discard now properly synchronizes both the Attachments database and SDM repository, eliminating data inconsistency issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single tenant | Named user

<img width="1000" height="227" alt="Screenshot 2025-11-13 at 3 33 04 PM" src="https://github.com/user-attachments/assets/0aa61a02-858e-4704-a10c-156d01a84305" />

Single tenant | Technical user

<img width="990" height="237" alt="Screenshot 2025-11-13 at 4 36 15 PM" src="https://github.com/user-attachments/assets/af08b666-6ba3-45fa-8ff8-25b50637c76c" />

Tenant1 named user flow

<img width="1156" height="237" alt="Screenshot 2025-11-14 at 7 11 05 PM" src="https://github.com/user-attachments/assets/a5b9c6a6-3e16-43f5-bea1-62ecb2b86c7c" />

Tenant1 technical user flow

<img width="2142" height="514" alt="image" src="https://github.com/user-attachments/assets/429c6af0-932e-4893-af49-ae7759f45788" />

Tenant2 named user flow

<img width="1427" height="247" alt="Screenshot 2025-11-14 at 7 26 06 PM" src="https://github.com/user-attachments/assets/5241ee6c-9d2b-4ee6-8cff-f968cdfd2eec" />

Tenant2 technical user flow

<img width="1440" height="174" alt="Screenshot 2025-11-15 at 10 09 29 AM" src="https://github.com/user-attachments/assets/019396f3-91e5-4b9c-9b13-93c0f38b44a1" />



