### PR TITLE
Support for moveAttachments

### DIFF
--- a/.github/workflows/cfdeploy.yml
+++ b/.github/workflows/cfdeploy.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Verify and Checkout Deploy Branch 🔄
         run: |
           git fetch origin
-          echo "📂 Verifying 'local_deploy' branch..."
-          if git rev-parse --verify origin/local_deploy; then
-            git checkout local_deploy
+          echo "📂 Verifying 'LeadingAppChangesForMoveAttachments' branch..."
+          if git rev-parse --verify origin/LeadingAppChangesForMoveAttachments; then
+            git checkout LeadingAppChangesForMoveAttachments
             echo "✅ Branch checked out successfully!"
           else
-            echo "❌ Branch 'local_deploy' not found. Please verify the branch name."
+            echo "❌ Branch 'LeadingAppChangesForMoveAttachments' not found. Please verify the branch name."
             exit 1
           fi
 

--- a/.github/workflows/cfdeploy.yml
+++ b/.github/workflows/cfdeploy.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Verify and Checkout Deploy Branch 🔄
         run: |
           git fetch origin
-          echo "📂 Verifying 'LeadingAppChangesForMoveAttachments' branch..."
-          if git rev-parse --verify origin/LeadingAppChangesForMoveAttachments; then
-            git checkout LeadingAppChangesForMoveAttachments
+          echo "📂 Verifying 'local_deploy' branch..."
+          if git rev-parse --verify origin/local_deploy; then
+            git checkout local_deploy
             echo "✅ Branch checked out successfully!"
           else
-            echo "❌ Branch 'LeadingAppChangesForMoveAttachments' not found. Please verify the branch name."
+            echo "❌ Branch 'local_deploy' not found. Please verify the branch name."
             exit 1
           fi
 

--- a/.github/workflows/internalArticatory.yml
+++ b/.github/workflows/internalArticatory.yml
@@ -7,6 +7,10 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy_branch:
+          description: 'Specify the branch foe which snapshot required'
+          required: true
 jobs:
   build-and-deploy-artifactory:
     runs-on: ubuntu-latest
@@ -15,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.deploy_branch }}
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - Copy attachments: Provides the capability to copy attachments from one entity to another entity.
 - Link as attachments: Provides the capability to support link or URL as attachments.
 - Edit Link-type attachments: Provides the capability to update URL of link-type attachments.
+- Move attachments: Provides the capability to move attachments from one entity to another entity.
 - Localization of error messages and UI fields: Provides the capability to have the UI fields and error messages translated to the local language of the leading application.
 ## Table of Contents
 
@@ -33,6 +34,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - [Support for Multiple attachment facets](#support-for-multiple-attachment-facets)
 - [Support for Technical user](#support-for-technical-user)
 - [Support for Copy attachments](#support-for-copy-attachments)
+- [Support for Move attachments](#support-for-move-attachments)
 - [Support for Link type attachments](#support-for-link-type-attachments)
 - [Support for Edit of Link type attachments](#support-for-edit-of-link-type-attachments)
 - [Support for Localization](#support-for-localization)
@@ -567,6 +569,143 @@ This plugin provides capability to copy attachments from one entity to another. 
       "objectIds": "abc","xyz"
    }
    ```
+
+## Support for move attachments
+
+This plugin provides capability to move attachments from one entity to another entity. This capability will move attachments metadata on CAP as well as actual content on the SAP Document Management service repository. The move operation is performed in parallel for optimal performance and includes comprehensive error handling and rollback mechanisms.
+
+### Key Features
+
+- **Parallel Processing**: Move operations are executed in parallel using a thread pool for improved performance.
+- **Custom Properties Support**: Preserves and validates custom properties during the move.
+- **Automatic Rollback**: If database updates fail after a successful SDM move, the operation is automatically rolled back.
+- **Comprehensive Error Handling**: Returns detailed failure information for each attachment that fails to move.
+- **Folder Management**: Automatically creates target folders if they don't exist.
+
+### Usage Methods
+
+1. **A helper method to move attachments from one entity to another**
+   
+   The `AttachmentService` instance can be used to call `moveAttachments` method. This method expects an object of `MoveAttachmentInput` which requires the source folder ID, target entity's ID (`up__Id`), the `attachments facet name` and the `list of objectIds` corresponding to attachments that are to be moved.
+
+   Example usage:
+   ```java
+      String sourceFolderId = "source-folder-id";
+      String up__ID = "123";
+      List<String> objectIds = ["abc", "xyz"];
+      String facet = "AdminService.Books.attachments"
+      boolean isSystemUser = false;
+      
+      var moveEventInput = new MoveAttachmentInput(
+         sourceFolderId,
+         up__ID,
+         facet,
+         objectIds
+      );
+      
+      List<Map<String, String>> failedAttachments = 
+         attachmentService.moveAttachments(moveEventInput, isSystemUser);
+      
+      // Check for failures
+      if (!failedAttachments.isEmpty()) {
+         for (Map<String, String> failure : failedAttachments) {
+            String objectId = failure.get("objectId");
+            String reason = failure.get("failureReason");
+            // Handle failure
+         }
+      }
+   ```
+
+2. **OData API to move attachments from one entity to another**
+   
+   You can also use an OData API call to trigger the move operation.
+   `AttachmentsService` endpoint URL can be used with suffix `/<Service_name>.moveAttachments`. This request expects the following request body:
+   ```json
+   {
+      "sourceFolderId": "<source-folder-id>",
+      "up__ID": "<target-up-id>",
+      "facet": "<Service_Name>.<Entity_Name>.attachments",
+      "objectIds": ["abc", "xyz"]
+   }
+   ```
+
+   Example usage:
+   ```
+   HTTP Method: POST
+   Request URL:
+   <app_url>/odata/v4/<Service_Name>/<Entity_Name>(ID=<up__ID>,IsActiveEntity=false)/attachments/<Service_name>.moveAttachments
+   Request Body:
+   {
+      "sourceFolderId": "<source-folder-id>",
+      "up__ID": "<target-up-id>",
+      "facet": "AdminService.Books.attachments",
+      "objectIds": ["abc", "xyz"]
+   }
+   ```
+   
+   Note: The `facet` parameter should be the fully qualified name of the target attachment composition (e.g., `AdminService.Books.attachments`).
+
+### Optional Parameters
+
+When moving attachments, you can provide optional source facet information for proper cleanup:
+
+```java
+var moveEventInput = new MoveAttachmentInput(
+   sourceFolderId,
+   up__ID,
+   facet,
+   objectIds,
+   sourceFacet    // Optional: Full facet path, e.g., "AdminService.Authors.attachments"
+);
+```
+
+If `sourceFacet` is provided, the source entity metadata will be properly cleaned up after the move. If omitted, attachments are moved but source metadata cleanup is skipped.
+
+For OData API calls, you can include the optional `sourceFacet` parameter in the request body:
+```json
+{
+   "sourceFolderId": "<source-folder-id>",
+   "up__ID": "<target-up-id>",
+   "facet": "AdminService.Books.attachments",
+   "objectIds": ["abc", "xyz"],
+   "sourceFacet": "AdminService.Authors.attachments"
+}
+```
+
+### Response Format
+
+The move operation returns a list of failed attachments with detailed failure reasons:
+
+```json
+[
+   {
+      "objectId": "abc",
+      "failureReason": "Attachment abc already exists in Target entity"
+   },
+   {
+      "objectId": "xyz",
+      "failureReason": "Invalid custom properties: customProp1, customProp2. These properties are not supported in the target entity."
+   }
+]
+```
+
+### Common Failure Scenarios
+
+- **MaxCount Exceeded**: Target entity has reached its maximum allowed attachments.
+- **Invalid Custom Properties**: Attachment has custom properties not supported by the target entity.
+- **Permission Denied**: User lacks authorization to move the attachment.
+- **Duplicate File**: File with the same name already exists in the target folder.
+- **Database Update Failed**: Move succeeded in SDM but database update failed (automatic rollback occurs).
+- **Source Not Found**: Source attachment doesn't exist in SDM.
+
+### Best Practices
+
+1. **Always check the returned list of failed attachments** to inform users about partial failures.
+2. **Validate maxCount constraints** before initiating large move operations.
+3. **Ensure custom properties compatibility** between source and target entities.
+5. **Handle rollback scenarios gracefully** - rolled back attachments remain in the source folder.
+
+> **CRITICAL**: To preserve custom properties attached with attachments on UI, ensure these properties are defined in the target entity. If custom properties are not present in the target entity definition, they will be lost after the move and will not be visible on the UI.
 
 ## Support for link type attachments
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.6.2-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.6.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -602,7 +602,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
@@ -612,7 +612,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>
                                             <value>MISSEDCOUNT</value>
-                                            <maximum>6</maximum>
+                                            <maximum>10</maximum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -602,7 +602,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
@@ -612,7 +612,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>
                                             <value>MISSEDCOUNT</value>
-                                            <maximum>10</maximum>
+                                            <maximum>15</maximum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -607,7 +607,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -565,6 +565,9 @@
                         <exclude>
                             com/sap/cds/sdm/service/handler/AttachmentCopyEventContext.class
                         </exclude>
+                        <exclude>
+                            com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.class
+                        </exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -602,17 +605,17 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>CLASS</counter>
                                             <value>MISSEDCOUNT</value>
-                                            <maximum>15</maximum>
+                                            <maximum>6</maximum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -98,6 +98,16 @@ public class SDMConstants {
   public static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
   public static final String DRAFT_READONLY_CONTEXT = "DRAFT_READONLY_CONTEXT";
   public static final String FAILED_TO_COPY_ATTACHMENT = "Failed to copy attachment";
+
+  // Error messages for move operations
+  public static final String SDM_MOVE_OPERATION_FAILED = "SDM move operation failed";
+  public static final String VALIDATION_FAILED_PREFIX = "Validation failed: ";
+  public static final String VALIDATION_FAILED_DEFAULT_MESSAGE =
+      "Validation failed: Unable to process attachment properties or metadata";
+  public static final String INVALID_SECONDARY_PROPERTIES_PREFIX =
+      "Invalid secondary properties detected: ";
+  public static final String INVALID_SECONDARY_PROPERTIES_SUFFIX =
+      ". These properties are not supported in the target entity. Attachment rolled back to source.";
   public static final String FAILED_TO_MOVE_ATTACHMENT = "Failed to move attachment";
   public static final String FAILED_TO_MOVE_ATTACHMENT_MSG = "SDM.Move.failedToMoveAttachmentError";
   public static final String MOVE_OPERATION_PARTIAL_FAILURE =

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -107,7 +107,7 @@ public class SDMConstants {
   public static final String INVALID_SECONDARY_PROPERTIES_PREFIX =
       "Invalid secondary properties detected: ";
   public static final String INVALID_SECONDARY_PROPERTIES_SUFFIX =
-      ". These properties are not supported in the target entity. Attachment rolled back to source.";
+      ". Attachment rolled back to source.";
   public static final String FAILED_TO_MOVE_ATTACHMENT = "Failed to move attachment";
   public static final String FAILED_TO_MOVE_ATTACHMENT_MSG = "SDM.Move.failedToMoveAttachmentError";
   public static final String MOVE_OPERATION_PARTIAL_FAILURE =

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMConstants.java
@@ -98,6 +98,10 @@ public class SDMConstants {
   public static final String ANNOTATION_IS_MEDIA_DATA = "_is_media_data";
   public static final String DRAFT_READONLY_CONTEXT = "DRAFT_READONLY_CONTEXT";
   public static final String FAILED_TO_COPY_ATTACHMENT = "Failed to copy attachment";
+  public static final String FAILED_TO_MOVE_ATTACHMENT = "Failed to move attachment";
+  public static final String FAILED_TO_MOVE_ATTACHMENT_MSG = "SDM.Move.failedToMoveAttachmentError";
+  public static final String MOVE_OPERATION_PARTIAL_FAILURE =
+      "Move operation completed with some failures";
   public static final String FAILED_TO_FETCH_UP_ID = "Failed to fetch up_id";
   public static final String FAILED_TO_FETCH_FACET =
       "Invalid facet format, unable to extract required information.";

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
@@ -1,7 +1,6 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -57,6 +56,6 @@ public class AttachmentMoveContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    return Collections.unmodifiableList(failedAttachments);
+    return failedAttachments;
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
@@ -1,0 +1,61 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.reflect.CdsEntity;
+import java.util.List;
+import java.util.Map;
+
+/** Helper class to hold attachment move context information. */
+public class AttachmentMoveContext {
+  private final String objectId;
+  private final MoveAttachmentsRequest request;
+  private final List<String> validSecondaryProperties;
+  private final Map<String, String> entityAnnotations;
+  private final CdsEntity targetEntity;
+  private final AttachmentProcessingResults processingResults;
+  private final List<Map<String, String>> failedAttachments;
+
+  public AttachmentMoveContext(
+      String objectId,
+      MoveAttachmentsRequest request,
+      List<String> validSecondaryProperties,
+      Map<String, String> entityAnnotations,
+      CdsEntity targetEntity,
+      AttachmentProcessingResults processingResults,
+      List<Map<String, String>> failedAttachments) {
+    this.objectId = objectId;
+    this.request = request;
+    this.validSecondaryProperties = validSecondaryProperties;
+    this.entityAnnotations = entityAnnotations;
+    this.targetEntity = targetEntity;
+    this.processingResults = processingResults;
+    this.failedAttachments = failedAttachments;
+  }
+
+  public String getObjectId() {
+    return objectId;
+  }
+
+  public MoveAttachmentsRequest getRequest() {
+    return request;
+  }
+
+  public List<String> getValidSecondaryProperties() {
+    return validSecondaryProperties;
+  }
+
+  public Map<String, String> getEntityAnnotations() {
+    return entityAnnotations;
+  }
+
+  public CdsEntity getTargetEntity() {
+    return targetEntity;
+  }
+
+  public AttachmentProcessingResults getProcessingResults() {
+    return processingResults;
+  }
+
+  public List<Map<String, String>> getFailedAttachments() {
+    return failedAttachments;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
@@ -1,6 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +57,14 @@ public class AttachmentMoveContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    return failedAttachments;
+    return Collections.unmodifiableList(failedAttachments);
+  }
+
+  /**
+   * Internal method for adding failed attachments during processing. For internal use only - do not
+   * expose to external callers.
+   */
+  public void addFailedAttachment(Map<String, String> failure) {
+    failedAttachments.add(failure);
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
@@ -14,6 +14,7 @@ public class AttachmentMoveContext {
   private final CdsEntity targetEntity;
   private final AttachmentProcessingResults processingResults;
   private final List<Map<String, String>> failedAttachments;
+  private List<String> invalidProperties; // Mutable field to track validation failures
 
   public AttachmentMoveContext(
       String objectId,
@@ -58,6 +59,14 @@ public class AttachmentMoveContext {
 
   public List<Map<String, String>> getFailedAttachments() {
     return Collections.unmodifiableList(failedAttachments);
+  }
+
+  public List<String> getInvalidProperties() {
+    return invalidProperties;
+  }
+
+  public void setInvalidProperties(List<String> invalidProperties) {
+    this.invalidProperties = invalidProperties;
   }
 
   /**

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentMoveContext.java
@@ -1,6 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +57,6 @@ public class AttachmentMoveContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    return failedAttachments;
+    return Collections.unmodifiableList(failedAttachments);
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentProcessingResults.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentProcessingResults.java
@@ -1,0 +1,31 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+
+/** Helper class to hold attachment processing results. */
+public class AttachmentProcessingResults {
+  private final List<String> successfulObjectIds;
+  private final List<List<String>> movedAttachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+
+  public AttachmentProcessingResults(
+      List<String> successfulObjectIds,
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments) {
+    this.successfulObjectIds = successfulObjectIds;
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+  }
+
+  public List<String> getSuccessfulObjectIds() {
+    return successfulObjectIds;
+  }
+
+  public List<List<String>> getMovedAttachmentsMetadata() {
+    return movedAttachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
@@ -19,6 +19,7 @@ public class CmisDocument {
   private InputStream content;
   private String parentId;
   private String folderId;
+  private String sourceFolderId;
   private String repositoryId;
   private String status;
   private String mimeType;

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CmisDocument.java
@@ -2,6 +2,7 @@ package com.sap.cds.sdm.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.InputStream;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,4 +29,5 @@ public class CmisDocument {
   private String url;
   private String contentId;
   private String type;
+  private Map<String, Object> secondaryProperties;
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentsResult.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/CopyAttachmentsResult.java
@@ -1,0 +1,24 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+import java.util.Map;
+
+/** Result class for copyAttachmentsToSDM method. */
+public class CopyAttachmentsResult {
+  private final List<Map<String, String>> attachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+
+  public CopyAttachmentsResult(
+      List<Map<String, String>> attachmentsMetadata, List<CmisDocument> populatedDocuments) {
+    this.attachmentsMetadata = attachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+  }
+
+  public List<Map<String, String>> getAttachmentsMetadata() {
+    return attachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
@@ -1,7 +1,6 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -64,8 +63,6 @@ public class DatabaseFailureContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    // Return an unmodifiable list with each map also wrapped as unmodifiable for deep immutability
-    return Collections.unmodifiableList(
-        failedAttachments.stream().map(Collections::unmodifiableMap).toList());
+    return failedAttachments;
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
@@ -1,6 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -63,6 +64,14 @@ public class DatabaseFailureContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    return failedAttachments;
+    return Collections.unmodifiableList(failedAttachments);
+  }
+
+  /**
+   * Internal method for adding failed attachments during processing. For internal use only - do not
+   * expose to external callers.
+   */
+  public void addFailedAttachment(Map<String, String> failure) {
+    failedAttachments.add(failure);
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
@@ -1,6 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -63,6 +64,8 @@ public class DatabaseFailureContext {
   }
 
   public List<Map<String, String>> getFailedAttachments() {
-    return failedAttachments;
+    // Return an unmodifiable list with each map also wrapped as unmodifiable for deep immutability
+    return Collections.unmodifiableList(
+        failedAttachments.stream().map(Collections::unmodifiableMap).toList());
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseFailureContext.java
@@ -1,0 +1,68 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import java.util.List;
+import java.util.Map;
+
+/** Helper class to hold database failure context information. */
+public class DatabaseFailureContext {
+  private final List<String> successfulObjectIds;
+  private final String sourceFolderId;
+  private final String targetFolderId;
+  private final String repositoryId;
+  private final SDMCredentials sdmCredentials;
+  private final Boolean isSystemUser;
+  private final AttachmentMoveEventContext context;
+  private final List<Map<String, String>> failedAttachments;
+
+  public DatabaseFailureContext(
+      List<String> successfulObjectIds,
+      String sourceFolderId,
+      String targetFolderId,
+      String repositoryId,
+      SDMCredentials sdmCredentials,
+      Boolean isSystemUser,
+      AttachmentMoveEventContext context,
+      List<Map<String, String>> failedAttachments) {
+    this.successfulObjectIds = successfulObjectIds;
+    this.sourceFolderId = sourceFolderId;
+    this.targetFolderId = targetFolderId;
+    this.repositoryId = repositoryId;
+    this.sdmCredentials = sdmCredentials;
+    this.isSystemUser = isSystemUser;
+    this.context = context;
+    this.failedAttachments = failedAttachments;
+  }
+
+  public List<String> getSuccessfulObjectIds() {
+    return successfulObjectIds;
+  }
+
+  public String getSourceFolderId() {
+    return sourceFolderId;
+  }
+
+  public String getTargetFolderId() {
+    return targetFolderId;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public SDMCredentials getSdmCredentials() {
+    return sdmCredentials;
+  }
+
+  public Boolean getIsSystemUser() {
+    return isSystemUser;
+  }
+
+  public AttachmentMoveEventContext getContext() {
+    return context;
+  }
+
+  public List<Map<String, String>> getFailedAttachments() {
+    return failedAttachments;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseUpdateRequest.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DatabaseUpdateRequest.java
@@ -1,0 +1,81 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import java.util.List;
+
+/** Request object encapsulating all parameters for database update and source cleanup. */
+public class DatabaseUpdateRequest {
+  private final List<List<String>> movedAttachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+  private final String parentEntity;
+  private final String compositionName;
+  private final String upID;
+  private final String upIdKey;
+  private final String repositoryId;
+  private final String folderId;
+  private final List<String> successfulObjectIds;
+  private final AttachmentMoveEventContext context;
+
+  public DatabaseUpdateRequest(
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      String upIdKey,
+      String repositoryId,
+      String folderId,
+      List<String> successfulObjectIds,
+      AttachmentMoveEventContext context) {
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+    this.parentEntity = parentEntity;
+    this.compositionName = compositionName;
+    this.upID = upID;
+    this.upIdKey = upIdKey;
+    this.repositoryId = repositoryId;
+    this.folderId = folderId;
+    this.successfulObjectIds = successfulObjectIds;
+    this.context = context;
+  }
+
+  public List<List<String>> getMovedAttachmentsMetadata() {
+    return movedAttachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+
+  public String getParentEntity() {
+    return parentEntity;
+  }
+
+  public String getCompositionName() {
+    return compositionName;
+  }
+
+  public String getUpID() {
+    return upID;
+  }
+
+  public String getUpIdKey() {
+    return upIdKey;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public String getFolderId() {
+    return folderId;
+  }
+
+  public List<String> getSuccessfulObjectIds() {
+    return successfulObjectIds;
+  }
+
+  public AttachmentMoveEventContext getContext() {
+    return context;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/DraftEntryMoveData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/DraftEntryMoveData.java
@@ -1,0 +1,66 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+
+/** Helper class to encapsulate draft entry creation parameters for move operations. */
+public class DraftEntryMoveData {
+  private final List<List<String>> movedAttachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+  private final String parentEntity;
+  private final String compositionName;
+  private final String upID;
+  private final String upIdKey;
+  private final String repositoryId;
+  private final String folderId;
+
+  public DraftEntryMoveData(
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      String upIdKey,
+      String repositoryId,
+      String folderId) {
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+    this.parentEntity = parentEntity;
+    this.compositionName = compositionName;
+    this.upID = upID;
+    this.upIdKey = upIdKey;
+    this.repositoryId = repositoryId;
+    this.folderId = folderId;
+  }
+
+  public List<List<String>> getMovedAttachmentsMetadata() {
+    return movedAttachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+
+  public String getParentEntity() {
+    return parentEntity;
+  }
+
+  public String getCompositionName() {
+    return compositionName;
+  }
+
+  public String getUpID() {
+    return upID;
+  }
+
+  public String getUpIdKey() {
+    return upIdKey;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public String getFolderId() {
+    return folderId;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
@@ -1,22 +1,46 @@
 package com.sap.cds.sdm.model;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The class {@link MoveAttachmentInput} is used to store the input for moving attachments. This
  * model supports both regular entities and projection entities by using facet-based navigation.
  *
  * @param sourceFolderId The folder ID in SDM from which attachments should be moved
- * @param sourceFacet The full facet path of the source entity (e.g., "Service.Entity.composition")
- *     that will be internally parsed to determine source parent entity and composition name for
- *     cleanup
  * @param targetUpId The key of the target parent entity instance
  * @param targetFacet The qualified name of the target facet/entity (e.g., "Service.Attachments")
  * @param objectIds List of attachment object IDs to move
+ * @param sourceFacet Optional full facet path of the source entity (e.g.,
+ *     "Service.Entity.composition") that will be internally parsed to determine source parent
+ *     entity and composition name for cleanup. If not provided, no source cleanup will be
+ *     performed.
  */
 public record MoveAttachmentInput(
     String sourceFolderId,
-    String sourceFacet,
     String targetUpId,
     String targetFacet,
-    List<String> objectIds) {}
+    List<String> objectIds,
+    Optional<String> sourceFacet) {
+
+  /** Constructor for when sourceFacet is omitted entirely. Defaults to Optional.empty(). */
+  public MoveAttachmentInput(
+      String sourceFolderId, String targetUpId, String targetFacet, List<String> objectIds) {
+    this(sourceFolderId, targetUpId, targetFacet, objectIds, Optional.empty());
+  }
+
+  /**
+   * Constructor that accepts a plain String for sourceFacet and wraps it in Optional. This allows
+   * UI/OData callers to pass a simple string value (or null) which will be automatically converted
+   * to Optional.
+   */
+  public MoveAttachmentInput(
+      String sourceFolderId,
+      String targetUpId,
+      String targetFacet,
+      List<String> objectIds,
+      String sourceFacetString) {
+    this(
+        sourceFolderId, targetUpId, targetFacet, objectIds, Optional.ofNullable(sourceFacetString));
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
@@ -7,10 +7,17 @@ import java.util.List;
  * model supports both regular entities and projection entities by using facet-based navigation.
  *
  * @param sourceFolderId The folder ID in SDM from which attachments should be moved
+ * @param sourceFacet The full facet path of the source entity (e.g., "Service.Entity.composition")
+ *     that will be internally parsed to determine source parent entity and composition name for
+ *     cleanup
  * @param upId The key of the target parent entity instance
  * @param targetFacet The full facet path (e.g., "Service.Entity.composition") that will be
  *     internally parsed to determine target parent entity and composition name
  * @param objectIds The list of attachment object IDs to be moved
  */
 public record MoveAttachmentInput(
-    String sourceFolderId, String upId, String targetFacet, List<String> objectIds) {}
+    String sourceFolderId,
+    String sourceFacet,
+    String upId,
+    String targetFacet,
+    List<String> objectIds) {}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @param sourceFacet The full facet path of the source entity (e.g., "Service.Entity.composition")
  *     that will be internally parsed to determine source parent entity and composition name for
  *     cleanup
- * @param upId The key of the target parent entity instance
+ * @param targetUpId The key of the target parent entity instance
  * @param targetFacet The qualified name of the target facet/entity (e.g., "Service.Attachments")
  * @param objectIds List of attachment object IDs to move
  */

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
@@ -1,0 +1,16 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+
+/**
+ * The class {@link MoveAttachmentInput} is used to store the input for moving attachments. This
+ * model supports both regular entities and projection entities by using facet-based navigation.
+ *
+ * @param sourceFolderId The folder ID in SDM from which attachments should be moved
+ * @param upId The key of the target parent entity instance
+ * @param targetFacet The full facet path (e.g., "Service.Entity.composition") that will be
+ *     internally parsed to determine target parent entity and composition name
+ * @param objectIds The list of attachment object IDs to be moved
+ */
+public record MoveAttachmentInput(
+    String sourceFolderId, String upId, String targetFacet, List<String> objectIds) {}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentInput.java
@@ -11,13 +11,12 @@ import java.util.List;
  *     that will be internally parsed to determine source parent entity and composition name for
  *     cleanup
  * @param upId The key of the target parent entity instance
- * @param targetFacet The full facet path (e.g., "Service.Entity.composition") that will be
- *     internally parsed to determine target parent entity and composition name
- * @param objectIds The list of attachment object IDs to be moved
+ * @param targetFacet The qualified name of the target facet/entity (e.g., "Service.Attachments")
+ * @param objectIds List of attachment object IDs to move
  */
 public record MoveAttachmentInput(
     String sourceFolderId,
     String sourceFacet,
-    String upId,
+    String targetUpId,
     String targetFacet,
     List<String> objectIds) {}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentsRequest.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentsRequest.java
@@ -1,0 +1,122 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import java.util.List;
+
+/**
+ * Parameter object for moveAttachmentsInSDM method to reduce parameter count and improve code
+ * maintainability.
+ */
+public class MoveAttachmentsRequest {
+  private final AttachmentMoveEventContext context;
+  private final String sourceFolderId;
+  private final List<String> objectIds;
+  private final String targetFolderId;
+  private final String repositoryId;
+  private final SDMCredentials sdmCredentials;
+  private final Boolean isSystemUser;
+  private final boolean targetFolderExists;
+
+  private MoveAttachmentsRequest(Builder builder) {
+    this.context = builder.context;
+    this.sourceFolderId = builder.sourceFolderId;
+    this.objectIds = builder.objectIds;
+    this.targetFolderId = builder.targetFolderId;
+    this.repositoryId = builder.repositoryId;
+    this.sdmCredentials = builder.sdmCredentials;
+    this.isSystemUser = builder.isSystemUser;
+    this.targetFolderExists = builder.targetFolderExists;
+  }
+
+  // Getters
+  public AttachmentMoveEventContext getContext() {
+    return context;
+  }
+
+  public String getSourceFolderId() {
+    return sourceFolderId;
+  }
+
+  public List<String> getObjectIds() {
+    return objectIds;
+  }
+
+  public String getTargetFolderId() {
+    return targetFolderId;
+  }
+
+  public String getRepositoryId() {
+    return repositoryId;
+  }
+
+  public SDMCredentials getSdmCredentials() {
+    return sdmCredentials;
+  }
+
+  public Boolean getIsSystemUser() {
+    return isSystemUser;
+  }
+
+  public boolean isTargetFolderExists() {
+    return targetFolderExists;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private AttachmentMoveEventContext context;
+    private String sourceFolderId;
+    private List<String> objectIds;
+    private String targetFolderId;
+    private String repositoryId;
+    private SDMCredentials sdmCredentials;
+    private Boolean isSystemUser;
+    private boolean targetFolderExists;
+
+    public Builder context(AttachmentMoveEventContext context) {
+      this.context = context;
+      return this;
+    }
+
+    public Builder sourceFolderId(String sourceFolderId) {
+      this.sourceFolderId = sourceFolderId;
+      return this;
+    }
+
+    public Builder objectIds(List<String> objectIds) {
+      this.objectIds = objectIds;
+      return this;
+    }
+
+    public Builder targetFolderId(String targetFolderId) {
+      this.targetFolderId = targetFolderId;
+      return this;
+    }
+
+    public Builder repositoryId(String repositoryId) {
+      this.repositoryId = repositoryId;
+      return this;
+    }
+
+    public Builder sdmCredentials(SDMCredentials sdmCredentials) {
+      this.sdmCredentials = sdmCredentials;
+      return this;
+    }
+
+    public Builder isSystemUser(Boolean isSystemUser) {
+      this.isSystemUser = isSystemUser;
+      return this;
+    }
+
+    public Builder targetFolderExists(boolean targetFolderExists) {
+      this.targetFolderExists = targetFolderExists;
+      return this;
+    }
+
+    public MoveAttachmentsRequest build() {
+      return new MoveAttachmentsRequest(this);
+    }
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentsResult.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/MoveAttachmentsResult.java
@@ -1,0 +1,42 @@
+package com.sap.cds.sdm.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encapsulates the result of a batch move operation in SDM. Contains metadata for successfully
+ * moved attachments and tracks failures.
+ */
+public class MoveAttachmentsResult {
+  private final List<List<String>> movedAttachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+  private final List<Map<String, String>> failedAttachments;
+  private final List<String> successfulObjectIds;
+
+  public MoveAttachmentsResult(
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      List<Map<String, String>> failedAttachments,
+      List<String> successfulObjectIds) {
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+    this.failedAttachments = failedAttachments;
+    this.successfulObjectIds = successfulObjectIds;
+  }
+
+  public List<List<String>> getMovedAttachmentsMetadata() {
+    return movedAttachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+
+  public List<Map<String, String>> getFailedAttachments() {
+    return failedAttachments;
+  }
+
+  public List<String> getSuccessfulObjectIds() {
+    return successfulObjectIds;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/SDMValidationData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/SDMValidationData.java
@@ -1,0 +1,33 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.reflect.CdsEntity;
+import java.util.List;
+import java.util.Map;
+
+/** Helper class to hold SDM validation data. */
+public class SDMValidationData {
+  private final List<String> validSecondaryProperties;
+  private final Map<String, String> entityAnnotations;
+  private final CdsEntity targetEntity;
+
+  public SDMValidationData(
+      List<String> validSecondaryProperties,
+      Map<String, String> entityAnnotations,
+      CdsEntity targetEntity) {
+    this.validSecondaryProperties = validSecondaryProperties;
+    this.entityAnnotations = entityAnnotations;
+    this.targetEntity = targetEntity;
+  }
+
+  public List<String> getValidSecondaryProperties() {
+    return validSecondaryProperties;
+  }
+
+  public Map<String, String> getEntityAnnotations() {
+    return entityAnnotations;
+  }
+
+  public CdsEntity getTargetEntity() {
+    return targetEntity;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/TargetFolderInfo.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/TargetFolderInfo.java
@@ -1,0 +1,20 @@
+package com.sap.cds.sdm.model;
+
+/** Helper class to hold target folder information. */
+public class TargetFolderInfo {
+  private final String targetFolderId;
+  private final Boolean targetFolderExists;
+
+  public TargetFolderInfo(String targetFolderId, Boolean targetFolderExists) {
+    this.targetFolderId = targetFolderId;
+    this.targetFolderExists = targetFolderExists;
+  }
+
+  public String getTargetFolderId() {
+    return targetFolderId;
+  }
+
+  public Boolean getTargetFolderExists() {
+    return targetFolderExists;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -1,0 +1,97 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.reflect.CdsEntity;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONObject;
+
+/** Helper class to encapsulate validated attachment data for processing. */
+public class ValidatedAttachmentData {
+  private final String objectId;
+  private final String fileName;
+  private final String mimeType;
+  private final String description;
+  private final String movedObjectId;
+  private final JSONObject succinctProperties;
+  private final Map<String, String> entityAnnotations;
+  private final CdsEntity targetEntity;
+  private final List<String> successfulObjectIds;
+  private final List<List<String>> movedAttachmentsMetadata;
+  private final List<CmisDocument> populatedDocuments;
+  private final CmisDocument sourceCmisDocument;
+
+  public ValidatedAttachmentData(
+      String objectId,
+      String fileName,
+      String mimeType,
+      String description,
+      String movedObjectId,
+      JSONObject succinctProperties,
+      Map<String, String> entityAnnotations,
+      CdsEntity targetEntity,
+      List<String> successfulObjectIds,
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      CmisDocument sourceCmisDocument) {
+    this.objectId = objectId;
+    this.fileName = fileName;
+    this.mimeType = mimeType;
+    this.description = description;
+    this.movedObjectId = movedObjectId;
+    this.succinctProperties = succinctProperties;
+    this.entityAnnotations = entityAnnotations;
+    this.targetEntity = targetEntity;
+    this.successfulObjectIds = successfulObjectIds;
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
+    this.sourceCmisDocument = sourceCmisDocument;
+  }
+
+  public String getObjectId() {
+    return objectId;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getMovedObjectId() {
+    return movedObjectId;
+  }
+
+  public JSONObject getSuccinctProperties() {
+    return succinctProperties;
+  }
+
+  public Map<String, String> getEntityAnnotations() {
+    return entityAnnotations;
+  }
+
+  public CdsEntity getTargetEntity() {
+    return targetEntity;
+  }
+
+  public List<String> getSuccessfulObjectIds() {
+    return successfulObjectIds;
+  }
+
+  public List<List<String>> getMovedAttachmentsMetadata() {
+    return movedAttachmentsMetadata;
+  }
+
+  public List<CmisDocument> getPopulatedDocuments() {
+    return populatedDocuments;
+  }
+
+  public CmisDocument getSourceCmisDocument() {
+    return sourceCmisDocument;
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -87,15 +87,15 @@ public class ValidatedAttachmentData {
   }
 
   public List<String> getSuccessfulObjectIds() {
-    return successfulObjectIds;
+    return List.copyOf(successfulObjectIds);
   }
 
   public List<List<String>> getMovedAttachmentsMetadata() {
-    return movedAttachmentsMetadata;
+    return Collections.unmodifiableList(movedAttachmentsMetadata);
   }
 
   public List<CmisDocument> getPopulatedDocuments() {
-    return populatedDocuments;
+    return Collections.unmodifiableList(populatedDocuments);
   }
 
   public CmisDocument getSourceCmisDocument() {

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -1,6 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
@@ -80,15 +81,39 @@ public class ValidatedAttachmentData {
   }
 
   public List<String> getSuccessfulObjectIds() {
-    return successfulObjectIds;
+    return Collections.unmodifiableList(successfulObjectIds);
   }
 
   public List<List<String>> getMovedAttachmentsMetadata() {
-    return movedAttachmentsMetadata;
+    return Collections.unmodifiableList(movedAttachmentsMetadata);
   }
 
   public List<CmisDocument> getPopulatedDocuments() {
-    return populatedDocuments;
+    return Collections.unmodifiableList(populatedDocuments);
+  }
+
+  /**
+   * Internal method for adding successful object IDs during processing. For internal use only - do
+   * not expose to external callers.
+   */
+  public void addSuccessfulObjectId(String objectId) {
+    successfulObjectIds.add(objectId);
+  }
+
+  /**
+   * Internal method for adding moved attachments metadata during processing. For internal use only
+   * - do not expose to external callers.
+   */
+  public void addMovedAttachmentMetadata(List<String> metadata) {
+    movedAttachmentsMetadata.add(metadata);
+  }
+
+  /**
+   * Internal method for adding populated documents during processing. For internal use only - do
+   * not expose to external callers.
+   */
+  public void addPopulatedDocument(CmisDocument document) {
+    populatedDocuments.add(document);
   }
 
   public CmisDocument getSourceCmisDocument() {

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -1,7 +1,7 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
-import java.util.Collections;
+import com.sap.cds.sdm.service.CmisDocument;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
@@ -81,15 +81,15 @@ public class ValidatedAttachmentData {
   }
 
   public List<String> getSuccessfulObjectIds() {
-    return List.copyOf(successfulObjectIds);
+    return successfulObjectIds;
   }
 
   public List<List<String>> getMovedAttachmentsMetadata() {
-    return Collections.unmodifiableList(movedAttachmentsMetadata);
+    return movedAttachmentsMetadata;
   }
 
   public List<CmisDocument> getPopulatedDocuments() {
-    return Collections.unmodifiableList(populatedDocuments);
+    return populatedDocuments;
   }
 
   public CmisDocument getSourceCmisDocument() {

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -4,7 +4,6 @@ import com.sap.cds.reflect.CdsEntity;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.json.JSONObject;
 
 /** Helper class to encapsulate validated attachment data for processing. */
@@ -43,14 +42,9 @@ public class ValidatedAttachmentData {
     this.succinctProperties = succinctProperties;
     this.entityAnnotations = entityAnnotations;
     this.targetEntity = targetEntity;
-    this.successfulObjectIds = List.copyOf(successfulObjectIds);
-    // Deep immutability: wrap outer list and each inner list as unmodifiable
-    this.movedAttachmentsMetadata =
-        Collections.unmodifiableList(
-            movedAttachmentsMetadata.stream()
-                .map(Collections::unmodifiableList)
-                .collect(Collectors.toList()));
-    this.populatedDocuments = List.copyOf(populatedDocuments);
+    this.successfulObjectIds = successfulObjectIds;
+    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+    this.populatedDocuments = populatedDocuments;
     this.sourceCmisDocument = sourceCmisDocument;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -1,8 +1,10 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.json.JSONObject;
 
 /** Helper class to encapsulate validated attachment data for processing. */
@@ -41,9 +43,14 @@ public class ValidatedAttachmentData {
     this.succinctProperties = succinctProperties;
     this.entityAnnotations = entityAnnotations;
     this.targetEntity = targetEntity;
-    this.successfulObjectIds = successfulObjectIds;
-    this.movedAttachmentsMetadata = movedAttachmentsMetadata;
-    this.populatedDocuments = populatedDocuments;
+    this.successfulObjectIds = List.copyOf(successfulObjectIds);
+    // Deep immutability: wrap outer list and each inner list as unmodifiable
+    this.movedAttachmentsMetadata =
+        Collections.unmodifiableList(
+            movedAttachmentsMetadata.stream()
+                .map(Collections::unmodifiableList)
+                .collect(Collectors.toList()));
+    this.populatedDocuments = List.copyOf(populatedDocuments);
     this.sourceCmisDocument = sourceCmisDocument;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/ValidatedAttachmentData.java
@@ -1,7 +1,6 @@
 package com.sap.cds.sdm.model;
 
 import com.sap.cds.reflect.CdsEntity;
-import com.sap.cds.sdm.service.CmisDocument;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -379,14 +379,15 @@ public class DBQuery {
       return 0;
     }
 
-    // Get the target entity of the composition
+    // Get the target entity of the composition (this is the SOURCE attachment entity)
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
-    String targetEntityName = assocType.getTarget().getQualifiedName();
+    String sourceAttachmentEntityName = assocType.getTarget().getQualifiedName();
 
     int deletedCount = 0;
 
     // Try deleting from draft table first
-    Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+    Optional<CdsEntity> attachmentDraftEntity =
+        model.findEntity(sourceAttachmentEntityName + "_drafts");
     if (attachmentDraftEntity.isPresent()) {
       var deleteQuery =
           Delete.from(attachmentDraftEntity.get())
@@ -394,14 +395,14 @@ public class DBQuery {
       Result result = persistenceService.run(deleteQuery);
       deletedCount += result.rowCount();
       logger.info(
-          "Deleted {} attachment records from draft table '{}' for objectIds: {}",
+          "Deleted {} attachment records from SOURCE draft table '{}' for objectIds: {}",
           result.rowCount(),
-          targetEntityName + "_drafts",
+          sourceAttachmentEntityName + "_drafts",
           objectIds);
     }
 
     // Try deleting from non-draft table
-    Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    Optional<CdsEntity> attachmentEntity = model.findEntity(sourceAttachmentEntityName);
     if (attachmentEntity.isPresent()) {
       var deleteQuery =
           Delete.from(attachmentEntity.get())
@@ -409,9 +410,9 @@ public class DBQuery {
       Result result = persistenceService.run(deleteQuery);
       deletedCount += result.rowCount();
       logger.info(
-          "Deleted {} attachment records from table '{}' for objectIds: {}",
+          "Deleted {} attachment records from SOURCE table '{}' for objectIds: {}",
           result.rowCount(),
-          targetEntityName,
+          sourceAttachmentEntityName,
           objectIds);
     }
 
@@ -419,7 +420,7 @@ public class DBQuery {
       logger.warn(
           "No attachment metadata found in source entity '{}' for objectIds: {}. This may indicate"
               + " the records were already cleaned up.",
-          targetEntityName,
+          sourceAttachmentEntityName,
           objectIds);
     }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -16,9 +16,11 @@ import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
 import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
+import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.util.*;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,10 +174,21 @@ public class DBQuery {
           String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
     }
 
-    // Search in active entity first
+    // Get secondary type properties (annotated with @SDM.Attachments.AdditionalProperty)
+    // to determine which columns to retrieve from database
+    Map<String, String> secondaryTypeProperties =
+        SDMUtils.getSecondaryTypeProperties(attachmentEntity, new HashMap<>());
+
+    // Build column list: standard fields (type, linkUrl) + annotated secondary properties
+    List<String> columnsToRetrieve = new ArrayList<>();
+    columnsToRetrieve.add("type");
+    columnsToRetrieve.add("linkUrl");
+    columnsToRetrieve.addAll(secondaryTypeProperties.keySet());
+
+    // Retrieve only the needed columns from database
     CqnSelect q =
         Select.from(attachmentEntity.get())
-            .columns("linkUrl", "type")
+            .columns(columnsToRetrieve.toArray(new String[0]))
             .where(doc -> doc.get("objectId").eq(id));
     Result result = persistenceService.run(q);
     Optional<Row> res = result.first();
@@ -185,13 +198,22 @@ public class DBQuery {
       Row row = res.get();
       cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
       cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+      // Store only the secondary properties (no standard fields)
+      Map<String, Object> secondaryProps = new HashMap<>();
+      for (String propertyKey : secondaryTypeProperties.keySet()) {
+        Object value = row.get(propertyKey);
+        if (value != null) {
+          secondaryProps.put(propertyKey, value);
+        }
+      }
+      cmisDocument.setSecondaryProperties(secondaryProps);
     } else {
       // Check in draft table as well
       Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
       if (attachmentDraftEntity.isPresent()) {
         q =
             Select.from(attachmentDraftEntity.get())
-                .columns("linkUrl", "type")
+                .columns(columnsToRetrieve.toArray(new String[0]))
                 .where(doc -> doc.get("objectId").eq(id));
         result = persistenceService.run(q);
         res = result.first();
@@ -199,6 +221,15 @@ public class DBQuery {
           Row row = res.get();
           cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
           cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+          // Store only the secondary properties (no standard fields)
+          Map<String, Object> secondaryProps = new HashMap<>();
+          for (String propertyKey : secondaryTypeProperties.keySet()) {
+            Object value = row.get(propertyKey);
+            if (value != null) {
+              secondaryProps.put(propertyKey, value);
+            }
+          }
+          cmisDocument.setSecondaryProperties(secondaryProps);
         }
       }
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -366,7 +366,7 @@ public class DBQuery {
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
     String sourceAttachmentEntityName = assocType.getTarget().getQualifiedName();
 
-    int deletedCount = 0;
+    long deletedCount = 0;
 
     // Resolve the up__ID key name
     String upIdKey = resolveUpIdKey(model, sourceParentEntity, sourceCompositionName);

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -16,7 +16,6 @@ import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
 import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
-import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.util.*;
@@ -146,7 +145,8 @@ public class DBQuery {
    * properties from SDM should be persisted to the database.
    *
    * @param context The move event context containing target entity information
-   * @return Map of valid secondary property names and their SDM property names
+   * @return Map of DB field name to SDM property name for properties annotated
+   *     with @SDM.Attachments.AdditionalProperty
    */
   public Map<String, String> getValidSecondaryPropertiesForMove(
       AttachmentMoveEventContext context) {
@@ -174,15 +174,57 @@ public class DBQuery {
     CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
     String targetEntityName = assocType.getTarget().getQualifiedName();
 
-    // Find the target attachment entity
+    // Find the target attachment entity (check both draft and non-draft)
     Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
     if (attachmentEntity.isEmpty()) {
-      throw new ServiceException(
-          String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
+      // Try with _drafts suffix
+      attachmentEntity = model.findEntity(targetEntityName + "_drafts");
+      if (attachmentEntity.isEmpty()) {
+        throw new ServiceException(
+            String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
+      }
     }
 
-    // Get secondary type properties (annotated with @SDM.Attachments.AdditionalProperty)
-    return SDMUtils.getSecondaryTypeProperties(attachmentEntity, new HashMap<>());
+    // Manually iterate over all elements to find those with @SDM.Attachments.AdditionalProperty
+    // annotation
+    Map<String, String> secondaryProperties = new HashMap<>();
+    CdsEntity entity = attachmentEntity.get();
+
+    entity
+        .elements()
+        .forEach(
+            element -> {
+              // Check for @SDM.Attachments.AdditionalProperty annotation
+              Optional<com.sap.cds.reflect.CdsAnnotation<Object>> annotation =
+                  element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY);
+              Optional<com.sap.cds.reflect.CdsAnnotation<Object>> nameAnnotation =
+                  element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME);
+
+              if (annotation.isPresent()) {
+                // Old annotation style: use element name as SDM property name
+                secondaryProperties.put(element.getName(), element.getName());
+                logger.debug(
+                    "Found secondary property (old style): DB field '{}' -> SDM property '{}'",
+                    element.getName(),
+                    element.getName());
+              } else if (nameAnnotation.isPresent()) {
+                // New annotation style: use specified SDM property name
+                String sdmPropertyName = nameAnnotation.get().getValue().toString();
+                secondaryProperties.put(element.getName(), sdmPropertyName);
+                logger.debug(
+                    "Found secondary property (new style): DB field '{}' -> SDM property '{}'",
+                    element.getName(),
+                    sdmPropertyName);
+              }
+            });
+
+    logger.info(
+        "Resolved {} secondary properties from target entity '{}': {}",
+        secondaryProperties.size(),
+        targetEntityName,
+        secondaryProperties);
+
+    return secondaryProperties;
   }
 
   public Result getAttachmentsForUPIDAndRepository(

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -227,6 +227,75 @@ public class DBQuery {
     return secondaryProperties;
   }
 
+  /**
+   * Retrieves valid secondary properties and the target entity for the move operation.
+   *
+   * @param context The move event context containing target entity information
+   * @return Object array with [0] = Map of DB field to SDM property, [1] = CdsEntity
+   */
+  public Object[] getValidSecondaryPropertiesWithEntity(AttachmentMoveEventContext context) {
+    String parentEntity = context.getParentEntity();
+    String compositionName = context.getCompositionName();
+    CdsModel model = context.getModel();
+
+    // Find the parent entity
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      throw new ServiceException(
+          String.format(SDMConstants.PARENT_ENTITY_NOT_FOUND_ERROR, parentEntity));
+    }
+
+    // Find the composition element
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(compositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      throw new ServiceException(
+          String.format(SDMConstants.COMPOSITION_NOT_FOUND_ERROR, compositionName, parentEntity));
+    }
+
+    // Get the target entity
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+
+    // Find the target attachment entity
+    Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    if (attachmentEntity.isEmpty()) {
+      attachmentEntity = model.findEntity(targetEntityName + "_drafts");
+      if (attachmentEntity.isEmpty()) {
+        throw new ServiceException(
+            String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
+      }
+    }
+
+    CdsEntity entity = attachmentEntity.get();
+
+    // Get secondary properties annotations
+    Map<String, String> secondaryProperties = new HashMap<>();
+    entity
+        .elements()
+        .forEach(
+            element -> {
+              Optional<com.sap.cds.reflect.CdsAnnotation<Object>> annotation =
+                  element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY);
+              Optional<com.sap.cds.reflect.CdsAnnotation<Object>> nameAnnotation =
+                  element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME);
+
+              if (annotation.isPresent()) {
+                secondaryProperties.put(element.getName(), element.getName());
+              } else if (nameAnnotation.isPresent()) {
+                String sdmPropertyName = nameAnnotation.get().getValue().toString();
+                secondaryProperties.put(element.getName(), sdmPropertyName);
+              }
+            });
+
+    logger.info(
+        "Resolved {} secondary properties from target entity '{}'",
+        secondaryProperties.size(),
+        targetEntityName);
+
+    return new Object[] {secondaryProperties, entity};
+  }
+
   public Result getAttachmentsForUPIDAndRepository(
       CdsEntity attachmentEntity,
       PersistenceService persistenceService,

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -14,6 +14,7 @@ import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.util.*;
@@ -70,6 +71,72 @@ public class DBQuery {
   public CmisDocument getAttachmentForObjectID(
       PersistenceService persistenceService, String id, AttachmentCopyEventContext context) {
 
+    // Use the new API to resolve the target attachment entity
+    String parentEntity = context.getParentEntity();
+    String compositionName = context.getCompositionName();
+    CdsModel model = context.getModel();
+
+    // Find the parent entity
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      throw new ServiceException(
+          String.format(SDMConstants.PARENT_ENTITY_NOT_FOUND_ERROR, parentEntity));
+    }
+
+    // Find the composition element in the parent entity
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(compositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      throw new ServiceException(
+          String.format(SDMConstants.COMPOSITION_NOT_FOUND_ERROR, compositionName, parentEntity));
+    }
+
+    // Get the target entity of the composition
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+
+    // Find the target attachment entity
+    Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    if (attachmentEntity.isEmpty()) {
+      throw new ServiceException(
+          String.format(SDMConstants.TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR, targetEntityName));
+    }
+
+    // Search in active entity first
+    CqnSelect q =
+        Select.from(attachmentEntity.get())
+            .columns("linkUrl", "type")
+            .where(doc -> doc.get("objectId").eq(id));
+    Result result = persistenceService.run(q);
+    Optional<Row> res = result.first();
+
+    CmisDocument cmisDocument = new CmisDocument();
+    if (res.isPresent()) {
+      Row row = res.get();
+      cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
+      cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+    } else {
+      // Check in draft table as well
+      Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+      if (attachmentDraftEntity.isPresent()) {
+        q =
+            Select.from(attachmentDraftEntity.get())
+                .columns("linkUrl", "type")
+                .where(doc -> doc.get("objectId").eq(id));
+        result = persistenceService.run(q);
+        res = result.first();
+        if (res.isPresent()) {
+          Row row = res.get();
+          cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
+          cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
+        }
+      }
+    }
+    return cmisDocument;
+  }
+
+  public CmisDocument getAttachmentForObjectID(
+      PersistenceService persistenceService, String id, AttachmentMoveEventContext context) {
     // Use the new API to resolve the target attachment entity
     String parentEntity = context.getParentEntity();
     String compositionName = context.getCompositionName();

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -3,6 +3,7 @@ package com.sap.cds.sdm.persistence;
 import com.sap.cds.Result;
 import com.sap.cds.Row;
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentMarkAsDeletedEventContext;
+import com.sap.cds.ql.Delete;
 import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.cqn.CqnSelect;
@@ -18,10 +19,13 @@ import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DBQuery {
 
   private static DBQuery dbQueryInstance = new DBQuery();
+  private static final Logger logger = LoggerFactory.getLogger(DBQuery.class);
 
   private DBQuery() {
     // Singleton pattern
@@ -324,5 +328,101 @@ public class DBQuery {
       propertyValueMap.put(mapKey, value != null ? value.toString() : null);
     }
     return propertyValueMap;
+  }
+
+  /**
+   * Deletes attachment metadata from the source entity (both draft and non-draft tables) for the
+   * given list of object IDs. This is used to clean up source entity after successful moves.
+   *
+   * @param persistenceService The persistence service to execute the delete
+   * @param objectIds The list of object IDs to delete
+   * @param context The move event context containing source entity information
+   * @return The number of records deleted
+   */
+  public int deleteAttachmentsByObjectIds(
+      PersistenceService persistenceService,
+      List<String> objectIds,
+      AttachmentMoveEventContext context) {
+    if (objectIds == null || objectIds.isEmpty()) {
+      return 0;
+    }
+
+    String sourceParentEntity = context.getSourceParentEntity();
+    String sourceCompositionName = context.getSourceCompositionName();
+
+    // If source entity info is not provided, skip cleanup
+    if (sourceParentEntity == null || sourceCompositionName == null) {
+      logger.warn(
+          "Source entity information not provided. Skipping metadata cleanup for {} attachments.",
+          objectIds.size());
+      return 0;
+    }
+
+    CdsModel model = context.getModel();
+
+    // Find the source parent entity
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(sourceParentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      logger.error(
+          "Unable to find source parent entity: {}. Skipping cleanup.", sourceParentEntity);
+      return 0;
+    }
+
+    // Find the composition element in the source parent entity
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(sourceCompositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      logger.error(
+          "Unable to find composition '{}' in source entity: {}. Skipping cleanup.",
+          sourceCompositionName,
+          sourceParentEntity);
+      return 0;
+    }
+
+    // Get the target entity of the composition
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+
+    int deletedCount = 0;
+
+    // Try deleting from draft table first
+    Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+    if (attachmentDraftEntity.isPresent()) {
+      var deleteQuery =
+          Delete.from(attachmentDraftEntity.get())
+              .where(doc -> doc.get("objectId").in(objectIds.toArray()));
+      Result result = persistenceService.run(deleteQuery);
+      deletedCount += result.rowCount();
+      logger.info(
+          "Deleted {} attachment records from draft table '{}' for objectIds: {}",
+          result.rowCount(),
+          targetEntityName + "_drafts",
+          objectIds);
+    }
+
+    // Try deleting from non-draft table
+    Optional<CdsEntity> attachmentEntity = model.findEntity(targetEntityName);
+    if (attachmentEntity.isPresent()) {
+      var deleteQuery =
+          Delete.from(attachmentEntity.get())
+              .where(doc -> doc.get("objectId").in(objectIds.toArray()));
+      Result result = persistenceService.run(deleteQuery);
+      deletedCount += result.rowCount();
+      logger.info(
+          "Deleted {} attachment records from table '{}' for objectIds: {}",
+          result.rowCount(),
+          targetEntityName,
+          objectIds);
+    }
+
+    if (deletedCount == 0) {
+      logger.warn(
+          "No attachment metadata found in source entity '{}' for objectIds: {}. This may indicate"
+              + " the records were already cleaned up.",
+          targetEntityName,
+          objectIds);
+    }
+
+    return deletedCount;
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -321,7 +321,7 @@ public class DBQuery {
    * @param context The move event context containing source entity information
    * @return The number of records deleted
    */
-  public int deleteAttachmentsByObjectIds(
+  public long deleteAttachmentsByObjectIds(
       PersistenceService persistenceService,
       List<String> objectIds,
       String sourceUpId,

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -141,9 +141,16 @@ public class DBQuery {
     return cmisDocument;
   }
 
-  public CmisDocument getAttachmentForObjectID(
-      PersistenceService persistenceService, String id, AttachmentMoveEventContext context) {
-    // Use the new API to resolve the target attachment entity
+  /**
+   * Retrieves valid secondary properties for the target attachment entity. Used to determine which
+   * properties from SDM should be persisted to the database.
+   *
+   * @param context The move event context containing target entity information
+   * @return Map of valid secondary property names and their SDM property names
+   */
+  public Map<String, String> getValidSecondaryPropertiesForMove(
+      AttachmentMoveEventContext context) {
+    // Use target entity to determine which secondary properties are valid
     String parentEntity = context.getParentEntity();
     String compositionName = context.getCompositionName();
     CdsModel model = context.getModel();
@@ -175,65 +182,7 @@ public class DBQuery {
     }
 
     // Get secondary type properties (annotated with @SDM.Attachments.AdditionalProperty)
-    // to determine which columns to retrieve from database
-    Map<String, String> secondaryTypeProperties =
-        SDMUtils.getSecondaryTypeProperties(attachmentEntity, new HashMap<>());
-
-    // Build column list: standard fields (type, linkUrl) + annotated secondary properties
-    List<String> columnsToRetrieve = new ArrayList<>();
-    columnsToRetrieve.add("type");
-    columnsToRetrieve.add("linkUrl");
-    columnsToRetrieve.addAll(secondaryTypeProperties.keySet());
-
-    // Retrieve only the needed columns from database
-    CqnSelect q =
-        Select.from(attachmentEntity.get())
-            .columns(columnsToRetrieve.toArray(new String[0]))
-            .where(doc -> doc.get("objectId").eq(id));
-    Result result = persistenceService.run(q);
-    Optional<Row> res = result.first();
-
-    CmisDocument cmisDocument = new CmisDocument();
-    if (res.isPresent()) {
-      Row row = res.get();
-      cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
-      cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
-      // Store only the secondary properties (no standard fields)
-      Map<String, Object> secondaryProps = new HashMap<>();
-      for (String propertyKey : secondaryTypeProperties.keySet()) {
-        Object value = row.get(propertyKey);
-        if (value != null) {
-          secondaryProps.put(propertyKey, value);
-        }
-      }
-      cmisDocument.setSecondaryProperties(secondaryProps);
-    } else {
-      // Check in draft table as well
-      Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
-      if (attachmentDraftEntity.isPresent()) {
-        q =
-            Select.from(attachmentDraftEntity.get())
-                .columns(columnsToRetrieve.toArray(new String[0]))
-                .where(doc -> doc.get("objectId").eq(id));
-        result = persistenceService.run(q);
-        res = result.first();
-        if (res.isPresent()) {
-          Row row = res.get();
-          cmisDocument.setType(row.get("type") != null ? row.get("type").toString() : null);
-          cmisDocument.setUrl(row.get("linkUrl") != null ? row.get("linkUrl").toString() : null);
-          // Store only the secondary properties (no standard fields)
-          Map<String, Object> secondaryProps = new HashMap<>();
-          for (String propertyKey : secondaryTypeProperties.keySet()) {
-            Object value = row.get(propertyKey);
-            if (value != null) {
-              secondaryProps.put(propertyKey, value);
-            }
-          }
-          cmisDocument.setSecondaryProperties(secondaryProps);
-        }
-      }
-    }
-    return cmisDocument;
+    return SDMUtils.getSecondaryTypeProperties(attachmentEntity, new HashMap<>());
   }
 
   public Result getAttachmentsForUPIDAndRepository(

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -336,12 +336,15 @@ public class DBQuery {
    *
    * @param persistenceService The persistence service to execute the delete
    * @param objectIds The list of object IDs to delete
+   * @param sourceUpId The up__ID of the source entity to filter deletions (critical when source and
+   *     target are same entity type)
    * @param context The move event context containing source entity information
    * @return The number of records deleted
    */
   public int deleteAttachmentsByObjectIds(
       PersistenceService persistenceService,
       List<String> objectIds,
+      String sourceUpId,
       AttachmentMoveEventContext context) {
     if (objectIds == null || objectIds.isEmpty()) {
       return 0;
@@ -385,13 +388,26 @@ public class DBQuery {
 
     int deletedCount = 0;
 
+    // Resolve the up__ID key name
+    String upIdKey = resolveUpIdKey(model, sourceParentEntity, sourceCompositionName);
+    if (upIdKey == null) {
+      logger.error(
+          "Unable to resolve up__ID key for source entity: {}. Skipping cleanup.",
+          sourceParentEntity);
+      return 0;
+    }
+
     // Try deleting from draft table first
     Optional<CdsEntity> attachmentDraftEntity =
         model.findEntity(sourceAttachmentEntityName + "_drafts");
     if (attachmentDraftEntity.isPresent()) {
       var deleteQuery =
           Delete.from(attachmentDraftEntity.get())
-              .where(doc -> doc.get("objectId").in(objectIds.toArray()));
+              .where(
+                  doc ->
+                      doc.get("objectId")
+                          .in(objectIds.toArray())
+                          .and(doc.get(upIdKey).eq(sourceUpId)));
       Result result = persistenceService.run(deleteQuery);
       deletedCount += result.rowCount();
       logger.info(
@@ -406,7 +422,11 @@ public class DBQuery {
     if (attachmentEntity.isPresent()) {
       var deleteQuery =
           Delete.from(attachmentEntity.get())
-              .where(doc -> doc.get("objectId").in(objectIds.toArray()));
+              .where(
+                  doc ->
+                      doc.get("objectId")
+                          .in(objectIds.toArray())
+                          .and(doc.get(upIdKey).eq(sourceUpId)));
       Result result = persistenceService.run(deleteQuery);
       deletedCount += result.rowCount();
       logger.info(
@@ -425,5 +445,127 @@ public class DBQuery {
     }
 
     return deletedCount;
+  }
+
+  /**
+   * Queries the source entity's up__ID from the database using the given objectIds. This is used to
+   * identify which source entity instance owns the attachments before cleanup.
+   *
+   * @param persistenceService The persistence service to execute the query
+   * @param objectIds The list of object IDs to query
+   * @param context The move event context containing source entity information
+   * @return The up__ID of the source entity, or null if not found
+   */
+  public String getSourceUpIdForObjectIds(
+      PersistenceService persistenceService,
+      List<String> objectIds,
+      AttachmentMoveEventContext context) {
+    if (objectIds == null || objectIds.isEmpty()) {
+      return null;
+    }
+
+    String sourceParentEntity = context.getSourceParentEntity();
+    String sourceCompositionName = context.getSourceCompositionName();
+
+    if (sourceParentEntity == null || sourceCompositionName == null) {
+      return null;
+    }
+
+    CdsModel model = context.getModel();
+
+    // Find the source parent entity
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(sourceParentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      return null;
+    }
+
+    // Find the composition element
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(sourceCompositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      return null;
+    }
+
+    // Get the source attachment entity
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String sourceAttachmentEntityName = assocType.getTarget().getQualifiedName();
+
+    // Resolve the up__ID key name
+    String upIdKey = resolveUpIdKey(model, sourceParentEntity, sourceCompositionName);
+    if (upIdKey == null) {
+      return null;
+    }
+
+    // Query from draft table first (most likely to have the records)
+    Optional<CdsEntity> attachmentDraftEntity =
+        model.findEntity(sourceAttachmentEntityName + "_drafts");
+    if (attachmentDraftEntity.isPresent()) {
+      CqnSelect q =
+          Select.from(attachmentDraftEntity.get())
+              .columns(upIdKey)
+              .where(doc -> doc.get("objectId").eq(objectIds.get(0)));
+      Result result = persistenceService.run(q);
+      Optional<Row> res = result.first();
+      if (res.isPresent()) {
+        Object upIdValue = res.get().get(upIdKey);
+        return upIdValue != null ? upIdValue.toString() : null;
+      }
+    }
+
+    // Try non-draft table
+    Optional<CdsEntity> attachmentEntity = model.findEntity(sourceAttachmentEntityName);
+    if (attachmentEntity.isPresent()) {
+      CqnSelect q =
+          Select.from(attachmentEntity.get())
+              .columns(upIdKey)
+              .where(doc -> doc.get("objectId").eq(objectIds.get(0)));
+      Result result = persistenceService.run(q);
+      Optional<Row> res = result.first();
+      if (res.isPresent()) {
+        Object upIdValue = res.get().get(upIdKey);
+        return upIdValue != null ? upIdValue.toString() : null;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolves the up__ID key name for the given entity and composition.
+   *
+   * @param model The CDS model
+   * @param parentEntity The qualified name of the parent entity
+   * @param compositionName The name of the composition
+   * @return The up__ID key name, or null if not found
+   */
+  private String resolveUpIdKey(CdsModel model, String parentEntity, String compositionName) {
+    Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
+    if (optionalParentEntity.isEmpty()) {
+      return null;
+    }
+
+    Optional<CdsElement> compositionElement =
+        optionalParentEntity.get().findElement(compositionName);
+    if (compositionElement.isEmpty() || !compositionElement.get().getType().isAssociation()) {
+      return null;
+    }
+
+    CdsAssociationType assocType = (CdsAssociationType) compositionElement.get().getType();
+    String targetEntityName = assocType.getTarget().getQualifiedName();
+
+    Optional<CdsEntity> attachmentDraftEntity = model.findEntity(targetEntityName + "_drafts");
+    if (attachmentDraftEntity.isPresent()) {
+      Optional<CdsElement> upAssociation = attachmentDraftEntity.get().findAssociation("up_");
+      if (upAssociation.isPresent()) {
+        CdsElement association = upAssociation.get();
+        CdsAssociationType upAssocType = association.getType();
+        List<String> fkElements = upAssocType.refs().map(ref -> "up__" + ref.path()).toList();
+        if (!fkElements.isEmpty()) {
+          return fkElements.get(0);
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
@@ -1,11 +1,14 @@
 package com.sap.cds.sdm.service;
 
 import com.sap.cds.sdm.model.CopyAttachmentInput;
+import com.sap.cds.sdm.model.MoveAttachmentInput;
 import com.sap.cds.services.Service;
+import java.util.List;
 
 public interface RegisterService extends Service {
   String SDM_NAME = "SDMAttachmentService$Default";
   String EVENT_COPY_ATTACHMENT = "COPY_ATTACHMENT";
+  String EVENT_MOVE_ATTACHMENT = "MOVE_ATTACHMENT";
 
   /**
    * Copies attachments using the facet-based approach. This method supports both regular entities
@@ -16,4 +19,16 @@ public interface RegisterService extends Service {
    * @param isSystemUser Whether to use system user flow
    */
   public void copyAttachments(CopyAttachmentInput input, boolean isSystemUser);
+
+  /**
+   * Moves attachments from a source folder to a target entity using the facet-based approach. This
+   * method supports both regular entities and projection entities by internally parsing the facet
+   * to determine parent entity and composition name.
+   *
+   * @param input The move attachment input containing source folder ID, target facet, and object
+   *     IDs
+   * @param isSystemUser Whether to use system user flow
+   * @return A list of object IDs for which the move operation failed (empty if all succeeded)
+   */
+  public List<String> moveAttachments(MoveAttachmentInput input, boolean isSystemUser);
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/RegisterService.java
@@ -3,7 +3,7 @@ package com.sap.cds.sdm.service;
 import com.sap.cds.sdm.model.CopyAttachmentInput;
 import com.sap.cds.sdm.model.MoveAttachmentInput;
 import com.sap.cds.services.Service;
-import java.util.List;
+import java.util.Map;
 
 public interface RegisterService extends Service {
   String SDM_NAME = "SDMAttachmentService$Default";
@@ -28,7 +28,8 @@ public interface RegisterService extends Service {
    * @param input The move attachment input containing source folder ID, target facet, and object
    *     IDs
    * @param isSystemUser Whether to use system user flow
-   * @return A list of object IDs for which the move operation failed (empty if all succeeded)
+   * @return A map containing the result with key "failedObjectIds" containing a list of object IDs
+   *     for which the move operation failed (empty list if all succeeded)
    */
-  public List<String> moveAttachments(MoveAttachmentInput input, boolean isSystemUser);
+  public Map<String, Object> moveAttachments(MoveAttachmentInput input, boolean isSystemUser);
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -95,11 +95,12 @@ public class SDMAttachmentsService extends ServiceDelegator
     // Parse source facet to extract source entity information for cleanup
     String sourceParentEntity = null;
     String sourceCompositionName = null;
-    if (input.sourceFacet() != null && !input.sourceFacet().isEmpty()) {
-      String[] sourceFacetParts = input.sourceFacet().split("\\.");
+    if (input.sourceFacet().isPresent()) {
+      String sourceFacetValue = input.sourceFacet().get();
+      String[] sourceFacetParts = sourceFacetValue.split("\\.");
       if (sourceFacetParts.length >= 2) {
         sourceCompositionName = sourceFacetParts[sourceFacetParts.length - 1];
-        sourceParentEntity = input.sourceFacet().substring(0, input.sourceFacet().lastIndexOf("."));
+        sourceParentEntity = sourceFacetValue.substring(0, sourceFacetValue.lastIndexOf("."));
         logger.info(
             "Source Composition Name: {}, Source Parent Entity: {}",
             sourceCompositionName,

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -12,11 +12,14 @@ import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentRe
 import com.sap.cds.feature.attachments.service.model.servicehandler.DeletionUserInfo;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.model.CopyAttachmentInput;
+import com.sap.cds.sdm.model.MoveAttachmentInput;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
 import com.sap.cds.services.ServiceDelegator;
 import com.sap.cds.services.request.UserInfo;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +58,42 @@ public class SDMAttachmentsService extends ServiceDelegator
     copyContext.setSystemUser(isSystemUser);
 
     emit(copyContext);
+  }
+
+  @Override
+  public List<String> moveAttachments(MoveAttachmentInput input, boolean isSystemUser) {
+    logger.info(
+        "Moving attachments from sourceFolderId: {} to upId: {}, targetFacet: {}, objectIds: {},"
+            + " isSystemUser: {}",
+        input.sourceFolderId(),
+        input.upId(),
+        input.targetFacet(),
+        input.objectIds(),
+        isSystemUser);
+
+    // Parse facet to extract parent entity and composition name
+    String[] facetParts = input.targetFacet().split("\\.");
+    if (facetParts.length < 3) {
+      throw new IllegalArgumentException(
+          String.format(SDMConstants.INVALID_FACET_FORMAT_ERROR, input.targetFacet()));
+    }
+
+    String parentEntity = facetParts[0] + "." + facetParts[1]; // Service.Entity
+    String compositionName = facetParts[2]; // composition name
+
+    var moveContext = AttachmentMoveEventContext.create();
+    moveContext.setSourceFolderId(input.sourceFolderId());
+    moveContext.setUpId(input.upId());
+    moveContext.setParentEntity(parentEntity);
+    moveContext.setCompositionName(compositionName);
+    moveContext.setObjectIds(input.objectIds());
+    moveContext.setSystemUser(isSystemUser);
+
+    emit(moveContext);
+
+    // Return the list of failed object IDs from context
+    System.out.println("Failed Object IDs: " + moveContext.getFailedObjectIds());
+    return moveContext.getFailedObjectIds();
   }
 
   @Override

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -69,7 +69,7 @@ public class SDMAttachmentsService extends ServiceDelegator
             + " {}, objectIds: {}, isSystemUser: {}",
         input.sourceFolderId(),
         input.sourceFacet(),
-        input.upId(),
+        input.targetUpId(),
         input.targetFacet(),
         input.objectIds(),
         isSystemUser);
@@ -99,7 +99,7 @@ public class SDMAttachmentsService extends ServiceDelegator
     moveContext.setSourceFolderId(input.sourceFolderId());
     moveContext.setSourceParentEntity(sourceParentEntity);
     moveContext.setSourceCompositionName(sourceCompositionName);
-    moveContext.setUpId(input.upId());
+    moveContext.setUpId(input.targetUpId());
     moveContext.setParentEntity(targetParentEntity);
     moveContext.setCompositionName(targetCompositionName);
     moveContext.setObjectIds(input.objectIds());
@@ -107,11 +107,14 @@ public class SDMAttachmentsService extends ServiceDelegator
 
     emit(moveContext);
 
-    // Get the failed object IDs and return them in a structured format
-    List<String> failedIds = moveContext.getFailedObjectIds();
-    if (failedIds != null && !failedIds.isEmpty()) {
-      logger.warn(
-          "Move operation completed with {} failed attachments: {}", failedIds.size(), failedIds);
+    // Get the failed attachments and return them in a structured format
+    List<Map<String, String>> failedAttachments = moveContext.getFailedAttachments();
+    if (failedAttachments != null && !failedAttachments.isEmpty()) {
+      logger.warn("Move operation completed with {} failed attachments", failedAttachments.size());
+      for (Map<String, String> failure : failedAttachments) {
+        logger.warn(
+            "  - ObjectId: {}, Reason: {}", failure.get("objectId"), failure.get("failureReason"));
+      }
     } else {
       logger.info(
           "Move operation completed successfully for all {} attachments", input.objectIds().size());
@@ -119,7 +122,7 @@ public class SDMAttachmentsService extends ServiceDelegator
 
     // Return structured result that OData can serialize
     Map<String, Object> result = new HashMap<>();
-    result.put("failedObjectIds", failedIds != null ? failedIds : List.of());
+    result.put("failedAttachments", failedAttachments != null ? failedAttachments : List.of());
     return result;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -19,7 +19,9 @@ import com.sap.cds.services.ServiceDelegator;
 import com.sap.cds.services.request.UserInfo;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,39 +63,64 @@ public class SDMAttachmentsService extends ServiceDelegator
   }
 
   @Override
-  public List<String> moveAttachments(MoveAttachmentInput input, boolean isSystemUser) {
+  public Map<String, Object> moveAttachments(MoveAttachmentInput input, boolean isSystemUser) {
     logger.info(
-        "Moving attachments from sourceFolderId: {} to upId: {}, targetFacet: {}, objectIds: {},"
-            + " isSystemUser: {}",
+        "Moving attachments from sourceFolderId: {} (sourceFacet: {}) to upId: {}, targetFacet:"
+            + " {}, objectIds: {}, isSystemUser: {}",
         input.sourceFolderId(),
+        input.sourceFacet(),
         input.upId(),
         input.targetFacet(),
         input.objectIds(),
         isSystemUser);
 
-    // Parse facet to extract parent entity and composition name
-    String[] facetParts = input.targetFacet().split("\\.");
-    if (facetParts.length < 3) {
+    // Parse target facet to extract parent entity and composition name
+    String[] targetFacetParts = input.targetFacet().split("\\.");
+    if (targetFacetParts.length < 3) {
       throw new IllegalArgumentException(
           String.format(SDMConstants.INVALID_FACET_FORMAT_ERROR, input.targetFacet()));
     }
 
-    String parentEntity = facetParts[0] + "." + facetParts[1]; // Service.Entity
-    String compositionName = facetParts[2]; // composition name
+    String targetParentEntity = targetFacetParts[0] + "." + targetFacetParts[1]; // Service.Entity
+    String targetCompositionName = targetFacetParts[2]; // composition name
+
+    // Parse source facet to extract source entity information for cleanup
+    String sourceParentEntity = null;
+    String sourceCompositionName = null;
+    if (input.sourceFacet() != null && !input.sourceFacet().isEmpty()) {
+      String[] sourceFacetParts = input.sourceFacet().split("\\.");
+      if (sourceFacetParts.length >= 3) {
+        sourceParentEntity = sourceFacetParts[0] + "." + sourceFacetParts[1]; // Service.Entity
+        sourceCompositionName = sourceFacetParts[2]; // composition name
+      }
+    }
 
     var moveContext = AttachmentMoveEventContext.create();
     moveContext.setSourceFolderId(input.sourceFolderId());
+    moveContext.setSourceParentEntity(sourceParentEntity);
+    moveContext.setSourceCompositionName(sourceCompositionName);
     moveContext.setUpId(input.upId());
-    moveContext.setParentEntity(parentEntity);
-    moveContext.setCompositionName(compositionName);
+    moveContext.setParentEntity(targetParentEntity);
+    moveContext.setCompositionName(targetCompositionName);
     moveContext.setObjectIds(input.objectIds());
     moveContext.setSystemUser(isSystemUser);
 
     emit(moveContext);
 
-    // Return the list of failed object IDs from context
-    System.out.println("Failed Object IDs: " + moveContext.getFailedObjectIds());
-    return moveContext.getFailedObjectIds();
+    // Get the failed object IDs and return them in a structured format
+    List<String> failedIds = moveContext.getFailedObjectIds();
+    if (failedIds != null && !failedIds.isEmpty()) {
+      logger.warn(
+          "Move operation completed with {} failed attachments: {}", failedIds.size(), failedIds);
+    } else {
+      logger.info(
+          "Move operation completed successfully for all {} attachments", input.objectIds().size());
+    }
+
+    // Return structured result that OData can serialize
+    Map<String, Object> result = new HashMap<>();
+    result.put("failedObjectIds", failedIds != null ? failedIds : List.of());
+    return result;
   }
 
   @Override

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -78,22 +78,32 @@ public class SDMAttachmentsService extends ServiceDelegator
 
     // Parse target facet to extract parent entity and composition name
     String[] targetFacetParts = input.targetFacet().split("\\.");
-    if (targetFacetParts.length < 3) {
+    if (targetFacetParts.length < 2) {
       throw new IllegalArgumentException(
           String.format(SDMConstants.INVALID_FACET_FORMAT_ERROR, input.targetFacet()));
     }
 
-    String targetParentEntity = targetFacetParts[0] + "." + targetFacetParts[1]; // Service.Entity
-    String targetCompositionName = targetFacetParts[2]; // composition name
+    // The last part is the composition name, everything else is the parent entity
+    String targetCompositionName = targetFacetParts[targetFacetParts.length - 1];
+    String targetParentEntity =
+        input.targetFacet().substring(0, input.targetFacet().lastIndexOf("."));
+    logger.info(
+        "Target Composition Name: {}, Target Parent Entity: {}",
+        targetCompositionName,
+        targetParentEntity);
 
     // Parse source facet to extract source entity information for cleanup
     String sourceParentEntity = null;
     String sourceCompositionName = null;
     if (input.sourceFacet() != null && !input.sourceFacet().isEmpty()) {
       String[] sourceFacetParts = input.sourceFacet().split("\\.");
-      if (sourceFacetParts.length >= 3) {
-        sourceParentEntity = sourceFacetParts[0] + "." + sourceFacetParts[1]; // Service.Entity
-        sourceCompositionName = sourceFacetParts[2]; // composition name
+      if (sourceFacetParts.length >= 2) {
+        sourceCompositionName = sourceFacetParts[sourceFacetParts.length - 1];
+        sourceParentEntity = input.sourceFacet().substring(0, input.sourceFacet().lastIndexOf("."));
+        logger.info(
+            "Source Composition Name: {}, Source Parent Entity: {}",
+            sourceCompositionName,
+            sourceParentEntity);
       }
     }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -63,7 +63,7 @@ public interface SDMService {
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;
 
-  public List<String> moveAttachment(
+  public String moveAttachment(
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -74,4 +74,7 @@ public interface SDMService {
   public JSONObject editLink(
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;
+
+  public String getLinkUrl(String objectId, SDMCredentials sdmCredentials, boolean isSystemUser)
+      throws IOException;
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -63,6 +63,10 @@ public interface SDMService {
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;
 
+  public List<String> moveAttachment(
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
+      throws IOException;
+
   public JSONObject editLink(
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -702,4 +702,66 @@ public class SDMServiceImpl implements SDMService {
       throw new ServiceException(SDMConstants.FAILED_TO_COPY_ATTACHMENT, e);
     }
   }
+
+  @Override
+  public List<String> moveAttachment(
+      CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
+      throws IOException {
+    String grantType = isSystemUser ? TECHNICAL_USER_FLOW : NAMED_USER_FLOW;
+
+    logger.info("Moving attachment - This is a :{} flow", grantType);
+
+    try {
+      // Use RxJava with retry logic for move operation
+      return io.reactivex.Flowable.fromCallable(
+              () -> {
+                var httpClient =
+                    tokenHandler.getHttpClient(binding, connectionPool, null, grantType);
+                String sdmUrl =
+                    sdmCredentials.getUrl() + "browser/" + cmisDocument.getRepositoryId() + "/root";
+                HttpPost moveFile = new HttpPost(sdmUrl);
+                MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+
+                // Add form fields for move operation
+                builder.addTextBody("cmisaction", "move", ContentType.TEXT_PLAIN);
+                builder.addTextBody("objectId", cmisDocument.getObjectId(), ContentType.TEXT_PLAIN);
+                builder.addTextBody(
+                    "sourceFolderId", cmisDocument.getSourceFolderId(), ContentType.TEXT_PLAIN);
+                builder.addTextBody(
+                    "targetFolderId", cmisDocument.getFolderId(), ContentType.TEXT_PLAIN);
+                builder.addTextBody("succinct", "true");
+                HttpEntity multipart = builder.build();
+                moveFile.setEntity(multipart);
+
+                try (var response = (CloseableHttpResponse) httpClient.execute(moveFile)) {
+                  // Handle response entity
+                  HttpEntity entity = response.getEntity();
+                  String responseBody =
+                      entity != null ? EntityUtils.toString(entity, StandardCharsets.UTF_8) : "";
+
+                  if (response.getStatusLine().getStatusCode() == 201
+                      || response.getStatusLine().getStatusCode() == 200) {
+                    // Process successful response
+                    JSONObject jsonObject = new JSONObject(responseBody);
+                    JSONObject props = jsonObject.getJSONObject("succinctProperties");
+                    String fileName = props.optString("cmis:name");
+                    String mimeType = props.optString("cmis:contentStreamMimeType");
+                    String objectId = props.optString("cmis:objectId");
+                    return List.of(fileName, mimeType, objectId);
+                  }
+
+                  // On error, throw exception with error information
+                  JSONObject errorJson = new JSONObject(responseBody);
+                  String exceptionType = errorJson.optString("exception");
+                  String errorMessage = errorJson.optString("message");
+                  throw new ServiceException(exceptionType + " : " + errorMessage);
+                }
+              })
+          .retryWhen(RetryUtils.retryLogic(5)) // Apply retry logic with 5 attempts
+          .blockingFirst();
+    } catch (Exception e) {
+      logger.error("Failed to move attachment after retries: {}", e.getMessage(), e);
+      throw new ServiceException(SDMConstants.FAILED_TO_MOVE_ATTACHMENT, e);
+    }
+  }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -704,7 +704,7 @@ public class SDMServiceImpl implements SDMService {
   }
 
   @Override
-  public List<String> moveAttachment(
+  public String moveAttachment(
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException {
     String grantType = isSystemUser ? TECHNICAL_USER_FLOW : NAMED_USER_FLOW;
@@ -741,13 +741,8 @@ public class SDMServiceImpl implements SDMService {
 
                   if (response.getStatusLine().getStatusCode() == 201
                       || response.getStatusLine().getStatusCode() == 200) {
-                    // Process successful response
-                    JSONObject jsonObject = new JSONObject(responseBody);
-                    JSONObject props = jsonObject.getJSONObject("succinctProperties");
-                    String fileName = props.optString("cmis:name");
-                    String mimeType = props.optString("cmis:contentStreamMimeType");
-                    String objectId = props.optString("cmis:objectId");
-                    return List.of(fileName, mimeType, objectId);
+                    // Return the SDM response JSON - caller can extract needed properties
+                    return responseBody;
                   }
 
                   // On error, throw exception with error information

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -382,6 +382,50 @@ public class SDMServiceImpl implements SDMService {
   }
 
   @Override
+  public String getLinkUrl(String objectId, SDMCredentials sdmCredentials, boolean isSystemUser)
+      throws IOException {
+    String grantType = isSystemUser ? TECHNICAL_USER_FLOW : NAMED_USER_FLOW;
+    logger.info("Fetching link URL - This is a :{} flow", grantType);
+    var httpClient = tokenHandler.getHttpClient(binding, connectionPool, null, grantType);
+
+    String sdmUrl =
+        sdmCredentials.getUrl()
+            + "browser/"
+            + SDMConstants.REPOSITORY_ID
+            + "/root?objectID="
+            + objectId
+            + "&cmisselector=content";
+
+    HttpGet getContentRequest = new HttpGet(sdmUrl);
+    try (var response = (CloseableHttpResponse) httpClient.execute(getContentRequest)) {
+      int responseCode = response.getStatusLine().getStatusCode();
+      if (responseCode != 200) {
+        logger.warn("Failed to fetch link content for objectId {}: {}", objectId, responseCode);
+        return null;
+      }
+
+      // Read the content which is in format: [InternetShortcut]\nURL=<actual-url>
+      String content = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+      // Parse the URL from the content
+      String[] lines = content.split("\n");
+      for (String line : lines) {
+        if (line.startsWith("URL=")) {
+          String url = line.substring(4).trim();
+          logger.info("Extracted link URL for objectId {}: {}", objectId, url);
+          return url;
+        }
+      }
+
+      logger.warn("Could not find URL in link content for objectId {}", objectId);
+      return null;
+    } catch (IOException e) {
+      logger.error("Failed to fetch link URL for objectId {}: {}", objectId, e.getMessage(), e);
+      throw new ServiceException("Failed to fetch link URL", e);
+    }
+  }
+
+  @Override
   public String getFolderId(
       Result result,
       PersistenceService persistenceService,

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -740,9 +740,8 @@ public class SDMServiceImpl implements SDMService {
       }
     }
   }
-}
 
-@Override
+  @Override
   public String moveAttachment(
       CmisDocument cmisDocument, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException {
@@ -798,3 +797,4 @@ public class SDMServiceImpl implements SDMService {
       throw new ServiceException(SDMConstants.FAILED_TO_MOVE_ATTACHMENT, e);
     }
   }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentCopyEventContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentCopyEventContext.java
@@ -1,6 +1,3 @@
-/**************************************************************************
- * (C) 2019-2025 SAP SE or an SAP affiliate company. All rights reserved. *
- **************************************************************************/
 package com.sap.cds.sdm.service.handler;
 
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
@@ -42,6 +42,37 @@ public interface AttachmentMoveEventContext extends AttachmentCreateEventContext
   void setSourceFolderId(String sourceFolderId);
 
   /**
+   * Gets the qualified name of the source parent entity from which attachments are being moved.
+   * This is used to clean up the attachment metadata after successful moves.
+   *
+   * @return The qualified name of the source parent entity or {@code null} if not specified
+   */
+  String getSourceParentEntity();
+
+  /**
+   * Sets the qualified name of the source parent entity from which attachments are being moved.
+   *
+   * @param sourceParentEntity The qualified name of the source parent entity (e.g.,
+   *     "Service.Entity")
+   */
+  void setSourceParentEntity(String sourceParentEntity);
+
+  /**
+   * Gets the name of the composition property in the source entity that links to the attachments.
+   * This is used to clean up the attachment metadata after successful moves.
+   *
+   * @return The name of the source composition property or {@code null} if not specified
+   */
+  String getSourceCompositionName();
+
+  /**
+   * Sets the name of the composition property in the source entity that links to the attachments.
+   *
+   * @param sourceCompositionName The name of the source composition property
+   */
+  void setSourceCompositionName(String sourceCompositionName);
+
+  /**
    * Gets the ID of the target parent entity instance for which attachments are being moved. This
    * represents the key values of the entity that contains the attachment composition.
    *

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
@@ -5,6 +5,7 @@ import com.sap.cds.sdm.service.RegisterService;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.EventName;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The {@link AttachmentMoveEventContext} is used to store the context of the move attachment event.
@@ -156,18 +157,18 @@ public interface AttachmentMoveEventContext extends AttachmentCreateEventContext
   void setSystemUser(boolean systemUser);
 
   /**
-   * Gets the list of object IDs for which the move operation failed. This is populated by the
-   * handler after attempting to move all attachments.
+   * Gets the list of failed attachments with their failure reasons. Each map contains objectId and
+   * failureReason.
    *
-   * @return The list of failed object IDs or {@code Collections.emptyList()} if all moves succeeded
+   * @return The list of failed attachments or {@code Collections.emptyList()} if all moves
+   *     succeeded
    */
-  List<String> getFailedObjectIds();
+  List<java.util.Map<String, String>> getFailedAttachments();
 
   /**
-   * Sets the list of object IDs for which the move operation failed. This should be set by the
-   * handler after processing all move operations.
+   * Sets the list of failed attachments with their failure reasons.
    *
-   * @param failedObjectIds The list of object IDs that failed to move
+   * @param failedAttachments The list of maps containing objectId and failureReason
    */
-  void setFailedObjectIds(List<String> failedObjectIds);
+  void setFailedAttachments(List<Map<String, String>> failedAttachments);
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/AttachmentMoveEventContext.java
@@ -1,0 +1,142 @@
+package com.sap.cds.sdm.service.handler;
+
+import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
+import com.sap.cds.sdm.service.RegisterService;
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.EventName;
+import java.util.List;
+
+/**
+ * The {@link AttachmentMoveEventContext} is used to store the context of the move attachment event.
+ * This interface provides methods to handle attachment moving for both regular entities and
+ * projection entities by working with parent entities and their composition relationships.
+ *
+ * <p>For projection entities, the API uses the parent entity that defines the attachments
+ * composition and the composition name to properly navigate the relationship hierarchy.
+ */
+@EventName(RegisterService.EVENT_MOVE_ATTACHMENT)
+public interface AttachmentMoveEventContext extends AttachmentCreateEventContext {
+
+  /**
+   * Creates an {@link EventContext} already overlay with this interface. The event is set to be
+   * {@link RegisterService#EVENT_MOVE_ATTACHMENT}
+   *
+   * @return the {@link AttachmentMoveEventContext}
+   */
+  static AttachmentMoveEventContext create() {
+    return EventContext.create(AttachmentMoveEventContext.class, null);
+  }
+
+  /**
+   * Gets the source folder ID in SDM from which attachments should be moved.
+   *
+   * @return The source folder ID or {@code null} if not specified
+   */
+  String getSourceFolderId();
+
+  /**
+   * Sets the source folder ID in SDM from which attachments should be moved.
+   *
+   * @param sourceFolderId The source folder ID in SDM
+   */
+  void setSourceFolderId(String sourceFolderId);
+
+  /**
+   * Gets the ID of the target parent entity instance for which attachments are being moved. This
+   * represents the key values of the entity that contains the attachment composition.
+   *
+   * @return The id of the target parent entity instance or {@code null} if no id was specified
+   */
+  String getUpId();
+
+  /**
+   * Sets the ID of the target parent entity instance for which attachments are being moved. This
+   * should be the key value of the entity that contains the attachment composition.
+   *
+   * @param upId The key of the target parent entity instance
+   */
+  void setUpId(String upId);
+
+  /**
+   * Gets the qualified name of the target parent entity that defines the attachments composition.
+   * This is the entity that contains the composition relationship to the attachment entity.
+   *
+   * @return The qualified name of the target parent entity or {@code null} if not specified
+   */
+  String getParentEntity();
+
+  /**
+   * Sets the qualified name of the target parent entity that defines the attachments composition.
+   * This entity should contain the composition relationship to the attachment entity.
+   *
+   * @param parentEntity The qualified name of the target parent entity (e.g., "Service.Entity")
+   */
+  void setParentEntity(String parentEntity);
+
+  /**
+   * Gets the name of the composition property that links the parent entity to the attachment
+   * entity. This is the property name used in the composition relationship.
+   *
+   * <p>Examples: "attachments", "references"
+   *
+   * @return The name of the composition property or {@code null} if not specified
+   */
+  String getCompositionName();
+
+  /**
+   * Sets the name of the composition property that links the parent entity to the attachment
+   * entity. This should match the property name defined in the CDS model.
+   *
+   * @param compositionName The name of the composition property (e.g., "references")
+   */
+  void setCompositionName(String compositionName);
+
+  /**
+   * Gets the list of object IDs representing the attachments to be moved. These are the IDs of
+   * existing attachment records in the source folder.
+   *
+   * @return The list of attachment object IDs or {@code Collections.emptyList()} if no IDs were
+   *     specified
+   */
+  List<String> getObjectIds();
+
+  /**
+   * Sets the list of object IDs representing the attachments to be moved. Each ID should correspond
+   * to an existing attachment record in the source folder.
+   *
+   * @param ids The list of attachment object IDs to be moved
+   */
+  void setObjectIds(List<String> ids);
+
+  /**
+   * Gets whether the system user flow is being used for the move operation. System user flow
+   * typically bypasses certain authorization checks and user-specific logic.
+   *
+   * @return {@code true} if the system user flow is used, {@code false} for regular user flow
+   */
+  Boolean getSystemUser();
+
+  /**
+   * Sets whether the system user flow should be used for the move operation. Use system user flow
+   * when the operation should bypass user-specific authorization or logic.
+   *
+   * @param systemUser {@code true} to use system user flow, {@code false} for regular user flow
+   */
+  void setSystemUser(boolean systemUser);
+
+  /**
+   * Gets the list of object IDs for which the move operation failed. This is populated by the
+   * handler after attempting to move all attachments.
+   *
+   * @return The list of failed object IDs or {@code Collections.emptyList()} if all moves succeeded
+   */
+  List<String> getFailedObjectIds();
+
+  /**
+   * Sets the list of object IDs for which the move operation failed. This should be set by the
+   * handler after processing all move operations.
+   *
+   * @param failedObjectIds The list of object IDs that failed to move
+   */
+  void setFailedObjectIds(List<String> failedObjectIds);
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -347,7 +347,7 @@ public class SDMCustomServiceHandler {
     // Clean up source entity metadata after successful move
     if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
       try {
-        int deletedCount =
+        long deletedCount =
             dbQuery.deleteAttachmentsByObjectIds(
                 persistenceService, successfulObjectIds, sourceUpId, context);
         logger.info(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -24,9 +24,11 @@ import com.sap.cds.services.persistence.PersistenceService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -45,6 +47,8 @@ public class SDMCustomServiceHandler {
 
   private static final int PARALLEL_MOVE_THREAD_POOL_SIZE = 10;
   private static final Logger logger = LoggerFactory.getLogger(SDMCustomServiceHandler.class);
+  private static final String OBJECT_ID_KEY = "objectId";
+  private static final String FAILURE_REASON_KEY = "failureReason";
 
   // Result class for copyAttachmentsToSDM method
   private static class CopyAttachmentsResult {
@@ -87,17 +91,17 @@ public class SDMCustomServiceHandler {
   private static class MoveAttachmentsResult {
     private final List<List<String>> movedAttachmentsMetadata;
     private final List<CmisDocument> populatedDocuments;
-    private final List<String> failedObjectIds;
+    private final List<Map<String, String>> failedAttachments;
     private final List<String> successfulObjectIds;
 
     public MoveAttachmentsResult(
         List<List<String>> movedAttachmentsMetadata,
         List<CmisDocument> populatedDocuments,
-        List<String> failedObjectIds,
+        List<Map<String, String>> failedAttachments,
         List<String> successfulObjectIds) {
       this.movedAttachmentsMetadata = movedAttachmentsMetadata;
       this.populatedDocuments = populatedDocuments;
-      this.failedObjectIds = failedObjectIds;
+      this.failedAttachments = failedAttachments;
       this.successfulObjectIds = successfulObjectIds;
     }
 
@@ -109,8 +113,8 @@ public class SDMCustomServiceHandler {
       return populatedDocuments;
     }
 
-    public List<String> getFailedObjectIds() {
-      return failedObjectIds;
+    public List<Map<String, String>> getFailedAttachments() {
+      return failedAttachments;
     }
 
     public List<String> getSuccessfulObjectIds() {
@@ -193,24 +197,11 @@ public class SDMCustomServiceHandler {
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
 
     // Ensure target folder exists in SDM before attempting moves
-    boolean targetFolderExists;
-    String targetFolderId;
-    try {
-      targetFolderExists =
-          sdmService.getFolderIdByPath(targetFolderName, repositoryId, sdmCredentials, isSystemUser)
-              != null;
-      targetFolderId =
-          ensureFolderExists(targetFolderName, repositoryId, sdmCredentials, isSystemUser);
-    } catch (IOException e) {
-      logger.error(
-          "Failed to create/verify target folder '{}': {}. Marking all {} attachments as failed.",
-          targetFolderName,
-          e.getMessage(),
-          objectIds.size());
-      context.setFailedObjectIds(objectIds);
-      context.setCompleted();
-      return;
-    }
+    TargetFolderInfo folderInfo =
+        ensureTargetFolderReady(
+            targetFolderName, repositoryId, sdmCredentials, isSystemUser, objectIds, context);
+    String targetFolderId = folderInfo.targetFolderId;
+    boolean targetFolderExists = folderInfo.targetFolderExists;
 
     MoveAttachmentsRequest request =
         MoveAttachmentsRequest.builder()
@@ -228,11 +219,26 @@ public class SDMCustomServiceHandler {
 
     List<List<String>> movedAttachmentsMetadata = moveResult.getMovedAttachmentsMetadata();
     List<CmisDocument> populatedDocuments = moveResult.getPopulatedDocuments();
-    List<String> failedObjectIds = moveResult.getFailedObjectIds();
+    List<Map<String, String>> failedAttachments = moveResult.getFailedAttachments();
     List<String> successfulObjectIds = moveResult.getSuccessfulObjectIds();
 
-    // Return failed object IDs to caller (convert to ArrayList for serialization)
-    context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
+    // Return failed attachments to caller
+    context.setFailedAttachments(new ArrayList<>(failedAttachments));
+
+    // Show warning if there are failures
+    if (!failedAttachments.isEmpty()) {
+      StringBuilder warningMessage =
+          new StringBuilder("Failed to move the following attachments:\n");
+      for (Map<String, String> failure : failedAttachments) {
+        warningMessage
+            .append("  - ObjectId: ")
+            .append(failure.get(OBJECT_ID_KEY))
+            .append(", Reason: ")
+            .append(failure.get(FAILURE_REASON_KEY))
+            .append("\n");
+      }
+      context.getMessages().warn(warningMessage.toString());
+    }
 
     // Process successfully moved attachments
     if (!movedAttachmentsMetadata.isEmpty()) {
@@ -251,61 +257,180 @@ public class SDMCustomServiceHandler {
               .build();
 
       try {
-        // Query source entity's up__ID before creating target records
-        // This ensures we get the correct source ID, especially important when moving
-        // between entities of the same type (e.g., Book A to Book B)
-        String sourceUpId = null;
-        if (!successfulObjectIds.isEmpty()) {
-          sourceUpId =
-              dbQuery.getSourceUpIdForObjectIds(persistenceService, successfulObjectIds, context);
-          logger.info("Retrieved source up__ID for cleanup: {}", sourceUpId);
-        }
-
-        createDraftEntries(draftRequest);
-
-        // Clean up source entity metadata after successful move
-        if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
-          try {
-            int deletedCount =
-                dbQuery.deleteAttachmentsByObjectIds(
-                    persistenceService, successfulObjectIds, sourceUpId, context);
-            logger.info(
-                "Cleaned up {} attachment metadata records from source entity for {} successfully"
-                    + " moved attachments",
-                deletedCount,
-                successfulObjectIds.size());
-          } catch (Exception cleanupException) {
-            logger.warn(
-                "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
-                    + " successfully moved to target.",
-                successfulObjectIds.size(),
-                cleanupException.getMessage());
-          }
-        }
+        updateDatabaseAndCleanupSource(draftRequest, successfulObjectIds, context);
       } catch (ServiceException e) {
-        // Database update failed - rollback all SDM moves to maintain consistency
-        logger.error(
-            "Failed to update DB for moved attachments after retries. Rolling back SDM moves: {}",
-            e.getMessage());
-        rollbackMovedAttachments(
-            successfulObjectIds,
-            sourceFolderId,
-            targetFolderId,
-            repositoryId,
-            sdmCredentials,
-            isSystemUser,
-            context);
-        // Mark rolled-back attachments as failed
-        failedObjectIds.addAll(successfulObjectIds);
-        context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
-        logger.warn(
-            "Move operation completed with failures. Total failed: {}, Rolled back: {}",
-            failedObjectIds.size(),
-            successfulObjectIds.size());
+        DatabaseFailureContext failureContext =
+            new DatabaseFailureContext(
+                successfulObjectIds,
+                sourceFolderId,
+                targetFolderId,
+                repositoryId,
+                sdmCredentials,
+                isSystemUser,
+                context,
+                failedAttachments);
+        handleDatabaseUpdateFailure(e, failureContext);
       }
     }
 
     context.setCompleted();
+  }
+
+  /**
+   * Updates database with moved attachments and cleans up source entity metadata.
+   *
+   * @throws ServiceException if database operations fail
+   */
+  private void updateDatabaseAndCleanupSource(
+      CreateDraftEntriesRequest draftRequest,
+      List<String> successfulObjectIds,
+      AttachmentMoveEventContext context)
+      throws ServiceException {
+    // Query source entity's up__ID before creating target records
+    // This ensures we get the correct source ID, especially important when moving
+    // between entities of the same type (e.g., Book A to Book B)
+    String sourceUpId = null;
+    if (!successfulObjectIds.isEmpty()) {
+      sourceUpId =
+          dbQuery.getSourceUpIdForObjectIds(persistenceService, successfulObjectIds, context);
+      logger.info("Retrieved source up__ID for cleanup: {}", sourceUpId);
+    }
+
+    createDraftEntries(draftRequest);
+
+    // Clean up source entity metadata after successful move
+    if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
+      try {
+        int deletedCount =
+            dbQuery.deleteAttachmentsByObjectIds(
+                persistenceService, successfulObjectIds, sourceUpId, context);
+        logger.info(
+            "Cleaned up {} attachment metadata records from source entity for {} successfully"
+                + " moved attachments",
+            deletedCount,
+            successfulObjectIds.size());
+      } catch (Exception cleanupException) {
+        logger.warn(
+            "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
+                + " successfully moved to target.",
+            successfulObjectIds.size(),
+            cleanupException.getMessage());
+      }
+    }
+  }
+
+  /** Helper class to hold database failure context information. */
+  private static class DatabaseFailureContext {
+    final List<String> successfulObjectIds;
+    final String sourceFolderId;
+    final String targetFolderId;
+    final String repositoryId;
+    final SDMCredentials sdmCredentials;
+    final Boolean isSystemUser;
+    final AttachmentMoveEventContext context;
+    final List<Map<String, String>> failedAttachments;
+
+    DatabaseFailureContext(
+        List<String> successfulObjectIds,
+        String sourceFolderId,
+        String targetFolderId,
+        String repositoryId,
+        SDMCredentials sdmCredentials,
+        Boolean isSystemUser,
+        AttachmentMoveEventContext context,
+        List<Map<String, String>> failedAttachments) {
+      this.successfulObjectIds = successfulObjectIds;
+      this.sourceFolderId = sourceFolderId;
+      this.targetFolderId = targetFolderId;
+      this.repositoryId = repositoryId;
+      this.sdmCredentials = sdmCredentials;
+      this.isSystemUser = isSystemUser;
+      this.context = context;
+      this.failedAttachments = failedAttachments;
+    }
+  }
+
+  /**
+   * Handles database update failure by rolling back SDM moves and marking attachments as failed.
+   */
+  private void handleDatabaseUpdateFailure(
+      ServiceException e, DatabaseFailureContext failureContext) {
+    // Database update failed - rollback all SDM moves to maintain consistency
+    logger.error(
+        "Failed to update DB for moved attachments after retries. Rolling back SDM moves: {}",
+        e.getMessage());
+    rollbackMovedAttachments(
+        failureContext.successfulObjectIds,
+        failureContext.sourceFolderId,
+        failureContext.targetFolderId,
+        failureContext.repositoryId,
+        failureContext.sdmCredentials,
+        failureContext.isSystemUser,
+        failureContext.context);
+    // Mark rolled-back attachments as failed
+    for (String objectId : failureContext.successfulObjectIds) {
+      Map<String, String> failureMap = new HashMap<>();
+      failureMap.put(OBJECT_ID_KEY, objectId);
+      failureMap.put(
+          FAILURE_REASON_KEY, "Database update failed, move rolled back: " + e.getMessage());
+      failureContext.failedAttachments.add(failureMap);
+    }
+    failureContext.context.setFailedAttachments(new ArrayList<>(failureContext.failedAttachments));
+
+    // Add warning message
+    StringBuilder warningMessage =
+        new StringBuilder(
+            "Move operation failed during database update. Rolled back attachments:\n");
+    for (String objectId : failureContext.successfulObjectIds) {
+      warningMessage.append("  - ObjectId: ").append(objectId).append("\n");
+    }
+    failureContext.context.getMessages().warn(warningMessage.toString());
+
+    logger.warn(
+        "Move operation completed with failures. Total failed: {}, Rolled back: {}",
+        failureContext.failedAttachments.size(),
+        failureContext.successfulObjectIds.size());
+  }
+
+  /**
+   * Ensures target folder exists and returns the folder state information.
+   *
+   * @return array containing [targetFolderId, targetFolderExists]
+   * @throws IOException if folder creation/verification fails
+   */
+  private TargetFolderInfo ensureTargetFolderReady(
+      String targetFolderName,
+      String repositoryId,
+      SDMCredentials sdmCredentials,
+      Boolean isSystemUser,
+      List<String> objectIds,
+      AttachmentMoveEventContext context)
+      throws IOException {
+    try {
+      boolean targetFolderExists =
+          sdmService.getFolderIdByPath(targetFolderName, repositoryId, sdmCredentials, isSystemUser)
+              != null;
+      String targetFolderId =
+          ensureFolderExists(targetFolderName, repositoryId, sdmCredentials, isSystemUser);
+      return new TargetFolderInfo(targetFolderId, targetFolderExists);
+    } catch (IOException e) {
+      logger.error(
+          "Failed to create/verify target folder '{}': {}. Marking all {} attachments as failed.",
+          targetFolderName,
+          e.getMessage(),
+          objectIds.size());
+      // Create failed attachments list with error reason
+      List<Map<String, String>> failedAttachments = new ArrayList<>();
+      for (String objectId : objectIds) {
+        Map<String, String> failureMap = new HashMap<>();
+        failureMap.put(OBJECT_ID_KEY, objectId);
+        failureMap.put(FAILURE_REASON_KEY, "Failed to create target folder: " + e.getMessage());
+        failedAttachments.add(failureMap);
+      }
+      context.setFailedAttachments(failedAttachments);
+      context.setCompleted();
+      throw e;
+    }
   }
 
   private String ensureFolderExists(
@@ -322,6 +447,17 @@ public class SDMCustomServiceHandler {
       folderId = succinctProperties.getString("cmis:objectId");
     }
     return folderId;
+  }
+
+  /** Helper class to hold target folder information. */
+  private static class TargetFolderInfo {
+    final String targetFolderId;
+    final boolean targetFolderExists;
+
+    TargetFolderInfo(String targetFolderId, boolean targetFolderExists) {
+      this.targetFolderId = targetFolderId;
+      this.targetFolderExists = targetFolderExists;
+    }
   }
 
   private CopyAttachmentsResult copyAttachmentsToSDM(CopyAttachmentsRequest request)
@@ -359,6 +495,69 @@ public class SDMCustomServiceHandler {
     return new CopyAttachmentsResult(attachmentsMetadata, populatedDocuments);
   }
 
+  /** Helper class to hold SDM validation data. */
+  private static class SDMValidationData {
+    final List<String> validSecondaryProperties;
+    final Map<String, String> entityAnnotations;
+
+    SDMValidationData(
+        List<String> validSecondaryProperties, Map<String, String> entityAnnotations) {
+      this.validSecondaryProperties = validSecondaryProperties;
+      this.entityAnnotations = entityAnnotations;
+    }
+  }
+
+  /**
+   * Fetches SDM validation data including secondary types and properties.
+   *
+   * @throws IOException if SDM operations fail
+   */
+  private SDMValidationData fetchSDMValidationData(MoveAttachmentsRequest request)
+      throws IOException {
+    // Fetch secondary types from SDM repository (similar to updateAttachments)
+    List<String> secondaryTypes;
+    try {
+      secondaryTypes =
+          sdmService.getSecondaryTypes(
+              request.getRepositoryId(), request.getSdmCredentials(), request.getIsSystemUser());
+      logger.info(
+          "Fetched {} secondary types from SDM repository: {}",
+          secondaryTypes.size(),
+          secondaryTypes);
+    } catch (Exception e) {
+      logger.error("Failed to fetch secondary types from SDM: {}", e.getMessage(), e);
+      throw new IOException("Failed to fetch secondary types from SDM", e);
+    }
+
+    // Fetch valid secondary properties from SDM (similar to updateAttachments)
+    List<String> validSecondaryProperties;
+    try {
+      validSecondaryProperties =
+          sdmService.getValidSecondaryProperties(
+              secondaryTypes,
+              request.getSdmCredentials(),
+              request.getRepositoryId(),
+              request.getIsSystemUser());
+      logger.info(
+          "Fetched {} valid secondary properties from SDM: {}",
+          validSecondaryProperties.size(),
+          validSecondaryProperties);
+    } catch (Exception e) {
+      logger.error("Failed to fetch valid secondary properties from SDM: {}", e.getMessage(), e);
+      throw new IOException("Failed to fetch valid secondary properties from SDM", e);
+    }
+
+    // Get entity annotations for filtering properties during DB insertion
+    Map<String, String> entityAnnotations =
+        dbQuery.getValidSecondaryPropertiesForMove(request.getContext());
+    logger.info(
+        "Target entity has {} annotated secondary properties for DB mapping: {}",
+        entityAnnotations.size(),
+        entityAnnotations);
+
+    return new SDMValidationData(validSecondaryProperties, entityAnnotations);
+  }
+
   /**
    * Executes attachment moves in parallel using a thread pool. Tracks successful and failed moves
    * separately for further processing.
@@ -373,15 +572,26 @@ public class SDMCustomServiceHandler {
         java.util.Collections.synchronizedList(new ArrayList<>());
     List<CmisDocument> populatedDocuments =
         java.util.Collections.synchronizedList(new ArrayList<>());
-    List<String> failedObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
+    List<Map<String, String>> failedAttachments =
+        java.util.Collections.synchronizedList(new ArrayList<>());
     List<String> successfulObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
+
+    // Fetch SDM validation data
+    SDMValidationData validationData = fetchSDMValidationData(request);
+    List<String> validSecondaryProperties = validationData.validSecondaryProperties;
+    Map<String, String> entityAnnotations = validationData.entityAnnotations;
 
     // Preserve request context for authentication in parallel threads
     com.sap.cds.services.runtime.RequestContextRunner contextRunner =
         request.getContext().getCdsRuntime().requestContext();
 
-    // Execute moves in parallel for better performance
-    List<CompletableFuture<Void>> moveFutures =
+    // Create results wrapper for successful processing
+    AttachmentProcessingResults processingResults =
+        new AttachmentProcessingResults(
+            successfulObjectIds, movedAttachmentsMetadata, populatedDocuments);
+
+    // Process each attachment in parallel: Move → Validate → Process/Rollback immediately
+    List<CompletableFuture<Void>> processFutures =
         request.getObjectIds().stream()
             .map(
                 objectId ->
@@ -389,57 +599,288 @@ public class SDMCustomServiceHandler {
                         () ->
                             contextRunner.run(
                                 ctx -> {
-                                  try {
-                                    CmisDocument cmisDocument =
-                                        dbQuery.getAttachmentForObjectID(
-                                            persistenceService, objectId, request.getContext());
-                                    cmisDocument.setObjectId(objectId);
-                                    cmisDocument.setRepositoryId(request.getRepositoryId());
-                                    cmisDocument.setSourceFolderId(request.getSourceFolderId());
-                                    cmisDocument.setFolderId(request.getTargetFolderId());
-
-                                    CmisDocument populatedDocument = new CmisDocument();
-                                    populatedDocument.setType(cmisDocument.getType());
-                                    populatedDocument.setUrl(cmisDocument.getUrl());
-                                    // Preserve secondary properties from source attachment
-                                    populatedDocument.setSecondaryProperties(
-                                        cmisDocument.getSecondaryProperties());
-
-                                    // Move attachment in SDM with automatic retry on transient
-                                    // failures
-                                    List<String> metadata =
-                                        sdmService.moveAttachment(
-                                            cmisDocument,
-                                            request.getSdmCredentials(),
-                                            request.getIsSystemUser());
-
-                                    // Track successful move (SDM preserves objectId within same
-                                    // repository)
-                                    successfulObjectIds.add(objectId);
-                                    movedAttachmentsMetadata.add(metadata);
-                                    populatedDocuments.add(populatedDocument);
-                                  } catch (ServiceException | IOException e) {
-                                    // Track failure and continue with remaining attachments
-                                    logger.error(
-                                        "Failed to move attachment with objectId {}: {}",
-                                        objectId,
-                                        e.getMessage());
-                                    failedObjectIds.add(objectId);
-                                  }
+                                  AttachmentMoveContext moveContext =
+                                      new AttachmentMoveContext(
+                                          objectId,
+                                          request,
+                                          validSecondaryProperties,
+                                          entityAnnotations,
+                                          processingResults,
+                                          failedAttachments);
+                                  processSingleAttachmentMove(moveContext);
                                   return null;
                                 }),
                         executorService))
             .toList();
 
-    // Wait for all move operations to complete
+    // Wait for all operations to complete
     try {
-      CompletableFuture.allOf(moveFutures.toArray(new CompletableFuture[0])).join();
+      CompletableFuture.allOf(processFutures.toArray(new CompletableFuture[0])).join();
     } catch (Exception e) {
-      throw new IOException("Error during parallel move operations", e);
+      throw new IOException("Error during parallel move and validation operations", e);
     }
 
+    logger.info(
+        "Move operation completed - Successful: {}, Failed: {}",
+        successfulObjectIds.size(),
+        failedAttachments.size());
+
     return new MoveAttachmentsResult(
-        movedAttachmentsMetadata, populatedDocuments, failedObjectIds, successfulObjectIds);
+        movedAttachmentsMetadata, populatedDocuments, failedAttachments, successfulObjectIds);
+  }
+
+  /**
+   * Handles validation failure by rolling back the attachment and recording the failure.
+   *
+   * @param objectId the attachment object ID
+   * @param invalidProperties list of invalid properties found
+   * @param request the move request containing credentials and folder info
+   * @param failedAttachments list to add the failure record to
+   */
+  private void handleValidationFailure(
+      String objectId,
+      List<String> invalidProperties,
+      MoveAttachmentsRequest request,
+      List<Map<String, String>> failedAttachments) {
+    logger.error(
+        "Attachment {} validation FAILED - Found {} invalid properties: {}. Rolling back...",
+        objectId,
+        invalidProperties.size(),
+        invalidProperties);
+
+    try {
+      rollbackSingleAttachment(
+          objectId,
+          request.getSourceFolderId(),
+          request.getTargetFolderId(),
+          request.getRepositoryId(),
+          request.getSdmCredentials(),
+          request.getIsSystemUser());
+      logger.info("Successfully rolled back attachment {} to source folder", objectId);
+    } catch (Exception rollbackEx) {
+      logger.error("Failed to rollback attachment {}: {}", objectId, rollbackEx.getMessage());
+    }
+
+    Map<String, String> failure = new HashMap<>();
+    failure.put(OBJECT_ID_KEY, objectId);
+    failure.put(
+        FAILURE_REASON_KEY,
+        "Target entity properties "
+            + invalidProperties
+            + " found in SDM response but not in valid secondary properties list. Attachment"
+            + " rolled back.");
+    failedAttachments.add(failure);
+  }
+
+  /** Helper class to hold attachment processing context for parallel execution. */
+  private static class AttachmentMoveContext {
+    final String objectId;
+    final MoveAttachmentsRequest request;
+    final List<String> validSecondaryProperties;
+    final Map<String, String> entityAnnotations;
+    final AttachmentProcessingResults processingResults;
+    final List<Map<String, String>> failedAttachments;
+
+    AttachmentMoveContext(
+        String objectId,
+        MoveAttachmentsRequest request,
+        List<String> validSecondaryProperties,
+        Map<String, String> entityAnnotations,
+        AttachmentProcessingResults processingResults,
+        List<Map<String, String>> failedAttachments) {
+      this.objectId = objectId;
+      this.request = request;
+      this.validSecondaryProperties = validSecondaryProperties;
+      this.entityAnnotations = entityAnnotations;
+      this.processingResults = processingResults;
+      this.failedAttachments = failedAttachments;
+    }
+  }
+
+  /**
+   * Processes a single attachment move: Move in SDM → Validate → Process or Rollback.
+   *
+   * @param moveContext the context containing all necessary information for processing
+   */
+  private void processSingleAttachmentMove(AttachmentMoveContext moveContext) {
+    try {
+      // Step 1: Move attachment in SDM
+      CmisDocument cmisDocument = new CmisDocument();
+      cmisDocument.setObjectId(moveContext.objectId);
+      cmisDocument.setRepositoryId(moveContext.request.getRepositoryId());
+      cmisDocument.setSourceFolderId(moveContext.request.getSourceFolderId());
+      cmisDocument.setFolderId(moveContext.request.getTargetFolderId());
+
+      String sdmResponseJson =
+          sdmService.moveAttachment(
+              cmisDocument,
+              moveContext.request.getSdmCredentials(),
+              moveContext.request.getIsSystemUser());
+      org.json.JSONObject sdmResponse = new org.json.JSONObject(sdmResponseJson);
+      org.json.JSONObject succinctProperties = sdmResponse.getJSONObject("succinctProperties");
+
+      String fileName = succinctProperties.optString("cmis:name");
+      String mimeType = succinctProperties.optString("cmis:contentStreamMimeType");
+      String movedObjectId = succinctProperties.optString("cmis:objectId");
+
+      logger.debug(
+          "Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}",
+          moveContext.objectId,
+          fileName,
+          mimeType);
+
+      // Step 2: Validate target entity properties in SDM response
+      // Get target entity's SDM property names from annotations
+      Set<String> targetEntitySdmProperties = new HashSet<>(moveContext.entityAnnotations.values());
+      Set<String> sdmResponseProperties = new HashSet<>(succinctProperties.keySet());
+
+      logger.debug(
+          "Validating attachment {} - Target entity expects {} SDM properties: {}",
+          moveContext.objectId,
+          targetEntitySdmProperties.size(),
+          targetEntitySdmProperties);
+      logger.debug(
+          "SDM response has {} properties: {}",
+          sdmResponseProperties.size(),
+          sdmResponseProperties);
+
+      // Validate: Check target entity properties that exist in SDM response
+      List<String> invalidProperties = new ArrayList<>();
+      for (String targetSdmProperty : targetEntitySdmProperties) {
+        if (sdmResponseProperties.contains(targetSdmProperty)
+            && !moveContext.validSecondaryProperties.contains(targetSdmProperty)) {
+          // Property defined in target entity, present in SDM response, but NOT in valid list →
+          // INVALID
+          invalidProperties.add(targetSdmProperty);
+          logger.warn(
+              "Attachment {} - Property '{}' is defined in target entity and in SDM response but"
+                  + " NOT in valid secondary properties list",
+              moveContext.objectId,
+              targetSdmProperty);
+        }
+      }
+
+      if (!invalidProperties.isEmpty()) {
+        // Step 3a: Validation failed → Rollback immediately
+        handleValidationFailure(
+            moveContext.objectId,
+            invalidProperties,
+            moveContext.request,
+            moveContext.failedAttachments);
+
+      } else {
+        // Step 3b: Validation passed → Process for DB insertion
+        processValidatedAttachment(
+            moveContext.objectId,
+            fileName,
+            mimeType,
+            movedObjectId,
+            succinctProperties,
+            moveContext.entityAnnotations,
+            moveContext.processingResults);
+      }
+
+    } catch (ServiceException | IOException e) {
+      // Move operation failed
+      logger.error("Failed to move attachment {}: {}", moveContext.objectId, e.getMessage());
+      Map<String, String> failure = new HashMap<>();
+      failure.put(OBJECT_ID_KEY, moveContext.objectId);
+      failure.put(FAILURE_REASON_KEY, "SDM move failed: " + e.getMessage());
+      moveContext.failedAttachments.add(failure);
+    } catch (Exception e) {
+      // Validation/processing failed
+      logger.error(
+          "Failed to validate/process attachment {}: {}", moveContext.objectId, e.getMessage(), e);
+      Map<String, String> failure = new HashMap<>();
+      failure.put(OBJECT_ID_KEY, moveContext.objectId);
+      failure.put(FAILURE_REASON_KEY, "Validation/processing failed: " + e.getMessage());
+      moveContext.failedAttachments.add(failure);
+    }
+  }
+
+  /** Helper class to hold results for processed attachments. */
+  private static class AttachmentProcessingResults {
+    final List<String> successfulObjectIds;
+    final List<List<String>> movedAttachmentsMetadata;
+    final List<CmisDocument> populatedDocuments;
+
+    AttachmentProcessingResults(
+        List<String> successfulObjectIds,
+        List<List<String>> movedAttachmentsMetadata,
+        List<CmisDocument> populatedDocuments) {
+      this.successfulObjectIds = successfulObjectIds;
+      this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+      this.populatedDocuments = populatedDocuments;
+    }
+  }
+
+  /**
+   * Processes a successfully validated attachment for DB insertion.
+   *
+   * @param objectId the attachment object ID
+   * @param fileName the file name
+   * @param mimeType the MIME type
+   * @param movedObjectId the new object ID after move
+   * @param succinctProperties SDM response properties
+   * @param entityAnnotations mapping of DB fields to SDM properties
+   * @param results holder for successful processing results
+   */
+  private void processValidatedAttachment(
+      String objectId,
+      String fileName,
+      String mimeType,
+      String movedObjectId,
+      org.json.JSONObject succinctProperties,
+      Map<String, String> entityAnnotations,
+      AttachmentProcessingResults results) {
+    logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
+
+    CmisDocument populatedDocument = new CmisDocument();
+    populatedDocument.setType(succinctProperties.optString("sap:type", null));
+    populatedDocument.setUrl(succinctProperties.optString("sap:linkURL", null));
+
+    // Filter secondary properties for DB
+    Map<String, Object> filteredSecondaryProps = new HashMap<>();
+    for (Map.Entry<String, String> propEntry : entityAnnotations.entrySet()) {
+      String dbPropertyName = propEntry.getKey();
+      String sdmPropertyName = propEntry.getValue();
+
+      if (succinctProperties.has(sdmPropertyName)) {
+        Object value = succinctProperties.get(sdmPropertyName);
+        if (value != null && !org.json.JSONObject.NULL.equals(value)) {
+          filteredSecondaryProps.put(dbPropertyName, value);
+        }
+      }
+    }
+
+    populatedDocument.setSecondaryProperties(filteredSecondaryProps);
+
+    logger.info(
+        "Attachment {} - Prepared {} properties for DB insertion",
+        objectId,
+        filteredSecondaryProps.size());
+
+    // Add to successful results
+    results.successfulObjectIds.add(objectId);
+    results.movedAttachmentsMetadata.add(List.of(fileName, mimeType, movedObjectId));
+    results.populatedDocuments.add(populatedDocument);
+  }
+
+  // Rollback a single attachment to source folder
+  private void rollbackSingleAttachment(
+      String objectId,
+      String sourceFolderId,
+      String targetFolderId,
+      String repositoryId,
+      SDMCredentials sdmCredentials,
+      Boolean isSystemUser)
+      throws IOException {
+    CmisDocument rollbackDoc = new CmisDocument();
+    rollbackDoc.setObjectId(objectId);
+    rollbackDoc.setRepositoryId(repositoryId);
+    rollbackDoc.setSourceFolderId(targetFolderId); // Move back from target
+    rollbackDoc.setFolderId(sourceFolderId); // To source
+    sdmService.moveAttachment(rollbackDoc, sdmCredentials, isSystemUser);
   }
 
   private void handleCopyFailure(
@@ -502,7 +943,7 @@ public class SDMCustomServiceHandler {
       String mimeType = attachmentMetadata.get(1);
       String newObjectId = attachmentMetadata.get(2);
 
-      updatedFields.put("objectId", newObjectId);
+      updatedFields.put(OBJECT_ID_KEY, newObjectId);
       updatedFields.put("repositoryId", request.getRepositoryId());
       updatedFields.put("folderId", request.getFolderId());
       updatedFields.put("status", "Clean");

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1034,32 +1034,26 @@ public class SDMCustomServiceHandler {
       String mimeType = succinctProperties.optString("cmis:contentStreamMimeType");
       String description = succinctProperties.optString("cmis:description");
       String movedObjectId = succinctProperties.optString("cmis:objectId");
+      String objectTypeId = succinctProperties.optString("cmis:objectTypeId");
 
-      // Extract linkUrl from SDM response if not already set (when sourceFacet not provided)
-      // This ensures link attachments are properly handled even without database fetch
-      if (cmisDocument.getUrl() == null) {
-        String urlFromSDM = succinctProperties.optString("sap:linkUrl", null);
-        cmisDocument.setUrl(urlFromSDM);
-      }
+      // Determine attachment type based on cmis:objectTypeId from SDM response
+      // Link attachments: "sap:link" -> "sap-icon://internet-browser"
+      // Document attachments: "cmis:document" -> "sap-icon://document"
+      String attachmentType =
+          "sap:link".equals(objectTypeId) ? "sap-icon://internet-browser" : "sap-icon://document";
+      cmisDocument.setType(attachmentType);
 
-      // Set type based on whether it's a link attachment or document attachment
-      // Link attachments: "sap-icon://internet-browser"
-      // Document attachments: "sap-icon://document"
-      // This should be done after extracting URL to properly determine the type
-      if (cmisDocument.getType() == null) {
-        String attachmentType =
-            (cmisDocument.getUrl() != null && !cmisDocument.getUrl().isEmpty())
-                ? "sap-icon://internet-browser"
-                : "sap-icon://document";
-        cmisDocument.setType(attachmentType);
-      }
+      // For link attachments, extract the URL from database if sourceFacet was provided
+      // Note: sap:linkUrl is not in the SDM move response, so we rely on database fetch
+      // If sourceFacet not provided, linkUrl will remain null (which is acceptable for move)
 
       logger.info(
-          "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}, Type: {}, LinkUrl: {}",
+          "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}, ObjectTypeId: {}, Type: {}, LinkUrl: {}",
           Thread.currentThread().getName(),
           moveContext.getObjectId(),
           fileName,
           mimeType,
+          objectTypeId,
           cmisDocument.getType(),
           cmisDocument.getUrl());
       logger.info(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1,5 +1,6 @@
 package com.sap.cds.sdm.service.handler;
 
+import com.sap.cds.Result;
 import com.sap.cds.ql.Insert;
 import com.sap.cds.reflect.CdsAssociationType;
 import com.sap.cds.reflect.CdsElement;
@@ -24,6 +25,7 @@ import com.sap.cds.sdm.model.ValidatedAttachmentData;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.RegisterService;
 import com.sap.cds.sdm.service.SDMService;
+import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.draft.DraftService;
@@ -183,6 +185,16 @@ public class SDMCustomServiceHandler {
 
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
 
+    // Check maxCount constraint before attempting move
+    List<Map<String, String>> failedAttachments =
+        checkMaxCountConstraintForMove(context, parentEntity, compositionName, upID, objectIds);
+    if (!failedAttachments.isEmpty()) {
+      // All attachments failed maxCount validation
+      context.setFailedAttachments(failedAttachments);
+      context.setCompleted();
+      return;
+    }
+
     // Ensure target folder exists in SDM before attempting moves
     TargetFolderInfo folderInfo =
         ensureTargetFolderReady(
@@ -206,17 +218,17 @@ public class SDMCustomServiceHandler {
 
     List<List<String>> movedAttachmentsMetadata = moveResult.getMovedAttachmentsMetadata();
     List<CmisDocument> populatedDocuments = moveResult.getPopulatedDocuments();
-    List<Map<String, String>> failedAttachments = moveResult.getFailedAttachments();
+    List<Map<String, String>> moveFailures = moveResult.getFailedAttachments();
     List<String> successfulObjectIds = moveResult.getSuccessfulObjectIds();
 
     // Return failed attachments to caller
-    context.setFailedAttachments(new ArrayList<>(failedAttachments));
+    context.setFailedAttachments(new ArrayList<>(moveFailures));
 
     // Show warning if there are failures
-    if (!failedAttachments.isEmpty()) {
+    if (!moveFailures.isEmpty()) {
       StringBuilder warningMessage =
           new StringBuilder("Failed to move the following attachments:\n");
-      for (Map<String, String> failure : failedAttachments) {
+      for (Map<String, String> failure : moveFailures) {
         warningMessage
             .append("  - ObjectId: ")
             .append(failure.get(OBJECT_ID_KEY))
@@ -259,6 +271,126 @@ public class SDMCustomServiceHandler {
     }
 
     context.setCompleted();
+  }
+
+  /**
+   * Checks if moving attachments would exceed the maxCount constraint on the target entity.
+   *
+   * @param context the move event context
+   * @param parentEntity the parent entity name
+   * @param compositionName the composition name
+   * @param upID the up ID
+   * @param objectIds list of attachment object IDs to move
+   * @return list of failed attachments if constraint is violated, empty list otherwise
+   */
+  private List<Map<String, String>> checkMaxCountConstraintForMove(
+      AttachmentMoveEventContext context,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      List<String> objectIds) {
+    List<Map<String, String>> failedAttachments = new ArrayList<>();
+
+    try {
+      // Get target attachment entity
+      Optional<CdsEntity> targetEntityOptional =
+          context.getModel().findEntity(parentEntity + "." + compositionName);
+      if (targetEntityOptional.isEmpty()) {
+        logger.warn(
+            "Target entity {}.{} not found, skipping maxCount validation",
+            parentEntity,
+            compositionName);
+        return failedAttachments;
+      }
+
+      CdsEntity targetAttachmentEntity = targetEntityOptional.get();
+
+      // Get maxCount and error message from annotations
+      String errorMessageCount =
+          SDMUtils.getAttachmentCountAndMessage(
+              context.getModel().entities().toList(), targetAttachmentEntity);
+      String[] maxCountArr = errorMessageCount.split("__");
+      long maxCount = Long.parseLong(maxCountArr[0]);
+
+      // If maxCount is 0 or negative, no limit is enforced
+      if (maxCount <= 0) {
+        return failedAttachments;
+      }
+
+      // Get target attachment draft entity for querying existing attachments
+      Optional<CdsEntity> draftEntityOptional =
+          context.getModel().findEntity(targetAttachmentEntity.getQualifiedName() + "_drafts");
+      if (draftEntityOptional.isEmpty()) {
+        logger.warn(
+            "Draft entity for {} not found, skipping maxCount validation",
+            targetAttachmentEntity.getQualifiedName());
+        return failedAttachments;
+      }
+
+      CdsEntity attachmentDraftEntity = draftEntityOptional.get();
+      String upIdKey = SDMUtils.getUpIdKey(attachmentDraftEntity);
+
+      // Count existing attachments in target entity
+      Result result =
+          dbQuery.getAttachmentsForUPIDAndRepository(
+              attachmentDraftEntity, persistenceService, upID, upIdKey);
+      long existingCount = result.rowCount();
+      long totalCountAfterMove = existingCount + objectIds.size();
+
+      logger.info(
+          "MaxCount validation - Target entity: {}, MaxCount: {}, Existing: {}, Moving: {},"
+              + " Total after move: {}",
+          targetAttachmentEntity.getQualifiedName(),
+          maxCount,
+          existingCount,
+          objectIds.size(),
+          totalCountAfterMove);
+
+      // Check if total would exceed maxCount
+      if (totalCountAfterMove > maxCount) {
+        String errorMessage = maxCountArr[1];
+        String failureReason;
+
+        if (errorMessage != null && !"null".equalsIgnoreCase(errorMessage)) {
+          // Use custom error message from annotation
+          failureReason = errorMessage;
+        } else {
+          // Use default error message
+          failureReason =
+              String.format(
+                  "Cannot move %d attachment(s). Target entity allows maximum %d attachments, and"
+                      + " already has %d. Maximum count would be exceeded.",
+                  objectIds.size(), maxCount, existingCount);
+        }
+
+        logger.warn(
+            "Move operation rejected: Total count {} exceeds maxCount {}. Marking all {} attachments"
+                + " as failed.",
+            totalCountAfterMove,
+            maxCount,
+            objectIds.size());
+
+        // Mark all attachments as failed
+        for (String objectId : objectIds) {
+          Map<String, String> failure = new HashMap<>();
+          failure.put(OBJECT_ID_KEY, objectId);
+          failure.put(FAILURE_REASON_KEY, failureReason);
+          failedAttachments.add(failure);
+        }
+
+        // Show warning message
+        context.getMessages().warn(failureReason);
+      }
+    } catch (Exception e) {
+      logger.error(
+          "Error during maxCount validation for move operation: {}. Proceeding without"
+              + " validation.",
+          e.getMessage(),
+          e);
+      // Don't block the move operation if validation fails
+    }
+
+    return failedAttachments;
   }
 
   /**
@@ -632,6 +764,73 @@ public class SDMCustomServiceHandler {
   }
 
   /**
+   * Parses SDM error message to extract meaningful failure reason.
+   *
+   * @param errorMessage The raw error message from SDM
+   * @return A user-friendly failure reason
+   */
+  private String parseSDMErrorMessage(String errorMessage) {
+    if (errorMessage == null || errorMessage.isEmpty()) {
+      return SDMConstants.SDM_MOVE_OPERATION_FAILED;
+    }
+
+    // Check for nameConstraintViolation (duplicate file)
+    if (errorMessage.contains("nameConstraintViolation")) {
+      // Extract the meaningful part: "Child 6.pdf with Id ... already exists"
+      int colonIndex = errorMessage.indexOf(":");
+      if (colonIndex != -1 && colonIndex + 1 < errorMessage.length()) {
+        return errorMessage.substring(colonIndex + 1).trim();
+      }
+    }
+
+    // Check for other common SDM errors and extract meaningful parts
+    // For now, return the full message as fallback
+    return errorMessage;
+  }
+
+  /**
+   * Builds a detailed validation failure message including invalid properties if available.
+   *
+   * @param moveContext The move context containing validation state
+   * @param exception The exception that occurred
+   * @return A detailed failure message
+   */
+  private String buildValidationFailureMessage(
+      AttachmentMoveContext moveContext, Exception exception) {
+    // Check if we have invalid properties information in the context
+    if (moveContext.getInvalidProperties() != null
+        && !moveContext.getInvalidProperties().isEmpty()) {
+      return SDMConstants.INVALID_SECONDARY_PROPERTIES_PREFIX
+          + String.join(", ", moveContext.getInvalidProperties())
+          + SDMConstants.INVALID_SECONDARY_PROPERTIES_SUFFIX;
+    }
+
+    // Detect specific failure types and provide meaningful messages
+    String exceptionType = exception.getClass().getSimpleName();
+    String exceptionMessage = exception.getMessage();
+
+    // Database fetch failure
+    if (exceptionType.contains("ServiceException")
+        || exceptionMessage != null && exceptionMessage.contains("database")) {
+      return "Failed to retrieve attachment metadata from database. Attachment rolled back to source.";
+    }
+
+    // JSON parsing failure
+    if (exceptionType.contains("JSONException")
+        || exceptionMessage != null && exceptionMessage.contains("JSON")) {
+      return "Failed to parse SDM response. Attachment rolled back to source.";
+    }
+
+    // Processing/other failures with specific message
+    if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
+      return "Processing failed: " + exceptionMessage + ". Attachment rolled back to source.";
+    }
+
+    // Generic fallback
+    return "Attachment processing failed. Attachment rolled back to source.";
+  }
+
+  /**
    * Processes a single attachment move: Move in SDM → Validate → Process or Rollback.
    *
    * @param moveContext the context containing all necessary information for processing
@@ -723,6 +922,8 @@ public class SDMCustomServiceHandler {
 
       if (!invalidProperties.isEmpty()) {
         // Step 3a: Validation failed → Rollback immediately
+        // Store invalid properties in context for detailed error message
+        moveContext.setInvalidProperties(invalidProperties);
         handleValidationFailure(
             moveContext.getObjectId(),
             invalidProperties,
@@ -757,10 +958,9 @@ public class SDMCustomServiceHandler {
           e.getMessage());
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
-      // Pass through the actual SDM error message for clarity
-      failure.put(
-          FAILURE_REASON_KEY,
-          e.getMessage() != null ? e.getMessage() : SDMConstants.SDM_MOVE_OPERATION_FAILED);
+      // Parse SDM error message to extract meaningful failure reason
+      String failureReason = parseSDMErrorMessage(e.getMessage());
+      failure.put(FAILURE_REASON_KEY, failureReason);
       moveContext.addFailedAttachment(failure);
     } catch (Exception e) {
       // Validation/processing failed
@@ -771,11 +971,8 @@ public class SDMCustomServiceHandler {
           e);
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
-      // Provide detailed validation error with context
-      String detailedReason =
-          e.getMessage() != null && !e.getMessage().isEmpty()
-              ? SDMConstants.VALIDATION_FAILED_PREFIX + e.getMessage()
-              : SDMConstants.VALIDATION_FAILED_DEFAULT_MESSAGE;
+      // Provide detailed validation error with invalid properties if available
+      String detailedReason = buildValidationFailureMessage(moveContext, e);
       failure.put(FAILURE_REASON_KEY, detailedReason);
       moveContext.addFailedAttachment(failure);
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -475,7 +475,7 @@ public class SDMCustomServiceHandler {
       failureMap.put(OBJECT_ID_KEY, objectId);
       failureMap.put(
           FAILURE_REASON_KEY, "Database update failed, move rolled back: " + e.getMessage());
-      failureContext.getFailedAttachments().add(failureMap);
+      failureContext.addFailedAttachment(failureMap);
     }
     failureContext
         .getContext()

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -7,11 +7,20 @@ import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
+import com.sap.cds.sdm.model.AttachmentMoveContext;
+import com.sap.cds.sdm.model.AttachmentProcessingResults;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.CopyAttachmentsRequest;
+import com.sap.cds.sdm.model.CopyAttachmentsResult;
 import com.sap.cds.sdm.model.CreateDraftEntriesRequest;
+import com.sap.cds.sdm.model.DatabaseFailureContext;
+import com.sap.cds.sdm.model.DraftEntryMoveData;
 import com.sap.cds.sdm.model.MoveAttachmentsRequest;
+import com.sap.cds.sdm.model.MoveAttachmentsResult;
 import com.sap.cds.sdm.model.SDMCredentials;
+import com.sap.cds.sdm.model.SDMValidationData;
+import com.sap.cds.sdm.model.TargetFolderInfo;
+import com.sap.cds.sdm.model.ValidatedAttachmentData;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.RegisterService;
 import com.sap.cds.sdm.service.SDMService;
@@ -21,8 +30,12 @@ import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cds.services.runtime.RequestContextRunner;
+import io.reactivex.Flowable;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,26 +64,6 @@ public class SDMCustomServiceHandler {
   private static final String OBJECT_ID_KEY = "objectId";
   private static final String FAILURE_REASON_KEY = "failureReason";
 
-  // Result class for copyAttachmentsToSDM method
-  private static class CopyAttachmentsResult {
-    private final List<Map<String, String>> attachmentsMetadata;
-    private final List<CmisDocument> populatedDocuments;
-
-    public CopyAttachmentsResult(
-        List<Map<String, String>> attachmentsMetadata, List<CmisDocument> populatedDocuments) {
-      this.attachmentsMetadata = attachmentsMetadata;
-      this.populatedDocuments = populatedDocuments;
-    }
-
-    public List<Map<String, String>> getAttachmentsMetadata() {
-      return attachmentsMetadata;
-    }
-
-    public List<CmisDocument> getPopulatedDocuments() {
-      return populatedDocuments;
-    }
-  }
-
   public SDMCustomServiceHandler(
       SDMService sdmService,
       List<DraftService> draftService,
@@ -83,44 +76,6 @@ public class SDMCustomServiceHandler {
     this.dbQuery = dbQuery;
     this.persistenceService = persistenceService;
     this.executorService = Executors.newFixedThreadPool(PARALLEL_MOVE_THREAD_POOL_SIZE);
-  }
-
-  /**
-   * Encapsulates the result of a batch move operation in SDM. Contains metadata for successfully
-   * moved attachments and tracks failures.
-   */
-  private static class MoveAttachmentsResult {
-    private final List<List<String>> movedAttachmentsMetadata;
-    private final List<CmisDocument> populatedDocuments;
-    private final List<Map<String, String>> failedAttachments;
-    private final List<String> successfulObjectIds;
-
-    public MoveAttachmentsResult(
-        List<List<String>> movedAttachmentsMetadata,
-        List<CmisDocument> populatedDocuments,
-        List<Map<String, String>> failedAttachments,
-        List<String> successfulObjectIds) {
-      this.movedAttachmentsMetadata = movedAttachmentsMetadata;
-      this.populatedDocuments = populatedDocuments;
-      this.failedAttachments = failedAttachments;
-      this.successfulObjectIds = successfulObjectIds;
-    }
-
-    public List<List<String>> getMovedAttachmentsMetadata() {
-      return movedAttachmentsMetadata;
-    }
-
-    public List<CmisDocument> getPopulatedDocuments() {
-      return populatedDocuments;
-    }
-
-    public List<Map<String, String>> getFailedAttachments() {
-      return failedAttachments;
-    }
-
-    public List<String> getSuccessfulObjectIds() {
-      return successfulObjectIds;
-    }
   }
 
   @On(event = RegisterService.EVENT_COPY_ATTACHMENT)
@@ -232,8 +187,8 @@ public class SDMCustomServiceHandler {
     TargetFolderInfo folderInfo =
         ensureTargetFolderReady(
             targetFolderName, repositoryId, sdmCredentials, isSystemUser, objectIds, context);
-    String targetFolderId = folderInfo.targetFolderId;
-    boolean targetFolderExists = folderInfo.targetFolderExists;
+    String targetFolderId = folderInfo.getTargetFolderId();
+    boolean targetFolderExists = folderInfo.getTargetFolderExists();
 
     MoveAttachmentsRequest request =
         MoveAttachmentsRequest.builder()
@@ -334,15 +289,17 @@ public class SDMCustomServiceHandler {
     }
 
     // Create draft entries for moved attachments with secondary properties
-    createDraftEntriesForMove(
-        movedAttachmentsMetadata,
-        populatedDocuments,
-        parentEntity,
-        compositionName,
-        upID,
-        upIdKey,
-        repositoryId,
-        folderId);
+    DraftEntryMoveData draftData =
+        new DraftEntryMoveData(
+            movedAttachmentsMetadata,
+            populatedDocuments,
+            parentEntity,
+            compositionName,
+            upID,
+            upIdKey,
+            repositoryId,
+            folderId);
+    createDraftEntriesForMove(draftData);
 
     // Clean up source entity metadata after successful move
     if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
@@ -365,37 +322,6 @@ public class SDMCustomServiceHandler {
     }
   }
 
-  /** Helper class to hold database failure context information. */
-  private static class DatabaseFailureContext {
-    final List<String> successfulObjectIds;
-    final String sourceFolderId;
-    final String targetFolderId;
-    final String repositoryId;
-    final SDMCredentials sdmCredentials;
-    final Boolean isSystemUser;
-    final AttachmentMoveEventContext context;
-    final List<Map<String, String>> failedAttachments;
-
-    DatabaseFailureContext(
-        List<String> successfulObjectIds,
-        String sourceFolderId,
-        String targetFolderId,
-        String repositoryId,
-        SDMCredentials sdmCredentials,
-        Boolean isSystemUser,
-        AttachmentMoveEventContext context,
-        List<Map<String, String>> failedAttachments) {
-      this.successfulObjectIds = successfulObjectIds;
-      this.sourceFolderId = sourceFolderId;
-      this.targetFolderId = targetFolderId;
-      this.repositoryId = repositoryId;
-      this.sdmCredentials = sdmCredentials;
-      this.isSystemUser = isSystemUser;
-      this.context = context;
-      this.failedAttachments = failedAttachments;
-    }
-  }
-
   /**
    * Handles database update failure by rolling back SDM moves and marking attachments as failed.
    */
@@ -406,36 +332,38 @@ public class SDMCustomServiceHandler {
         "Failed to update DB for moved attachments after retries. Rolling back SDM moves: {}",
         e.getMessage());
     rollbackMovedAttachments(
-        failureContext.successfulObjectIds,
-        failureContext.sourceFolderId,
-        failureContext.targetFolderId,
-        failureContext.repositoryId,
-        failureContext.sdmCredentials,
-        failureContext.isSystemUser,
-        failureContext.context);
+        failureContext.getSuccessfulObjectIds(),
+        failureContext.getSourceFolderId(),
+        failureContext.getTargetFolderId(),
+        failureContext.getRepositoryId(),
+        failureContext.getSdmCredentials(),
+        failureContext.getIsSystemUser(),
+        failureContext.getContext());
     // Mark rolled-back attachments as failed
-    for (String objectId : failureContext.successfulObjectIds) {
+    for (String objectId : failureContext.getSuccessfulObjectIds()) {
       Map<String, String> failureMap = new HashMap<>();
       failureMap.put(OBJECT_ID_KEY, objectId);
       failureMap.put(
           FAILURE_REASON_KEY, "Database update failed, move rolled back: " + e.getMessage());
-      failureContext.failedAttachments.add(failureMap);
+      failureContext.getFailedAttachments().add(failureMap);
     }
-    failureContext.context.setFailedAttachments(new ArrayList<>(failureContext.failedAttachments));
+    failureContext
+        .getContext()
+        .setFailedAttachments(new ArrayList<>(failureContext.getFailedAttachments()));
 
     // Add warning message
     StringBuilder warningMessage =
         new StringBuilder(
             "Move operation failed during database update. Rolled back attachments:\n");
-    for (String objectId : failureContext.successfulObjectIds) {
+    for (String objectId : failureContext.getSuccessfulObjectIds()) {
       warningMessage.append("  - ObjectId: ").append(objectId).append("\n");
     }
-    failureContext.context.getMessages().warn(warningMessage.toString());
+    failureContext.getContext().getMessages().warn(warningMessage.toString());
 
     logger.warn(
         "Move operation completed with failures. Total failed: {}, Rolled back: {}",
-        failureContext.failedAttachments.size(),
-        failureContext.successfulObjectIds.size());
+        failureContext.getFailedAttachments().size(),
+        failureContext.getSuccessfulObjectIds().size());
   }
 
   /**
@@ -495,17 +423,6 @@ public class SDMCustomServiceHandler {
     return folderId;
   }
 
-  /** Helper class to hold target folder information. */
-  private static class TargetFolderInfo {
-    final String targetFolderId;
-    final boolean targetFolderExists;
-
-    TargetFolderInfo(String targetFolderId, boolean targetFolderExists) {
-      this.targetFolderId = targetFolderId;
-      this.targetFolderExists = targetFolderExists;
-    }
-  }
-
   private CopyAttachmentsResult copyAttachmentsToSDM(
       CopyAttachmentsRequest request, Set<String> customPropertiesInSDM) throws IOException {
     List<Map<String, String>> attachmentsMetadata = new ArrayList<>();
@@ -544,22 +461,6 @@ public class SDMCustomServiceHandler {
     }
 
     return new CopyAttachmentsResult(attachmentsMetadata, populatedDocuments);
-  }
-
-  /** Helper class to hold SDM validation data. */
-  private static class SDMValidationData {
-    final List<String> validSecondaryProperties;
-    final Map<String, String> entityAnnotations;
-    final com.sap.cds.reflect.CdsEntity targetEntity;
-
-    SDMValidationData(
-        List<String> validSecondaryProperties,
-        Map<String, String> entityAnnotations,
-        com.sap.cds.reflect.CdsEntity targetEntity) {
-      this.validSecondaryProperties = validSecondaryProperties;
-      this.entityAnnotations = entityAnnotations;
-      this.targetEntity = targetEntity;
-    }
   }
 
   /**
@@ -606,7 +507,7 @@ public class SDMCustomServiceHandler {
     Object[] entityData = dbQuery.getValidSecondaryPropertiesWithEntity(request.getContext());
     @SuppressWarnings("unchecked")
     Map<String, String> entityAnnotations = (Map<String, String>) entityData[0];
-    com.sap.cds.reflect.CdsEntity targetEntity = (com.sap.cds.reflect.CdsEntity) entityData[1];
+    CdsEntity targetEntity = (CdsEntity) entityData[1];
     logger.info(
         "Target entity has {} annotated secondary properties for DB mapping: {}",
         entityAnnotations.size(),
@@ -625,28 +526,29 @@ public class SDMCustomServiceHandler {
    */
   private MoveAttachmentsResult moveAttachmentsInSDM(MoveAttachmentsRequest request)
       throws IOException {
-    List<List<String>> movedAttachmentsMetadata =
-        java.util.Collections.synchronizedList(new ArrayList<>());
-    List<CmisDocument> populatedDocuments =
-        java.util.Collections.synchronizedList(new ArrayList<>());
-    List<Map<String, String>> failedAttachments =
-        java.util.Collections.synchronizedList(new ArrayList<>());
-    List<String> successfulObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
+    List<List<String>> movedAttachmentsMetadata = Collections.synchronizedList(new ArrayList<>());
+    List<CmisDocument> populatedDocuments = Collections.synchronizedList(new ArrayList<>());
+    List<Map<String, String>> failedAttachments = Collections.synchronizedList(new ArrayList<>());
+    List<String> successfulObjectIds = Collections.synchronizedList(new ArrayList<>());
 
     // Fetch SDM validation data
     SDMValidationData validationData = fetchSDMValidationData(request);
-    List<String> validSecondaryProperties = validationData.validSecondaryProperties;
-    Map<String, String> entityAnnotations = validationData.entityAnnotations;
-    com.sap.cds.reflect.CdsEntity targetEntity = validationData.targetEntity;
+    List<String> validSecondaryProperties = validationData.getValidSecondaryProperties();
+    Map<String, String> entityAnnotations = validationData.getEntityAnnotations();
+    CdsEntity targetEntity = validationData.getTargetEntity();
 
     // Preserve request context for authentication in parallel threads
-    com.sap.cds.services.runtime.RequestContextRunner contextRunner =
-        request.getContext().getCdsRuntime().requestContext();
+    RequestContextRunner contextRunner = request.getContext().getCdsRuntime().requestContext();
 
     // Create results wrapper for successful processing
     AttachmentProcessingResults processingResults =
         new AttachmentProcessingResults(
             successfulObjectIds, movedAttachmentsMetadata, populatedDocuments);
+
+    logger.info(
+        "Starting parallel move operation for {} attachments using {} threads",
+        request.getObjectIds().size(),
+        PARALLEL_MOVE_THREAD_POOL_SIZE);
 
     // Process each attachment in parallel: Move → Validate → Process/Rollback immediately
     List<CompletableFuture<Void>> processFutures =
@@ -730,65 +632,41 @@ public class SDMCustomServiceHandler {
     failedAttachments.add(failure);
   }
 
-  /** Helper class to hold attachment processing context for parallel execution. */
-  private static class AttachmentMoveContext {
-    final String objectId;
-    final MoveAttachmentsRequest request;
-    final List<String> validSecondaryProperties;
-    final Map<String, String> entityAnnotations;
-    final com.sap.cds.reflect.CdsEntity targetEntity;
-    final AttachmentProcessingResults processingResults;
-    final List<Map<String, String>> failedAttachments;
-
-    AttachmentMoveContext(
-        String objectId,
-        MoveAttachmentsRequest request,
-        List<String> validSecondaryProperties,
-        Map<String, String> entityAnnotations,
-        com.sap.cds.reflect.CdsEntity targetEntity,
-        AttachmentProcessingResults processingResults,
-        List<Map<String, String>> failedAttachments) {
-      this.objectId = objectId;
-      this.request = request;
-      this.validSecondaryProperties = validSecondaryProperties;
-      this.entityAnnotations = entityAnnotations;
-      this.targetEntity = targetEntity;
-      this.processingResults = processingResults;
-      this.failedAttachments = failedAttachments;
-    }
-  }
-
   /**
    * Processes a single attachment move: Move in SDM → Validate → Process or Rollback.
    *
    * @param moveContext the context containing all necessary information for processing
    */
   private void processSingleAttachmentMove(AttachmentMoveContext moveContext) {
+    String threadName = Thread.currentThread().getName();
+    logger.info(
+        "[Thread: {}] Starting move for attachment: {}", threadName, moveContext.getObjectId());
     try {
       // Step 1: Fetch attachment metadata from database to get type and URL (needed for link
       // attachments)
       // Create a copy event context to fetch attachment from source location
-      AttachmentMoveEventContext eventContext = moveContext.request.getContext();
+      AttachmentMoveEventContext eventContext = moveContext.getRequest().getContext();
       AttachmentCopyEventContext copyContext = AttachmentCopyEventContext.create();
       copyContext.setParentEntity(eventContext.getSourceParentEntity());
       copyContext.setCompositionName(eventContext.getSourceCompositionName());
 
       CmisDocument cmisDocument =
-          dbQuery.getAttachmentForObjectID(persistenceService, moveContext.objectId, copyContext);
+          dbQuery.getAttachmentForObjectID(
+              persistenceService, moveContext.getObjectId(), copyContext);
 
       // Set move operation specific fields
-      cmisDocument.setObjectId(moveContext.objectId);
-      cmisDocument.setRepositoryId(moveContext.request.getRepositoryId());
-      cmisDocument.setSourceFolderId(moveContext.request.getSourceFolderId());
-      cmisDocument.setFolderId(moveContext.request.getTargetFolderId());
+      cmisDocument.setObjectId(moveContext.getObjectId());
+      cmisDocument.setRepositoryId(moveContext.getRequest().getRepositoryId());
+      cmisDocument.setSourceFolderId(moveContext.getRequest().getSourceFolderId());
+      cmisDocument.setFolderId(moveContext.getRequest().getTargetFolderId());
 
       String sdmResponseJson =
           sdmService.moveAttachment(
               cmisDocument,
-              moveContext.request.getSdmCredentials(),
-              moveContext.request.getIsSystemUser());
-      org.json.JSONObject sdmResponse = new org.json.JSONObject(sdmResponseJson);
-      org.json.JSONObject succinctProperties = sdmResponse.getJSONObject("succinctProperties");
+              moveContext.getRequest().getSdmCredentials(),
+              moveContext.getRequest().getIsSystemUser());
+      JSONObject sdmResponse = new JSONObject(sdmResponseJson);
+      JSONObject succinctProperties = sdmResponse.getJSONObject("succinctProperties");
 
       String fileName = succinctProperties.optString("cmis:name");
       String mimeType = succinctProperties.optString("cmis:contentStreamMimeType");
@@ -796,24 +674,27 @@ public class SDMCustomServiceHandler {
       String movedObjectId = succinctProperties.optString("cmis:objectId");
 
       logger.info(
-          "Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}",
-          moveContext.objectId,
+          "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}",
+          Thread.currentThread().getName(),
+          moveContext.getObjectId(),
           fileName,
           mimeType);
       logger.info(
           "SDM response for attachment {} contains {} total properties: {}",
-          moveContext.objectId,
+          moveContext.getObjectId(),
           succinctProperties.length(),
           succinctProperties.keySet());
 
       // Step 2: Validate target entity properties in SDM response
       // Get target entity's SDM property names from annotations
-      Set<String> targetEntitySdmProperties = new HashSet<>(moveContext.entityAnnotations.values());
+      Set<String> targetEntitySdmProperties =
+          new HashSet<>(moveContext.getEntityAnnotations().values());
       Set<String> sdmResponseProperties = new HashSet<>(succinctProperties.keySet());
 
       logger.info(
-          "Validating attachment {} - Target entity expects {} SDM properties: {}",
-          moveContext.objectId,
+          "[Thread: {}] Validating attachment {} - Target entity expects {} SDM properties: {}",
+          Thread.currentThread().getName(),
+          moveContext.getObjectId(),
           targetEntitySdmProperties.size(),
           targetEntitySdmProperties);
       logger.info(
@@ -822,21 +703,21 @@ public class SDMCustomServiceHandler {
           sdmResponseProperties);
       logger.info(
           "Valid secondary properties list has {} entries: {}",
-          moveContext.validSecondaryProperties.size(),
-          moveContext.validSecondaryProperties);
+          moveContext.getValidSecondaryProperties().size(),
+          moveContext.getValidSecondaryProperties());
 
       // Validate: Check target entity properties that exist in SDM response
       List<String> invalidProperties = new ArrayList<>();
       for (String targetSdmProperty : targetEntitySdmProperties) {
         if (sdmResponseProperties.contains(targetSdmProperty)
-            && !moveContext.validSecondaryProperties.contains(targetSdmProperty)) {
+            && !moveContext.getValidSecondaryProperties().contains(targetSdmProperty)) {
           // Property defined in target entity, present in SDM response, but NOT in valid list →
           // INVALID
           invalidProperties.add(targetSdmProperty);
           logger.warn(
               "Attachment {} - Property '{}' is defined in target entity and in SDM response but"
                   + " NOT in valid secondary properties list",
-              moveContext.objectId,
+              moveContext.getObjectId(),
               targetSdmProperty);
         }
       }
@@ -844,116 +725,103 @@ public class SDMCustomServiceHandler {
       if (!invalidProperties.isEmpty()) {
         // Step 3a: Validation failed → Rollback immediately
         handleValidationFailure(
-            moveContext.objectId,
+            moveContext.getObjectId(),
             invalidProperties,
-            moveContext.request,
-            moveContext.failedAttachments);
+            moveContext.getRequest(),
+            moveContext.getFailedAttachments());
 
       } else {
         // Step 3b: Validation passed → Process for DB insertion
-        processValidatedAttachment(
-            moveContext.objectId,
-            fileName,
-            mimeType,
-            description,
-            movedObjectId,
-            succinctProperties,
-            moveContext.entityAnnotations,
-            moveContext.targetEntity,
-            moveContext.processingResults,
-            cmisDocument);
+        ValidatedAttachmentData validatedData =
+            new ValidatedAttachmentData(
+                moveContext.getObjectId(),
+                fileName,
+                mimeType,
+                description,
+                movedObjectId,
+                succinctProperties,
+                moveContext.getEntityAnnotations(),
+                moveContext.getTargetEntity(),
+                moveContext.getProcessingResults().getSuccessfulObjectIds(),
+                moveContext.getProcessingResults().getMovedAttachmentsMetadata(),
+                moveContext.getProcessingResults().getPopulatedDocuments(),
+                cmisDocument);
+        processValidatedAttachment(validatedData);
       }
 
     } catch (ServiceException | IOException e) {
       // Move operation failed
-      logger.error("Failed to move attachment {}: {}", moveContext.objectId, e.getMessage());
+      logger.error(
+          "[Thread: {}] Failed to move attachment {}: {}",
+          Thread.currentThread().getName(),
+          moveContext.getObjectId(),
+          e.getMessage());
       Map<String, String> failure = new HashMap<>();
-      failure.put(OBJECT_ID_KEY, moveContext.objectId);
+      failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
       failure.put(FAILURE_REASON_KEY, "SDM move failed: " + e.getMessage());
-      moveContext.failedAttachments.add(failure);
+      moveContext.getFailedAttachments().add(failure);
     } catch (Exception e) {
       // Validation/processing failed
       logger.error(
-          "Failed to validate/process attachment {}: {}", moveContext.objectId, e.getMessage(), e);
+          "Failed to validate/process attachment {}: {}",
+          moveContext.getObjectId(),
+          e.getMessage(),
+          e);
       Map<String, String> failure = new HashMap<>();
-      failure.put(OBJECT_ID_KEY, moveContext.objectId);
+      failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
       failure.put(FAILURE_REASON_KEY, "Validation/processing failed: " + e.getMessage());
-      moveContext.failedAttachments.add(failure);
-    }
-  }
-
-  /** Helper class to hold results for processed attachments. */
-  private static class AttachmentProcessingResults {
-    final List<String> successfulObjectIds;
-    final List<List<String>> movedAttachmentsMetadata;
-    final List<CmisDocument> populatedDocuments;
-
-    AttachmentProcessingResults(
-        List<String> successfulObjectIds,
-        List<List<String>> movedAttachmentsMetadata,
-        List<CmisDocument> populatedDocuments) {
-      this.successfulObjectIds = successfulObjectIds;
-      this.movedAttachmentsMetadata = movedAttachmentsMetadata;
-      this.populatedDocuments = populatedDocuments;
+      moveContext.getFailedAttachments().add(failure);
     }
   }
 
   /**
    * Processes a successfully validated attachment for DB insertion.
    *
-   * @param objectId the attachment object ID
-   * @param fileName the file name
-   * @param mimeType the MIME type
-   * @param description the description (note) from cmis:description
-   * @param movedObjectId the new object ID after move
-   * @param succinctProperties SDM response properties
-   * @param entityAnnotations mapping of DB fields to SDM properties
-   * @param targetEntity the target attachment entity (for type checking)
-   * @param results holder for successful processing results
-   * @param sourceCmisDocument the original cmisDocument from database with type and URL
+   * @param data encapsulated validated attachment data
    */
-  private void processValidatedAttachment(
-      String objectId,
-      String fileName,
-      String mimeType,
-      String description,
-      String movedObjectId,
-      org.json.JSONObject succinctProperties,
-      Map<String, String> entityAnnotations,
-      com.sap.cds.reflect.CdsEntity targetEntity,
-      AttachmentProcessingResults results,
-      CmisDocument sourceCmisDocument) {
-    logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
-    logger.info("Entity annotations mapping (DB field -> SDM property): {}", entityAnnotations);
+  private void processValidatedAttachment(ValidatedAttachmentData data) {
+    logger.info(
+        "[Thread: {}] Attachment {} validation PASSED - Processing for DB insertion",
+        Thread.currentThread().getName(),
+        data.getObjectId());
+    logger.info(
+        "Entity annotations mapping (DB field -> SDM property): {}", data.getEntityAnnotations());
 
-    CmisDocument populatedDocument =
-        createPopulatedDocument(succinctProperties, sourceCmisDocument);
+    CmisDocument populatedDocument = createPopulatedDocument(data.getSourceCmisDocument());
     Map<String, Object> filteredSecondaryProps =
-        filterSecondaryProperties(objectId, succinctProperties, entityAnnotations, targetEntity);
+        filterSecondaryProperties(
+            data.getObjectId(),
+            data.getSuccinctProperties(),
+            data.getEntityAnnotations(),
+            data.getTargetEntity());
 
     populatedDocument.setSecondaryProperties(filteredSecondaryProps);
 
     logger.info(
         "Attachment {} - Prepared {} properties for DB insertion: {}",
-        objectId,
+        data.getObjectId(),
         filteredSecondaryProps.size(),
         filteredSecondaryProps);
 
     // Add to successful results
-    results.successfulObjectIds.add(objectId);
-    results.movedAttachmentsMetadata.add(List.of(fileName, mimeType, description, movedObjectId));
-    results.populatedDocuments.add(populatedDocument);
+    data.getSuccessfulObjectIds().add(data.getObjectId());
+    data.getMovedAttachmentsMetadata()
+        .add(
+            List.of(
+                data.getFileName(),
+                data.getMimeType(),
+                data.getDescription(),
+                data.getMovedObjectId()));
+    data.getPopulatedDocuments().add(populatedDocument);
   }
 
   /**
-   * Creates a CmisDocument with basic metadata from SDM response and source document.
+   * Creates a CmisDocument with basic metadata from source document.
    *
-   * @param succinctProperties SDM response properties
    * @param sourceCmisDocument the original cmisDocument from database with type and URL
    * @return populated CmisDocument
    */
-  private CmisDocument createPopulatedDocument(
-      org.json.JSONObject succinctProperties, CmisDocument sourceCmisDocument) {
+  private CmisDocument createPopulatedDocument(CmisDocument sourceCmisDocument) {
     CmisDocument document = new CmisDocument();
     // Preserve type and URL from source document (fetched from database)
     // This is essential for link attachments where URL is not in SDM response
@@ -973,9 +841,9 @@ public class SDMCustomServiceHandler {
    */
   private Map<String, Object> filterSecondaryProperties(
       String objectId,
-      org.json.JSONObject succinctProperties,
+      JSONObject succinctProperties,
       Map<String, String> entityAnnotations,
-      com.sap.cds.reflect.CdsEntity targetEntity) {
+      CdsEntity targetEntity) {
     Map<String, Object> filteredProperties = new HashMap<>();
 
     for (Map.Entry<String, String> propEntry : entityAnnotations.entrySet()) {
@@ -991,7 +859,7 @@ public class SDMCustomServiceHandler {
       if (succinctProperties.has(sdmPropertyName)) {
         Object value = succinctProperties.get(sdmPropertyName);
         processSecondaryProperty(
-            objectId, dbPropertyName, sdmPropertyName, value, targetEntity, filteredProperties);
+            dbPropertyName, sdmPropertyName, value, targetEntity, filteredProperties);
       }
     }
 
@@ -1001,7 +869,6 @@ public class SDMCustomServiceHandler {
   /**
    * Processes a single secondary property: logs, converts if needed, and adds to filtered map.
    *
-   * @param objectId the attachment object ID (for logging)
    * @param dbPropertyName the DB field name
    * @param sdmPropertyName the SDM property name
    * @param value the property value from SDM
@@ -1009,11 +876,10 @@ public class SDMCustomServiceHandler {
    * @param filteredProperties the map to add the processed property to
    */
   private void processSecondaryProperty(
-      String objectId,
       String dbPropertyName,
       String sdmPropertyName,
       Object value,
-      com.sap.cds.reflect.CdsEntity targetEntity,
+      CdsEntity targetEntity,
       Map<String, Object> filteredProperties) {
     logger.info(
         "Found SDM property '{}' with value: {} (type: {})",
@@ -1021,7 +887,7 @@ public class SDMCustomServiceHandler {
         value,
         value != null ? value.getClass().getSimpleName() : "null");
 
-    if (value == null || org.json.JSONObject.NULL.equals(value)) {
+    if (value == null || JSONObject.NULL.equals(value)) {
       return;
     }
 
@@ -1039,15 +905,14 @@ public class SDMCustomServiceHandler {
    * @param targetEntity the target entity for type checking
    * @return converted value or original value if no conversion needed
    */
-  private Object convertValueIfNeeded(
-      Object value, String dbPropertyName, com.sap.cds.reflect.CdsEntity targetEntity) {
+  private Object convertValueIfNeeded(Object value, String dbPropertyName, CdsEntity targetEntity) {
     if (!(value instanceof Long)) {
       return value;
     }
 
-    com.sap.cds.reflect.CdsElement element = targetEntity.getElement(dbPropertyName);
+    CdsElement element = targetEntity.getElement(dbPropertyName);
     if (isDateTimeField(element)) {
-      Object converted = java.time.Instant.ofEpochMilli((Long) value);
+      Object converted = Instant.ofEpochMilli((Long) value);
       logger.info(
           "Converted Long timestamp {} to Instant {} for DateTime field '{}'",
           value,
@@ -1072,7 +937,7 @@ public class SDMCustomServiceHandler {
    * @param element the CDS element
    * @return true if the element is a DateTime field
    */
-  private boolean isDateTimeField(com.sap.cds.reflect.CdsElement element) {
+  private boolean isDateTimeField(CdsElement element) {
     return element != null
         && element.getType() != null
         && "cds.DateTime".equals(element.getType().getQualifiedName());
@@ -1148,20 +1013,14 @@ public class SDMCustomServiceHandler {
    * Creates draft entries for moved attachments with secondary properties support. This method is
    * specifically for move operations where we need to preserve validated secondary properties from
    * the SDM response.
+   *
+   * @param data encapsulated draft entry creation data
    */
-  private void createDraftEntriesForMove(
-      List<List<String>> movedAttachmentsMetadata,
-      List<CmisDocument> populatedDocuments,
-      String parentEntity,
-      String compositionName,
-      String upID,
-      String upIdKey,
-      String repositoryId,
-      String folderId) {
+  private void createDraftEntriesForMove(DraftEntryMoveData data) {
 
-    for (int i = 0; i < movedAttachmentsMetadata.size(); i++) {
-      List<String> attachmentMetadata = movedAttachmentsMetadata.get(i);
-      CmisDocument cmisDocument = populatedDocuments.get(i);
+    for (int i = 0; i < data.getMovedAttachmentsMetadata().size(); i++) {
+      List<String> attachmentMetadata = data.getMovedAttachmentsMetadata().get(i);
+      CmisDocument cmisDocument = data.getPopulatedDocuments().get(i);
       Map<String, Object> updatedFields = new HashMap<>();
 
       String fileName = attachmentMetadata.get(0);
@@ -1170,8 +1029,8 @@ public class SDMCustomServiceHandler {
       String newObjectId = attachmentMetadata.get(3);
 
       updatedFields.put(OBJECT_ID_KEY, newObjectId);
-      updatedFields.put("repositoryId", repositoryId);
-      updatedFields.put("folderId", folderId);
+      updatedFields.put("repositoryId", data.getRepositoryId());
+      updatedFields.put("folderId", data.getFolderId());
       updatedFields.put("status", "Clean");
       updatedFields.put("mimeType", mimeType);
       updatedFields.put("type", cmisDocument.getType());
@@ -1184,14 +1043,14 @@ public class SDMCustomServiceHandler {
           "contentId",
           newObjectId
               + ":"
-              + folderId
+              + data.getFolderId()
               + ":"
-              + parentEntity
+              + data.getParentEntity()
               + "."
-              + compositionName
+              + data.getCompositionName()
               + ":"
               + mimeType);
-      updatedFields.put(upIdKey, upID);
+      updatedFields.put(data.getUpIdKey(), data.getUpID());
 
       // Include secondary properties from moved attachment
       // Properties are already filtered and validated in processValidatedAttachment()
@@ -1214,21 +1073,26 @@ public class SDMCustomServiceHandler {
           updatedFields.size(),
           updatedFields.keySet());
 
-      String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
+      String baseKeyField =
+          data.getUpIdKey() != null ? data.getUpIdKey().replace("up__", "") : "ID";
       var insert =
-          Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
+          Insert.into(
+                  data.getParentEntity(),
+                  e ->
+                      e.filter(e.get(baseKeyField).eq(data.getUpID()))
+                          .to(data.getCompositionName()))
               .entry(updatedFields);
 
       DraftService matchingService =
           draftService.stream()
-              .filter(ds -> parentEntity.contains(ds.getName()))
+              .filter(ds -> data.getParentEntity().contains(ds.getName()))
               .findFirst()
               .orElse(null);
 
       if (matchingService != null) {
         // Wrap DB insert with retry logic to handle transient DB failures
         try {
-          io.reactivex.Flowable.fromCallable(
+          Flowable.fromCallable(
                   () -> {
                     matchingService.newDraft(insert);
                     return true;
@@ -1240,7 +1104,8 @@ public class SDMCustomServiceHandler {
               "Failed to insert attachment entry in DB after retries: " + e.getMessage(), e);
         }
       } else {
-        throw new ServiceException("No suitable service found for entity: " + parentEntity);
+        throw new ServiceException(
+            "No suitable service found for entity: " + data.getParentEntity());
       }
     }
   }
@@ -1318,7 +1183,7 @@ public class SDMCustomServiceHandler {
       if (matchingService != null) {
         // Wrap DB insert with retry logic to handle transient DB failures
         try {
-          io.reactivex.Flowable.fromCallable(
+          Flowable.fromCallable(
                   () -> {
                     matchingService.newDraft(insert);
                     return true;
@@ -1363,8 +1228,7 @@ public class SDMCustomServiceHandler {
         targetFolderId,
         sourceFolderId);
 
-    com.sap.cds.services.runtime.RequestContextRunner contextRunner =
-        context.getCdsRuntime().requestContext();
+    RequestContextRunner contextRunner = context.getCdsRuntime().requestContext();
 
     List<CompletableFuture<Void>> rollbackFutures =
         successfulObjectIds.stream()

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -248,12 +248,19 @@ public class SDMCustomServiceHandler {
         // Only clean up successfully moved attachments (not failed ones)
         // Use the OLD objectIds (before move) to identify source records
         List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
+        logger.info(
+            "DEBUG: successfulMovesMap contains {} entries. Keys (OLD IDs): {}, Values (NEW IDs):"
+                + " {}",
+            successfulMovesMap.size(),
+            oldObjectIds,
+            new ArrayList<>(successfulMovesMap.values()));
         if (!oldObjectIds.isEmpty()) {
           try {
             // Get the source up__ID from the database to filter cleanup
             // This is critical when source and target are the same entity type
             String sourceUpId =
                 dbQuery.getSourceUpIdForObjectIds(persistenceService, oldObjectIds, context);
+            logger.info("DEBUG: Retrieved source up__ID: {}", sourceUpId);
 
             int deletedCount =
                 dbQuery.deleteAttachmentsByObjectIds(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -80,22 +80,25 @@ public class SDMCustomServiceHandler {
     this.executorService = Executors.newFixedThreadPool(PARALLEL_MOVE_THREAD_POOL_SIZE);
   }
 
-  // Result class for moveAttachmentsInSDM method
+  /**
+   * Encapsulates the result of a batch move operation in SDM. Contains metadata for successfully
+   * moved attachments and tracks failures.
+   */
   private static class MoveAttachmentsResult {
     private final List<List<String>> movedAttachmentsMetadata;
     private final List<CmisDocument> populatedDocuments;
     private final List<String> failedObjectIds;
-    private final Map<String, String> successfulMovesMap; // objectId -> newObjectId mapping
+    private final List<String> successfulObjectIds;
 
     public MoveAttachmentsResult(
         List<List<String>> movedAttachmentsMetadata,
         List<CmisDocument> populatedDocuments,
         List<String> failedObjectIds,
-        Map<String, String> successfulMovesMap) {
+        List<String> successfulObjectIds) {
       this.movedAttachmentsMetadata = movedAttachmentsMetadata;
       this.populatedDocuments = populatedDocuments;
       this.failedObjectIds = failedObjectIds;
-      this.successfulMovesMap = successfulMovesMap;
+      this.successfulObjectIds = successfulObjectIds;
     }
 
     public List<List<String>> getMovedAttachmentsMetadata() {
@@ -110,8 +113,8 @@ public class SDMCustomServiceHandler {
       return failedObjectIds;
     }
 
-    public Map<String, String> getSuccessfulMovesMap() {
-      return successfulMovesMap;
+    public List<String> getSuccessfulObjectIds() {
+      return successfulObjectIds;
     }
   }
 
@@ -168,6 +171,14 @@ public class SDMCustomServiceHandler {
     context.setCompleted();
   }
 
+  /**
+   * Moves attachments from source entity to target entity in SDM. Executes moves in parallel,
+   * updates database records, and cleans up source metadata. If any step fails, the operation is
+   * rolled back to maintain consistency.
+   *
+   * @param context the move event context containing source and target information
+   * @throws IOException if there's an error during the move operation
+   */
   @On(event = RegisterService.EVENT_MOVE_ATTACHMENT)
   public void moveAttachments(AttachmentMoveEventContext context) throws IOException {
     String parentEntity = context.getParentEntity();
@@ -181,7 +192,7 @@ public class SDMCustomServiceHandler {
 
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
 
-    // Check if target folder exists before trying to create it
+    // Ensure target folder exists in SDM before attempting moves
     boolean targetFolderExists;
     String targetFolderId;
     try {
@@ -191,7 +202,6 @@ public class SDMCustomServiceHandler {
       targetFolderId =
           ensureFolderExists(targetFolderName, repositoryId, sdmCredentials, isSystemUser);
     } catch (IOException e) {
-      // Folder creation/verification failed - mark all objectIds as failed
       logger.error(
           "Failed to create/verify target folder '{}': {}. Marking all {} attachments as failed.",
           targetFolderName,
@@ -219,13 +229,12 @@ public class SDMCustomServiceHandler {
     List<List<String>> movedAttachmentsMetadata = moveResult.getMovedAttachmentsMetadata();
     List<CmisDocument> populatedDocuments = moveResult.getPopulatedDocuments();
     List<String> failedObjectIds = moveResult.getFailedObjectIds();
-    Map<String, String> successfulMovesMap = moveResult.getSuccessfulMovesMap();
+    List<String> successfulObjectIds = moveResult.getSuccessfulObjectIds();
 
-    // Set the failed object IDs in the context for the caller
-    // Convert to ArrayList to avoid Collections$SynchronizedRandomAccessList serialization issue
+    // Return failed object IDs to caller (convert to ArrayList for serialization)
     context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
 
-    // Only create draft entries for successfully moved attachments
+    // Process successfully moved attachments
     if (!movedAttachmentsMetadata.isEmpty()) {
       String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
 
@@ -242,69 +251,57 @@ public class SDMCustomServiceHandler {
               .build();
 
       try {
-        // Get the source up__ID BEFORE creating draft entries
-        // This is critical when source and target are the same entity type
-        // We must query before createDraftEntries to avoid getting the target up__ID
-        List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
+        // Query source entity's up__ID before creating target records
+        // This ensures we get the correct source ID, especially important when moving
+        // between entities of the same type (e.g., Book A to Book B)
         String sourceUpId = null;
-        if (!oldObjectIds.isEmpty()) {
-          sourceUpId = dbQuery.getSourceUpIdForObjectIds(persistenceService, oldObjectIds, context);
-          logger.info("DEBUG: Retrieved source up__ID BEFORE createDraftEntries: {}", sourceUpId);
+        if (!successfulObjectIds.isEmpty()) {
+          sourceUpId =
+              dbQuery.getSourceUpIdForObjectIds(persistenceService, successfulObjectIds, context);
+          logger.info("Retrieved source up__ID for cleanup: {}", sourceUpId);
         }
 
         createDraftEntries(draftRequest);
 
-        // After successful DB update, clean up source entity metadata
-        // Only clean up successfully moved attachments (not failed ones)
-        logger.info(
-            "DEBUG: successfulMovesMap contains {} entries. Keys (OLD IDs): {}, Values (NEW IDs):"
-                + " {}",
-            successfulMovesMap.size(),
-            oldObjectIds,
-            new ArrayList<>(successfulMovesMap.values()));
-        if (!oldObjectIds.isEmpty() && sourceUpId != null) {
+        // Clean up source entity metadata after successful move
+        if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
           try {
-
             int deletedCount =
                 dbQuery.deleteAttachmentsByObjectIds(
-                    persistenceService, oldObjectIds, sourceUpId, context);
+                    persistenceService, successfulObjectIds, sourceUpId, context);
             logger.info(
                 "Cleaned up {} attachment metadata records from source entity for {} successfully"
                     + " moved attachments",
                 deletedCount,
-                oldObjectIds.size());
+                successfulObjectIds.size());
           } catch (Exception cleanupException) {
-            // Log cleanup failure but don't fail the entire move operation
             logger.warn(
                 "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
                     + " successfully moved to target.",
-                oldObjectIds.size(),
+                successfulObjectIds.size(),
                 cleanupException.getMessage());
           }
         }
       } catch (ServiceException e) {
-        // If DB update fails after retries, rollback the SDM moves
+        // Database update failed - rollback all SDM moves to maintain consistency
         logger.error(
             "Failed to update DB for moved attachments after retries. Rolling back SDM moves: {}",
             e.getMessage());
         rollbackMovedAttachments(
-            successfulMovesMap,
+            successfulObjectIds,
             sourceFolderId,
             targetFolderId,
             repositoryId,
             sdmCredentials,
             isSystemUser,
             context);
-        // Add all successfully moved objects to failed list since we rolled back
-        failedObjectIds.addAll(successfulMovesMap.keySet());
-        // Convert to ArrayList to avoid Collections$SynchronizedRandomAccessList serialization
-        // issue
+        // Mark rolled-back attachments as failed
+        failedObjectIds.addAll(successfulObjectIds);
         context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
-        // Don't throw exception - return failed IDs to caller as per acceptance criteria
         logger.warn(
             "Move operation completed with failures. Total failed: {}, Rolled back: {}",
             failedObjectIds.size(),
-            successfulMovesMap.size());
+            successfulObjectIds.size());
       }
     }
 
@@ -362,6 +359,14 @@ public class SDMCustomServiceHandler {
     return new CopyAttachmentsResult(attachmentsMetadata, populatedDocuments);
   }
 
+  /**
+   * Executes attachment moves in parallel using a thread pool. Tracks successful and failed moves
+   * separately for further processing.
+   *
+   * @param request the move request containing attachments to move
+   * @return result containing moved metadata and success/failure tracking
+   * @throws IOException if parallel execution fails
+   */
   private MoveAttachmentsResult moveAttachmentsInSDM(MoveAttachmentsRequest request)
       throws IOException {
     List<List<String>> movedAttachmentsMetadata =
@@ -369,21 +374,19 @@ public class SDMCustomServiceHandler {
     List<CmisDocument> populatedDocuments =
         java.util.Collections.synchronizedList(new ArrayList<>());
     List<String> failedObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
-    Map<String, String> successfulMovesMap =
-        new java.util.concurrent.ConcurrentHashMap<>(); // objectId -> newObjectId
+    List<String> successfulObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
 
-    // Capture the current request context to propagate to background threads
+    // Preserve request context for authentication in parallel threads
     com.sap.cds.services.runtime.RequestContextRunner contextRunner =
         request.getContext().getCdsRuntime().requestContext();
 
-    // Create parallel tasks for each attachment move
+    // Execute moves in parallel for better performance
     List<CompletableFuture<Void>> moveFutures =
         request.getObjectIds().stream()
             .map(
                 objectId ->
                     CompletableFuture.runAsync(
                         () ->
-                            // Run within the captured request context to preserve authentication
                             contextRunner.run(
                                 ctx -> {
                                   try {
@@ -395,27 +398,25 @@ public class SDMCustomServiceHandler {
                                     cmisDocument.setSourceFolderId(request.getSourceFolderId());
                                     cmisDocument.setFolderId(request.getTargetFolderId());
 
-                                    // Create individual document for each attachment with its own
-                                    // type and linkUrl
                                     CmisDocument populatedDocument = new CmisDocument();
                                     populatedDocument.setType(cmisDocument.getType());
                                     populatedDocument.setUrl(cmisDocument.getUrl());
 
-                                    // Perform SDM move operation with retry
+                                    // Move attachment in SDM with automatic retry on transient
+                                    // failures
                                     List<String> metadata =
                                         sdmService.moveAttachment(
                                             cmisDocument,
                                             request.getSdmCredentials(),
                                             request.getIsSystemUser());
 
-                                    // Track successful move for rollback (thread-safe)
-                                    String newObjectId = metadata.get(2);
-                                    successfulMovesMap.put(objectId, newObjectId);
+                                    // Track successful move (SDM preserves objectId within same
+                                    // repository)
+                                    successfulObjectIds.add(objectId);
                                     movedAttachmentsMetadata.add(metadata);
                                     populatedDocuments.add(populatedDocument);
                                   } catch (ServiceException | IOException e) {
-                                    // Add to failed list and continue with next attachment
-                                    // (thread-safe)
+                                    // Track failure and continue with remaining attachments
                                     logger.error(
                                         "Failed to move attachment with objectId {}: {}",
                                         objectId,
@@ -435,7 +436,7 @@ public class SDMCustomServiceHandler {
     }
 
     return new MoveAttachmentsResult(
-        movedAttachmentsMetadata, populatedDocuments, failedObjectIds, successfulMovesMap);
+        movedAttachmentsMetadata, populatedDocuments, failedObjectIds, successfulObjectIds);
   }
 
   private void handleCopyFailure(
@@ -559,11 +560,20 @@ public class SDMCustomServiceHandler {
   }
 
   /**
-   * Rollback moved attachments by moving them back to the source folder. This is called when DB
-   * update fails after SDM move succeeds.
+   * Rolls back successfully moved attachments when database update fails. Moves attachments back to
+   * their original source folder in parallel. Continues with remaining rollbacks even if individual
+   * operations fail.
+   *
+   * @param successfulObjectIds list of objectIds that were successfully moved in SDM
+   * @param sourceFolderId original source folder ID
+   * @param targetFolderId target folder ID where attachments were moved
+   * @param repositoryId SDM repository ID
+   * @param sdmCredentials SDM credentials for authentication
+   * @param isSystemUser whether this is a system user operation
+   * @param context the move event context
    */
   private void rollbackMovedAttachments(
-      Map<String, String> successfulMovesMap,
+      List<String> successfulObjectIds,
       String sourceFolderId,
       String targetFolderId,
       String repositoryId,
@@ -572,44 +582,38 @@ public class SDMCustomServiceHandler {
       AttachmentMoveEventContext context) {
     logger.warn(
         "Rolling back {} moved attachments from {} to {}",
-        successfulMovesMap.size(),
+        successfulObjectIds.size(),
         targetFolderId,
         sourceFolderId);
 
-    // Capture the current request context to propagate to background threads
     com.sap.cds.services.runtime.RequestContextRunner contextRunner =
         context.getCdsRuntime().requestContext();
 
     List<CompletableFuture<Void>> rollbackFutures =
-        successfulMovesMap.entrySet().stream()
+        successfulObjectIds.stream()
             .map(
-                entry ->
+                objectId ->
                     CompletableFuture.runAsync(
                         () ->
                             contextRunner.run(
                                 ctx -> {
-                                  String originalObjectId = entry.getKey();
-                                  String newObjectId = entry.getValue();
                                   try {
-                                    // Create CMIS document for rollback move
                                     CmisDocument rollbackDoc = new CmisDocument();
-                                    rollbackDoc.setObjectId(newObjectId);
+                                    rollbackDoc.setObjectId(objectId);
                                     rollbackDoc.setRepositoryId(repositoryId);
                                     rollbackDoc.setSourceFolderId(targetFolderId);
                                     rollbackDoc.setFolderId(sourceFolderId);
 
-                                    // Move back to source folder with retry
                                     sdmService.moveAttachment(
                                         rollbackDoc, sdmCredentials, isSystemUser);
                                     logger.info(
                                         "Successfully rolled back attachment {} to source folder",
-                                        originalObjectId);
+                                        objectId);
                                   } catch (Exception e) {
                                     logger.error(
-                                        "Failed to rollback attachment {} during rollback: {}",
-                                        originalObjectId,
+                                        "Failed to rollback attachment {}: {}",
+                                        objectId,
                                         e.getMessage());
-                                    // Continue with other rollbacks even if one fails
                                   }
                                   return null;
                                 }),

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -913,59 +913,9 @@ public class SDMCustomServiceHandler {
     logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
     logger.info("Entity annotations mapping (DB field -> SDM property): {}", entityAnnotations);
 
-    CmisDocument populatedDocument = new CmisDocument();
-    populatedDocument.setType(succinctProperties.optString("sap:type", null));
-    populatedDocument.setUrl(succinctProperties.optString("sap:linkURL", null));
-
-    // Filter secondary properties for DB
-    Map<String, Object> filteredSecondaryProps = new HashMap<>();
-    for (Map.Entry<String, String> propEntry : entityAnnotations.entrySet()) {
-      String dbPropertyName = propEntry.getKey();
-      String sdmPropertyName = propEntry.getValue();
-
-      logger.info(
-          "Checking property - DB field: '{}', SDM property: '{}', exists in SDM response: {}",
-          dbPropertyName,
-          sdmPropertyName,
-          succinctProperties.has(sdmPropertyName));
-
-      if (succinctProperties.has(sdmPropertyName)) {
-        Object value = succinctProperties.get(sdmPropertyName);
-        logger.info(
-            "Found SDM property '{}' with value: {} (type: {})",
-            sdmPropertyName,
-            value,
-            value != null ? value.getClass().getSimpleName() : "null");
-        if (value != null && !org.json.JSONObject.NULL.equals(value)) {
-          // Convert Long timestamp to Instant ONLY for DateTime fields
-          // Check the CDS type of the field to determine if conversion is needed
-          Object convertedValue = value;
-          if (value instanceof Long) {
-            com.sap.cds.reflect.CdsElement element = targetEntity.getElement(dbPropertyName);
-            if (element != null
-                && element.getType() != null
-                && "cds.DateTime".equals(element.getType().getQualifiedName())) {
-              convertedValue = java.time.Instant.ofEpochMilli((Long) value);
-              logger.info(
-                  "Converted Long timestamp {} to Instant {} for DateTime field '{}'",
-                  value,
-                  convertedValue,
-                  dbPropertyName);
-            } else {
-              logger.info(
-                  "Keeping Long value {} as-is for non-DateTime field '{}' (type: {})",
-                  value,
-                  dbPropertyName,
-                  element != null && element.getType() != null
-                      ? element.getType().getQualifiedName()
-                      : "unknown");
-            }
-          }
-          filteredSecondaryProps.put(dbPropertyName, convertedValue);
-          logger.info("Added to DB map: '{}' = '{}'", dbPropertyName, convertedValue);
-        }
-      }
-    }
+    CmisDocument populatedDocument = createPopulatedDocument(succinctProperties);
+    Map<String, Object> filteredSecondaryProps =
+        filterSecondaryProperties(objectId, succinctProperties, entityAnnotations, targetEntity);
 
     populatedDocument.setSecondaryProperties(filteredSecondaryProps);
 
@@ -979,6 +929,135 @@ public class SDMCustomServiceHandler {
     results.successfulObjectIds.add(objectId);
     results.movedAttachmentsMetadata.add(List.of(fileName, mimeType, description, movedObjectId));
     results.populatedDocuments.add(populatedDocument);
+  }
+
+  /**
+   * Creates a CmisDocument with basic metadata from SDM response.
+   *
+   * @param succinctProperties SDM response properties
+   * @return populated CmisDocument
+   */
+  private CmisDocument createPopulatedDocument(org.json.JSONObject succinctProperties) {
+    CmisDocument document = new CmisDocument();
+    document.setType(succinctProperties.optString("sap:type", null));
+    document.setUrl(succinctProperties.optString("sap:linkURL", null));
+    return document;
+  }
+
+  /**
+   * Filters and converts secondary properties from SDM response for DB insertion.
+   *
+   * @param objectId the attachment object ID (for logging)
+   * @param succinctProperties SDM response properties
+   * @param entityAnnotations mapping of DB fields to SDM properties
+   * @param targetEntity the target attachment entity (for type checking)
+   * @return filtered and converted properties map
+   */
+  private Map<String, Object> filterSecondaryProperties(
+      String objectId,
+      org.json.JSONObject succinctProperties,
+      Map<String, String> entityAnnotations,
+      com.sap.cds.reflect.CdsEntity targetEntity) {
+    Map<String, Object> filteredProperties = new HashMap<>();
+
+    for (Map.Entry<String, String> propEntry : entityAnnotations.entrySet()) {
+      String dbPropertyName = propEntry.getKey();
+      String sdmPropertyName = propEntry.getValue();
+
+      logger.info(
+          "Checking property - DB field: '{}', SDM property: '{}', exists in SDM response: {}",
+          dbPropertyName,
+          sdmPropertyName,
+          succinctProperties.has(sdmPropertyName));
+
+      if (succinctProperties.has(sdmPropertyName)) {
+        Object value = succinctProperties.get(sdmPropertyName);
+        processSecondaryProperty(
+            objectId, dbPropertyName, sdmPropertyName, value, targetEntity, filteredProperties);
+      }
+    }
+
+    return filteredProperties;
+  }
+
+  /**
+   * Processes a single secondary property: logs, converts if needed, and adds to filtered map.
+   *
+   * @param objectId the attachment object ID (for logging)
+   * @param dbPropertyName the DB field name
+   * @param sdmPropertyName the SDM property name
+   * @param value the property value from SDM
+   * @param targetEntity the target entity for type checking
+   * @param filteredProperties the map to add the processed property to
+   */
+  private void processSecondaryProperty(
+      String objectId,
+      String dbPropertyName,
+      String sdmPropertyName,
+      Object value,
+      com.sap.cds.reflect.CdsEntity targetEntity,
+      Map<String, Object> filteredProperties) {
+    logger.info(
+        "Found SDM property '{}' with value: {} (type: {})",
+        sdmPropertyName,
+        value,
+        value != null ? value.getClass().getSimpleName() : "null");
+
+    if (value == null || org.json.JSONObject.NULL.equals(value)) {
+      return;
+    }
+
+    Object convertedValue = convertValueIfNeeded(value, dbPropertyName, targetEntity);
+    filteredProperties.put(dbPropertyName, convertedValue);
+    logger.info("Added to DB map: '{}' = '{}'", dbPropertyName, convertedValue);
+  }
+
+  /**
+   * Converts value to appropriate type based on CDS field definition. Specifically handles Long to
+   * Instant conversion for DateTime fields.
+   *
+   * @param value the original value
+   * @param dbPropertyName the DB field name
+   * @param targetEntity the target entity for type checking
+   * @return converted value or original value if no conversion needed
+   */
+  private Object convertValueIfNeeded(
+      Object value, String dbPropertyName, com.sap.cds.reflect.CdsEntity targetEntity) {
+    if (!(value instanceof Long)) {
+      return value;
+    }
+
+    com.sap.cds.reflect.CdsElement element = targetEntity.getElement(dbPropertyName);
+    if (isDateTimeField(element)) {
+      Object converted = java.time.Instant.ofEpochMilli((Long) value);
+      logger.info(
+          "Converted Long timestamp {} to Instant {} for DateTime field '{}'",
+          value,
+          converted,
+          dbPropertyName);
+      return converted;
+    }
+
+    logger.info(
+        "Keeping Long value {} as-is for non-DateTime field '{}' (type: {})",
+        value,
+        dbPropertyName,
+        element != null && element.getType() != null
+            ? element.getType().getQualifiedName()
+            : "unknown");
+    return value;
+  }
+
+  /**
+   * Checks if a CDS element is a DateTime field.
+   *
+   * @param element the CDS element
+   * @return true if the element is a DateTime field
+   */
+  private boolean isDateTimeField(com.sap.cds.reflect.CdsElement element) {
+    return element != null
+        && element.getType() != null
+        && "cds.DateTime".equals(element.getType().getQualifiedName());
   }
 
   // Rollback a single attachment to source folder

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -246,7 +246,7 @@ public class SDMCustomServiceHandler {
               .compositionName(compositionName)
               .upID(upID)
               .upIdKey(upIdKey)
-              .repositoryId(repositoryId)
+              .repositoryId(targetFolderId)
               .folderId(targetFolderId)
               .build();
 
@@ -401,6 +401,9 @@ public class SDMCustomServiceHandler {
                                     CmisDocument populatedDocument = new CmisDocument();
                                     populatedDocument.setType(cmisDocument.getType());
                                     populatedDocument.setUrl(cmisDocument.getUrl());
+                                    // Preserve secondary properties from source attachment
+                                    populatedDocument.setSecondaryProperties(
+                                        cmisDocument.getSecondaryProperties());
 
                                     // Move attachment in SDM with automatic retry on transient
                                     // failures
@@ -521,6 +524,13 @@ public class SDMCustomServiceHandler {
               + ":"
               + mimeType);
       updatedFields.put(request.getUpIdKey(), request.getUpID());
+
+      // Include secondary properties from source attachment if available
+      // Properties are already filtered in DBQuery.getAttachmentForObjectID()
+      // to only include those annotated with @SDM.Attachments.AdditionalProperty
+      if (cmisDocument.getSecondaryProperties() != null) {
+        updatedFields.putAll(cmisDocument.getSecondaryProperties());
+      }
 
       String baseKeyField =
           request.getUpIdKey() != null ? request.getUpIdKey().replace("up__", "") : "ID";

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -246,23 +246,23 @@ public class SDMCustomServiceHandler {
 
         // After successful DB update, clean up source entity metadata
         // Only clean up successfully moved attachments (not failed ones)
-        List<String> successfullyMovedObjectIds = new ArrayList<>(successfulMovesMap.keySet());
-        if (!successfullyMovedObjectIds.isEmpty()) {
+        // Use the OLD objectIds (before move) to identify source records
+        List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
+        if (!oldObjectIds.isEmpty()) {
           try {
             int deletedCount =
-                dbQuery.deleteAttachmentsByObjectIds(
-                    persistenceService, successfullyMovedObjectIds, context);
+                dbQuery.deleteAttachmentsByObjectIds(persistenceService, oldObjectIds, context);
             logger.info(
                 "Cleaned up {} attachment metadata records from source entity for {} successfully"
                     + " moved attachments",
                 deletedCount,
-                successfullyMovedObjectIds.size());
+                oldObjectIds.size());
           } catch (Exception cleanupException) {
             // Log cleanup failure but don't fail the entire move operation
             logger.warn(
                 "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
                     + " successfully moved to target.",
-                successfullyMovedObjectIds.size(),
+                oldObjectIds.size(),
                 cleanupException.getMessage());
           }
         }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -242,25 +242,28 @@ public class SDMCustomServiceHandler {
               .build();
 
       try {
+        // Get the source up__ID BEFORE creating draft entries
+        // This is critical when source and target are the same entity type
+        // We must query before createDraftEntries to avoid getting the target up__ID
+        List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
+        String sourceUpId = null;
+        if (!oldObjectIds.isEmpty()) {
+          sourceUpId = dbQuery.getSourceUpIdForObjectIds(persistenceService, oldObjectIds, context);
+          logger.info("DEBUG: Retrieved source up__ID BEFORE createDraftEntries: {}", sourceUpId);
+        }
+
         createDraftEntries(draftRequest);
 
         // After successful DB update, clean up source entity metadata
         // Only clean up successfully moved attachments (not failed ones)
-        // Use the OLD objectIds (before move) to identify source records
-        List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
         logger.info(
             "DEBUG: successfulMovesMap contains {} entries. Keys (OLD IDs): {}, Values (NEW IDs):"
                 + " {}",
             successfulMovesMap.size(),
             oldObjectIds,
             new ArrayList<>(successfulMovesMap.values()));
-        if (!oldObjectIds.isEmpty()) {
+        if (!oldObjectIds.isEmpty() && sourceUpId != null) {
           try {
-            // Get the source up__ID from the database to filter cleanup
-            // This is critical when source and target are the same entity type
-            String sourceUpId =
-                dbQuery.getSourceUpIdForObjectIds(persistenceService, oldObjectIds, context);
-            logger.info("DEBUG: Retrieved source up__ID: {}", sourceUpId);
 
             int deletedCount =
                 dbQuery.deleteAttachmentsByObjectIds(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -774,26 +774,35 @@ public class SDMCustomServiceHandler {
       String description = succinctProperties.optString("cmis:description");
       String movedObjectId = succinctProperties.optString("cmis:objectId");
 
-      logger.debug(
+      logger.info(
           "Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}",
           moveContext.objectId,
           fileName,
           mimeType);
+      logger.info(
+          "SDM response for attachment {} contains {} total properties: {}",
+          moveContext.objectId,
+          succinctProperties.length(),
+          succinctProperties.keySet());
 
       // Step 2: Validate target entity properties in SDM response
       // Get target entity's SDM property names from annotations
       Set<String> targetEntitySdmProperties = new HashSet<>(moveContext.entityAnnotations.values());
       Set<String> sdmResponseProperties = new HashSet<>(succinctProperties.keySet());
 
-      logger.debug(
+      logger.info(
           "Validating attachment {} - Target entity expects {} SDM properties: {}",
           moveContext.objectId,
           targetEntitySdmProperties.size(),
           targetEntitySdmProperties);
-      logger.debug(
+      logger.info(
           "SDM response has {} properties: {}",
           sdmResponseProperties.size(),
           sdmResponseProperties);
+      logger.info(
+          "Valid secondary properties list has {} entries: {}",
+          moveContext.validSecondaryProperties.size(),
+          moveContext.validSecondaryProperties);
 
       // Validate: Check target entity properties that exist in SDM response
       List<String> invalidProperties = new ArrayList<>();
@@ -888,6 +897,7 @@ public class SDMCustomServiceHandler {
       Map<String, String> entityAnnotations,
       AttachmentProcessingResults results) {
     logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
+    logger.info("Entity annotations mapping (DB field -> SDM property): {}", entityAnnotations);
 
     CmisDocument populatedDocument = new CmisDocument();
     populatedDocument.setType(succinctProperties.optString("sap:type", null));
@@ -899,10 +909,22 @@ public class SDMCustomServiceHandler {
       String dbPropertyName = propEntry.getKey();
       String sdmPropertyName = propEntry.getValue();
 
+      logger.info(
+          "Checking property - DB field: '{}', SDM property: '{}', exists in SDM response: {}",
+          dbPropertyName,
+          sdmPropertyName,
+          succinctProperties.has(sdmPropertyName));
+
       if (succinctProperties.has(sdmPropertyName)) {
         Object value = succinctProperties.get(sdmPropertyName);
+        logger.info(
+            "Found SDM property '{}' with value: {} (type: {})",
+            sdmPropertyName,
+            value,
+            value != null ? value.getClass().getSimpleName() : "null");
         if (value != null && !org.json.JSONObject.NULL.equals(value)) {
           filteredSecondaryProps.put(dbPropertyName, value);
+          logger.info("Added to DB map: '{}' = '{}'", dbPropertyName, value);
         }
       }
     }
@@ -910,9 +932,10 @@ public class SDMCustomServiceHandler {
     populatedDocument.setSecondaryProperties(filteredSecondaryProps);
 
     logger.info(
-        "Attachment {} - Prepared {} properties for DB insertion",
+        "Attachment {} - Prepared {} properties for DB insertion: {}",
         objectId,
-        filteredSecondaryProps.size());
+        filteredSecondaryProps.size(),
+        filteredSecondaryProps);
 
     // Add to successful results
     results.successfulObjectIds.add(objectId);
@@ -1040,8 +1063,21 @@ public class SDMCustomServiceHandler {
       // to only include those annotated with @SDM.Attachments.AdditionalProperty
       // and present in valid secondary properties list
       if (cmisDocument.getSecondaryProperties() != null) {
+        logger.info(
+            "Adding {} secondary properties to DB insert for attachment {}: {}",
+            cmisDocument.getSecondaryProperties().size(),
+            newObjectId,
+            cmisDocument.getSecondaryProperties());
         updatedFields.putAll(cmisDocument.getSecondaryProperties());
+      } else {
+        logger.warn("No secondary properties to add for attachment {}", newObjectId);
       }
+
+      logger.info(
+          "Final DB insert map for attachment {} contains {} fields: {}",
+          newObjectId,
+          updatedFields.size(),
+          updatedFields.keySet());
 
       String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
       var insert =

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -625,10 +625,9 @@ public class SDMCustomServiceHandler {
     failure.put(OBJECT_ID_KEY, objectId);
     failure.put(
         FAILURE_REASON_KEY,
-        "Target entity properties "
-            + invalidProperties
-            + " found in SDM response but not in valid secondary properties list. Attachment"
-            + " rolled back.");
+        SDMConstants.INVALID_SECONDARY_PROPERTIES_PREFIX
+            + String.join(", ", invalidProperties)
+            + SDMConstants.INVALID_SECONDARY_PROPERTIES_SUFFIX);
     failedAttachments.add(failure);
   }
 
@@ -758,7 +757,10 @@ public class SDMCustomServiceHandler {
           e.getMessage());
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
-      failure.put(FAILURE_REASON_KEY, "SDM move failed: " + e.getMessage());
+      // Pass through the actual SDM error message for clarity
+      failure.put(
+          FAILURE_REASON_KEY,
+          e.getMessage() != null ? e.getMessage() : SDMConstants.SDM_MOVE_OPERATION_FAILED);
       moveContext.addFailedAttachment(failure);
     } catch (Exception e) {
       // Validation/processing failed
@@ -769,7 +771,12 @@ public class SDMCustomServiceHandler {
           e);
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
-      failure.put(FAILURE_REASON_KEY, "Validation/processing failed: " + e.getMessage());
+      // Provide detailed validation error with context
+      String detailedReason =
+          e.getMessage() != null && !e.getMessage().isEmpty()
+              ? SDMConstants.VALIDATION_FAILED_PREFIX + e.getMessage()
+              : SDMConstants.VALIDATION_FAILED_DEFAULT_MESSAGE;
+      failure.put(FAILURE_REASON_KEY, detailedReason);
       moveContext.addFailedAttachment(failure);
     }
   }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -939,6 +939,71 @@ public class SDMCustomServiceHandler {
   }
 
   /**
+   * Fetches attachment metadata either from database or directly from SDM.
+   *
+   * @param moveContext the context containing attachment and request information
+   * @param threadName the name of the current thread for logging
+   * @return CmisDocument with attachment metadata
+   */
+  private CmisDocument fetchAttachmentMetadata(
+      AttachmentMoveContext moveContext, String threadName) {
+    AttachmentMoveEventContext eventContext = moveContext.getRequest().getContext();
+
+    // If sourceFacet is provided, fetch from database; otherwise fetch from SDM directly
+    if (eventContext.getSourceParentEntity() != null
+        && !eventContext.getSourceParentEntity().isEmpty()) {
+      // Source facet provided - fetch metadata from database
+      logger.info(
+          "[Thread: {}] Fetching attachment metadata from database (sourceFacet provided)",
+          threadName);
+      AttachmentCopyEventContext copyContext = AttachmentCopyEventContext.create();
+      copyContext.setParentEntity(eventContext.getSourceParentEntity());
+      copyContext.setCompositionName(eventContext.getSourceCompositionName());
+
+      return dbQuery.getAttachmentForObjectID(
+          persistenceService, moveContext.getObjectId(), copyContext);
+    } else {
+      // No source facet - fetch metadata directly from SDM
+      logger.info(
+          "[Thread: {}] Fetching attachment metadata from SDM (no sourceFacet provided)",
+          threadName);
+      return fetchAttachmentMetadataFromSDM(moveContext);
+    }
+  }
+
+  /**
+   * Fetches attachment metadata directly from SDM repository.
+   *
+   * @param moveContext the context containing attachment and request information
+   * @return CmisDocument with attachment metadata from SDM
+   */
+  private CmisDocument fetchAttachmentMetadataFromSDM(AttachmentMoveContext moveContext) {
+    try {
+      List<String> sdmMetadata =
+          sdmService.getObject(
+              moveContext.getObjectId(),
+              moveContext.getRequest().getSdmCredentials(),
+              moveContext.getRequest().getIsSystemUser());
+
+      if (sdmMetadata == null || sdmMetadata.isEmpty()) {
+        throw new ServiceException("Attachment not found in SDM: " + moveContext.getObjectId());
+      }
+
+      // Create CmisDocument with metadata from SDM
+      CmisDocument cmisDocument = new CmisDocument();
+      cmisDocument.setFileName(sdmMetadata.get(0)); // cmis:name
+      if (sdmMetadata.size() > 1) {
+        cmisDocument.setDescription(sdmMetadata.get(1)); // cmis:description
+      }
+      // Type and URL will be null for non-link attachments (which is fine for move)
+      return cmisDocument;
+    } catch (IOException e) {
+      throw new ServiceException(
+          "Failed to fetch attachment metadata from SDM: " + e.getMessage(), e);
+    }
+  }
+
+  /**
    * Processes a single attachment move: Move in SDM → Validate → Process or Rollback.
    *
    * @param moveContext the context containing all necessary information for processing
@@ -948,17 +1013,8 @@ public class SDMCustomServiceHandler {
     logger.info(
         "[Thread: {}] Starting move for attachment: {}", threadName, moveContext.getObjectId());
     try {
-      // Step 1: Fetch attachment metadata from database to get type and URL (needed for link
-      // attachments)
-      // Create a copy event context to fetch attachment from source location
-      AttachmentMoveEventContext eventContext = moveContext.getRequest().getContext();
-      AttachmentCopyEventContext copyContext = AttachmentCopyEventContext.create();
-      copyContext.setParentEntity(eventContext.getSourceParentEntity());
-      copyContext.setCompositionName(eventContext.getSourceCompositionName());
-
-      CmisDocument cmisDocument =
-          dbQuery.getAttachmentForObjectID(
-              persistenceService, moveContext.getObjectId(), copyContext);
+      // Step 1: Fetch attachment metadata
+      CmisDocument cmisDocument = fetchAttachmentMetadata(moveContext, threadName);
 
       // Set move operation specific fields
       cmisDocument.setObjectId(moveContext.getObjectId());
@@ -979,12 +1035,26 @@ public class SDMCustomServiceHandler {
       String description = succinctProperties.optString("cmis:description");
       String movedObjectId = succinctProperties.optString("cmis:objectId");
 
+      // Extract type and linkUrl from SDM response if not already set (when sourceFacet not
+      // provided)
+      // This ensures link attachments are properly handled even without database fetch
+      if (cmisDocument.getType() == null) {
+        String typeFromSDM = succinctProperties.optString("sap:type", null);
+        cmisDocument.setType(typeFromSDM);
+      }
+      if (cmisDocument.getUrl() == null) {
+        String urlFromSDM = succinctProperties.optString("sap:linkUrl", null);
+        cmisDocument.setUrl(urlFromSDM);
+      }
+
       logger.info(
-          "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}",
+          "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}, Type: {}, LinkUrl: {}",
           Thread.currentThread().getName(),
           moveContext.getObjectId(),
           fileName,
-          mimeType);
+          mimeType,
+          cmisDocument.getType(),
+          cmisDocument.getUrl());
       logger.info(
           "SDM response for attachment {} contains {} total properties: {}",
           moveContext.getObjectId(),

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -790,10 +790,7 @@ public class SDMCustomServiceHandler {
     CmisDocument populatedDocument = createPopulatedDocument(data.getSourceCmisDocument());
     Map<String, Object> filteredSecondaryProps =
         filterSecondaryProperties(
-            data.getObjectId(),
-            data.getSuccinctProperties(),
-            data.getEntityAnnotations(),
-            data.getTargetEntity());
+            data.getSuccinctProperties(), data.getEntityAnnotations(), data.getTargetEntity());
 
     populatedDocument.setSecondaryProperties(filteredSecondaryProps);
 
@@ -833,14 +830,12 @@ public class SDMCustomServiceHandler {
   /**
    * Filters and converts secondary properties from SDM response for DB insertion.
    *
-   * @param objectId the attachment object ID (for logging)
    * @param succinctProperties SDM response properties
    * @param entityAnnotations mapping of DB fields to SDM properties
    * @param targetEntity the target attachment entity (for type checking)
    * @return filtered and converted properties map
    */
   private Map<String, Object> filterSecondaryProperties(
-      String objectId,
       JSONObject succinctProperties,
       Map<String, String> entityAnnotations,
       CdsEntity targetEntity) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1035,16 +1035,23 @@ public class SDMCustomServiceHandler {
       String description = succinctProperties.optString("cmis:description");
       String movedObjectId = succinctProperties.optString("cmis:objectId");
 
-      // Extract type and linkUrl from SDM response if not already set (when sourceFacet not
-      // provided)
+      // Extract linkUrl from SDM response if not already set (when sourceFacet not provided)
       // This ensures link attachments are properly handled even without database fetch
-      if (cmisDocument.getType() == null) {
-        String typeFromSDM = succinctProperties.optString("sap:type", null);
-        cmisDocument.setType(typeFromSDM);
-      }
       if (cmisDocument.getUrl() == null) {
         String urlFromSDM = succinctProperties.optString("sap:linkUrl", null);
         cmisDocument.setUrl(urlFromSDM);
+      }
+
+      // Set type based on whether it's a link attachment or document attachment
+      // Link attachments: "sap-icon://internet-browser"
+      // Document attachments: "sap-icon://document"
+      // This should be done after extracting URL to properly determine the type
+      if (cmisDocument.getType() == null) {
+        String attachmentType =
+            (cmisDocument.getUrl() != null && !cmisDocument.getUrl().isEmpty())
+                ? "sap-icon://internet-browser"
+                : "sap-icon://document";
+        cmisDocument.setType(attachmentType);
       }
 
       logger.info(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -15,6 +15,7 @@ import com.sap.cds.sdm.model.CopyAttachmentsRequest;
 import com.sap.cds.sdm.model.CopyAttachmentsResult;
 import com.sap.cds.sdm.model.CreateDraftEntriesRequest;
 import com.sap.cds.sdm.model.DatabaseFailureContext;
+import com.sap.cds.sdm.model.DatabaseUpdateRequest;
 import com.sap.cds.sdm.model.DraftEntryMoveData;
 import com.sap.cds.sdm.model.MoveAttachmentsRequest;
 import com.sap.cds.sdm.model.MoveAttachmentsResult;
@@ -244,17 +245,19 @@ public class SDMCustomServiceHandler {
       String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
 
       try {
-        updateDatabaseAndCleanupSource(
-            movedAttachmentsMetadata,
-            populatedDocuments,
-            parentEntity,
-            compositionName,
-            upID,
-            upIdKey,
-            repositoryId,
-            targetFolderId,
-            successfulObjectIds,
-            context);
+        DatabaseUpdateRequest updateRequest =
+            new DatabaseUpdateRequest(
+                movedAttachmentsMetadata,
+                populatedDocuments,
+                parentEntity,
+                compositionName,
+                upID,
+                upIdKey,
+                repositoryId,
+                targetFolderId,
+                successfulObjectIds,
+                context);
+        updateDatabaseAndCleanupSource(updateRequest);
       } catch (ServiceException e) {
         DatabaseFailureContext failureContext =
             new DatabaseFailureContext(
@@ -396,59 +399,54 @@ public class SDMCustomServiceHandler {
   /**
    * Updates database with moved attachments and cleans up source entity metadata.
    *
+   * @param request encapsulated database update request data
    * @throws ServiceException if database operations fail
    */
-  private void updateDatabaseAndCleanupSource(
-      List<List<String>> movedAttachmentsMetadata,
-      List<CmisDocument> populatedDocuments,
-      String parentEntity,
-      String compositionName,
-      String upID,
-      String upIdKey,
-      String repositoryId,
-      String folderId,
-      List<String> successfulObjectIds,
-      AttachmentMoveEventContext context)
+  private void updateDatabaseAndCleanupSource(DatabaseUpdateRequest request)
       throws ServiceException {
     // Query source entity's up__ID before creating target records
     // This ensures we get the correct source ID, especially important when moving
     // between entities of the same type (e.g., Book A to Book B)
     String sourceUpId = null;
-    if (!successfulObjectIds.isEmpty()) {
+    if (!request.getSuccessfulObjectIds().isEmpty()) {
       sourceUpId =
-          dbQuery.getSourceUpIdForObjectIds(persistenceService, successfulObjectIds, context);
+          dbQuery.getSourceUpIdForObjectIds(
+              persistenceService, request.getSuccessfulObjectIds(), request.getContext());
       logger.info("Retrieved source up__ID for cleanup: {}", sourceUpId);
     }
 
     // Create draft entries for moved attachments with secondary properties
     DraftEntryMoveData draftData =
         new DraftEntryMoveData(
-            movedAttachmentsMetadata,
-            populatedDocuments,
-            parentEntity,
-            compositionName,
-            upID,
-            upIdKey,
-            repositoryId,
-            folderId);
+            request.getMovedAttachmentsMetadata(),
+            request.getPopulatedDocuments(),
+            request.getParentEntity(),
+            request.getCompositionName(),
+            request.getUpID(),
+            request.getUpIdKey(),
+            request.getRepositoryId(),
+            request.getFolderId());
     createDraftEntriesForMove(draftData);
 
     // Clean up source entity metadata after successful move
-    if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
+    if (!request.getSuccessfulObjectIds().isEmpty() && sourceUpId != null) {
       try {
         long deletedCount =
             dbQuery.deleteAttachmentsByObjectIds(
-                persistenceService, successfulObjectIds, sourceUpId, context);
+                persistenceService,
+                request.getSuccessfulObjectIds(),
+                sourceUpId,
+                request.getContext());
         logger.info(
             "Cleaned up {} attachment metadata records from source entity for {} successfully"
                 + " moved attachments",
             deletedCount,
-            successfulObjectIds.size());
+            request.getSuccessfulObjectIds().size());
       } catch (Exception cleanupException) {
         logger.warn(
             "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
                 + " successfully moved to target.",
-            successfulObjectIds.size(),
+            request.getSuccessfulObjectIds().size(),
             cleanupException.getMessage());
       }
     }
@@ -764,27 +762,137 @@ public class SDMCustomServiceHandler {
   }
 
   /**
-   * Parses SDM error message to extract meaningful failure reason.
+   * Parses SDM error message to extract meaningful failure reason. Handles different SDM error
+   * types similar to createAttachment() flow.
    *
-   * @param errorMessage The raw error message from SDM
+   * @param exception The exception from SDM operation
    * @return A user-friendly failure reason
    */
-  private String parseSDMErrorMessage(String errorMessage) {
+  private String parseSDMErrorMessage(Exception exception) {
+    String errorMessage = extractErrorMessage(exception);
+
     if (errorMessage == null || errorMessage.isEmpty()) {
       return SDMConstants.SDM_MOVE_OPERATION_FAILED;
     }
 
-    // Check for nameConstraintViolation (duplicate file)
-    if (errorMessage.contains("nameConstraintViolation")) {
-      // Extract the meaningful part: "Child 6.pdf with Id ... already exists"
-      int colonIndex = errorMessage.indexOf(":");
-      if (colonIndex != -1 && colonIndex + 1 < errorMessage.length()) {
-        return errorMessage.substring(colonIndex + 1).trim();
+    // Try to match specific error types
+    String specificError = matchSpecificErrorType(errorMessage);
+    if (specificError != null) {
+      return specificError;
+    }
+
+    // Generic SDM error pattern: "errorType : detailed message"
+    return extractDetailedMessage(errorMessage);
+  }
+
+  /**
+   * Extracts error message from exception chain.
+   *
+   * @param exception the exception to extract message from
+   * @return the most detailed error message found
+   */
+  private String extractErrorMessage(Exception exception) {
+    String errorMessage = exception.getMessage();
+
+    // If the main message is generic, check the cause chain
+    if (isGenericMessage(errorMessage) && exception.getCause() != null) {
+      Throwable cause = exception.getCause();
+      while (cause != null) {
+        String causeMessage = cause.getMessage();
+        if (!isGenericMessage(causeMessage)) {
+          return causeMessage;
+        }
+        cause = cause.getCause();
       }
     }
 
-    // Check for other common SDM errors and extract meaningful parts
-    // For now, return the full message as fallback
+    return errorMessage;
+  }
+
+  /**
+   * Checks if a message is generic and should be replaced with a more detailed one.
+   *
+   * @param message the message to check
+   * @return true if the message is null, empty, or generic
+   */
+  private boolean isGenericMessage(String message) {
+    return message == null
+        || message.isEmpty()
+        || message.equals(SDMConstants.FAILED_TO_MOVE_ATTACHMENT);
+  }
+
+  /**
+   * Matches error message against specific SDM error types.
+   *
+   * @param errorMessage the error message to match
+   * @return specific error message if matched, null otherwise
+   */
+  private String matchSpecificErrorType(String errorMessage) {
+    String lowerCaseMessage = errorMessage.toLowerCase();
+
+    if (lowerCaseMessage.contains("duplicate")
+        || lowerCaseMessage.contains("nameconstraintviolation")) {
+      return parseDuplicateError(errorMessage);
+    }
+
+    if (lowerCaseMessage.contains("virus") || lowerCaseMessage.contains("malware")) {
+      return "File contains potential malware and cannot be moved";
+    }
+
+    if (lowerCaseMessage.contains("unauthorized")
+        || lowerCaseMessage.contains("not authorized")
+        || lowerCaseMessage.contains("permission")) {
+      return SDMConstants.USER_NOT_AUTHORISED_ERROR;
+    }
+
+    if (lowerCaseMessage.contains("blocked") || lowerCaseMessage.contains("mimetype")) {
+      return SDMConstants.MIMETYPE_INVALID_ERROR;
+    }
+
+    if (lowerCaseMessage.contains("not found") || lowerCaseMessage.contains("object not found")) {
+      return SDMConstants.FILE_NOT_FOUND_ERROR;
+    }
+
+    return null;
+  }
+
+  /**
+   * Parses duplicate file error and extracts filename.
+   *
+   * @param errorMessage the error message
+   * @return parsed duplicate error message
+   */
+  private String parseDuplicateError(String errorMessage) {
+    int colonIndex = errorMessage.indexOf(" : ");
+    if (colonIndex == -1) {
+      return "Duplicate file already exists in the target location";
+    }
+
+    String detailedMessage = errorMessage.substring(colonIndex + 3).trim();
+    if (detailedMessage.startsWith("Child ")) {
+      int withIndex = detailedMessage.indexOf(" with Id");
+      if (withIndex != -1) {
+        String filename = detailedMessage.substring(6, withIndex).trim();
+        return SDMConstants.getDuplicateFilesError(filename);
+      }
+    }
+    return detailedMessage;
+  }
+
+  /**
+   * Extracts detailed message from generic SDM error pattern.
+   *
+   * @param errorMessage the error message
+   * @return detailed message or original message
+   */
+  private String extractDetailedMessage(String errorMessage) {
+    int colonIndex = errorMessage.indexOf(" : ");
+    if (colonIndex != -1) {
+      String detailedMessage = errorMessage.substring(colonIndex + 3).trim();
+      if (!detailedMessage.isEmpty()) {
+        return detailedMessage;
+      }
+    }
     return errorMessage;
   }
 
@@ -955,11 +1063,13 @@ public class SDMCustomServiceHandler {
           "[Thread: {}] Failed to move attachment {}: {}",
           Thread.currentThread().getName(),
           moveContext.getObjectId(),
-          e.getMessage());
+          e.getMessage(),
+          e);
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
       // Parse SDM error message to extract meaningful failure reason
-      String failureReason = parseSDMErrorMessage(e.getMessage());
+      // Check both the exception message and cause for detailed error
+      String failureReason = parseSDMErrorMessage(e);
       failure.put(FAILURE_REASON_KEY, failureReason);
       moveContext.addFailedAttachment(failure);
     } catch (Exception e) {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -243,6 +243,29 @@ public class SDMCustomServiceHandler {
 
       try {
         createDraftEntries(draftRequest);
+
+        // After successful DB update, clean up source entity metadata
+        // Only clean up successfully moved attachments (not failed ones)
+        List<String> successfullyMovedObjectIds = new ArrayList<>(successfulMovesMap.keySet());
+        if (!successfullyMovedObjectIds.isEmpty()) {
+          try {
+            int deletedCount =
+                dbQuery.deleteAttachmentsByObjectIds(
+                    persistenceService, successfullyMovedObjectIds, context);
+            logger.info(
+                "Cleaned up {} attachment metadata records from source entity for {} successfully"
+                    + " moved attachments",
+                deletedCount,
+                successfullyMovedObjectIds.size());
+          } catch (Exception cleanupException) {
+            // Log cleanup failure but don't fail the entire move operation
+            logger.warn(
+                "Failed to clean up source entity metadata for {} attachments: {}. Attachments were"
+                    + " successfully moved to target.",
+                successfullyMovedObjectIds.size(),
+                cleanupException.getMessage());
+          }
+        }
       } catch (ServiceException e) {
         // If DB update fails after retries, rollback the SDM moves
         logger.error(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -246,7 +246,7 @@ public class SDMCustomServiceHandler {
               .compositionName(compositionName)
               .upID(upID)
               .upIdKey(upIdKey)
-              .repositoryId(targetFolderId)
+              .repositoryId(repositoryId)
               .folderId(targetFolderId)
               .build();
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -765,8 +765,18 @@ public class SDMCustomServiceHandler {
    */
   private void processSingleAttachmentMove(AttachmentMoveContext moveContext) {
     try {
-      // Step 1: Move attachment in SDM
-      CmisDocument cmisDocument = new CmisDocument();
+      // Step 1: Fetch attachment metadata from database to get type and URL (needed for link
+      // attachments)
+      // Create a copy event context to fetch attachment from source location
+      AttachmentMoveEventContext eventContext = moveContext.request.getContext();
+      AttachmentCopyEventContext copyContext = AttachmentCopyEventContext.create();
+      copyContext.setParentEntity(eventContext.getSourceParentEntity());
+      copyContext.setCompositionName(eventContext.getSourceCompositionName());
+
+      CmisDocument cmisDocument =
+          dbQuery.getAttachmentForObjectID(persistenceService, moveContext.objectId, copyContext);
+
+      // Set move operation specific fields
       cmisDocument.setObjectId(moveContext.objectId);
       cmisDocument.setRepositoryId(moveContext.request.getRepositoryId());
       cmisDocument.setSourceFolderId(moveContext.request.getSourceFolderId());
@@ -850,7 +860,8 @@ public class SDMCustomServiceHandler {
             succinctProperties,
             moveContext.entityAnnotations,
             moveContext.targetEntity,
-            moveContext.processingResults);
+            moveContext.processingResults,
+            cmisDocument);
       }
 
     } catch (ServiceException | IOException e) {
@@ -899,6 +910,7 @@ public class SDMCustomServiceHandler {
    * @param entityAnnotations mapping of DB fields to SDM properties
    * @param targetEntity the target attachment entity (for type checking)
    * @param results holder for successful processing results
+   * @param sourceCmisDocument the original cmisDocument from database with type and URL
    */
   private void processValidatedAttachment(
       String objectId,
@@ -909,11 +921,13 @@ public class SDMCustomServiceHandler {
       org.json.JSONObject succinctProperties,
       Map<String, String> entityAnnotations,
       com.sap.cds.reflect.CdsEntity targetEntity,
-      AttachmentProcessingResults results) {
+      AttachmentProcessingResults results,
+      CmisDocument sourceCmisDocument) {
     logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
     logger.info("Entity annotations mapping (DB field -> SDM property): {}", entityAnnotations);
 
-    CmisDocument populatedDocument = createPopulatedDocument(succinctProperties);
+    CmisDocument populatedDocument =
+        createPopulatedDocument(succinctProperties, sourceCmisDocument);
     Map<String, Object> filteredSecondaryProps =
         filterSecondaryProperties(objectId, succinctProperties, entityAnnotations, targetEntity);
 
@@ -932,15 +946,19 @@ public class SDMCustomServiceHandler {
   }
 
   /**
-   * Creates a CmisDocument with basic metadata from SDM response.
+   * Creates a CmisDocument with basic metadata from SDM response and source document.
    *
    * @param succinctProperties SDM response properties
+   * @param sourceCmisDocument the original cmisDocument from database with type and URL
    * @return populated CmisDocument
    */
-  private CmisDocument createPopulatedDocument(org.json.JSONObject succinctProperties) {
+  private CmisDocument createPopulatedDocument(
+      org.json.JSONObject succinctProperties, CmisDocument sourceCmisDocument) {
     CmisDocument document = new CmisDocument();
-    document.setType(succinctProperties.optString("sap:type", null));
-    document.setUrl(succinctProperties.optString("sap:linkURL", null));
+    // Preserve type and URL from source document (fetched from database)
+    // This is essential for link attachments where URL is not in SDM response
+    document.setType(sourceCmisDocument.getType());
+    document.setUrl(sourceCmisDocument.getUrl());
     return document;
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -222,7 +222,8 @@ public class SDMCustomServiceHandler {
     Map<String, String> successfulMovesMap = moveResult.getSuccessfulMovesMap();
 
     // Set the failed object IDs in the context for the caller
-    context.setFailedObjectIds(failedObjectIds);
+    // Convert to ArrayList to avoid Collections$SynchronizedRandomAccessList serialization issue
+    context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
 
     // Only create draft entries for successfully moved attachments
     if (!movedAttachmentsMetadata.isEmpty()) {
@@ -253,10 +254,13 @@ public class SDMCustomServiceHandler {
             targetFolderId,
             repositoryId,
             sdmCredentials,
-            isSystemUser);
+            isSystemUser,
+            context);
         // Add all successfully moved objects to failed list since we rolled back
         failedObjectIds.addAll(successfulMovesMap.keySet());
-        context.setFailedObjectIds(failedObjectIds);
+        // Convert to ArrayList to avoid Collections$SynchronizedRandomAccessList serialization
+        // issue
+        context.setFailedObjectIds(new ArrayList<>(failedObjectIds));
         // Don't throw exception - return failed IDs to caller as per acceptance criteria
         logger.warn(
             "Move operation completed with failures. Total failed: {}, Rolled back: {}",
@@ -329,49 +333,58 @@ public class SDMCustomServiceHandler {
     Map<String, String> successfulMovesMap =
         new java.util.concurrent.ConcurrentHashMap<>(); // objectId -> newObjectId
 
+    // Capture the current request context to propagate to background threads
+    com.sap.cds.services.runtime.RequestContextRunner contextRunner =
+        request.getContext().getCdsRuntime().requestContext();
+
     // Create parallel tasks for each attachment move
     List<CompletableFuture<Void>> moveFutures =
         request.getObjectIds().stream()
             .map(
                 objectId ->
                     CompletableFuture.runAsync(
-                        () -> {
-                          try {
-                            CmisDocument cmisDocument =
-                                dbQuery.getAttachmentForObjectID(
-                                    persistenceService, objectId, request.getContext());
-                            cmisDocument.setObjectId(objectId);
-                            cmisDocument.setRepositoryId(request.getRepositoryId());
-                            cmisDocument.setSourceFolderId(request.getSourceFolderId());
-                            cmisDocument.setFolderId(request.getTargetFolderId());
+                        () ->
+                            // Run within the captured request context to preserve authentication
+                            contextRunner.run(
+                                ctx -> {
+                                  try {
+                                    CmisDocument cmisDocument =
+                                        dbQuery.getAttachmentForObjectID(
+                                            persistenceService, objectId, request.getContext());
+                                    cmisDocument.setObjectId(objectId);
+                                    cmisDocument.setRepositoryId(request.getRepositoryId());
+                                    cmisDocument.setSourceFolderId(request.getSourceFolderId());
+                                    cmisDocument.setFolderId(request.getTargetFolderId());
 
-                            // Create individual document for each attachment with its own type and
-                            // linkUrl
-                            CmisDocument populatedDocument = new CmisDocument();
-                            populatedDocument.setType(cmisDocument.getType());
-                            populatedDocument.setUrl(cmisDocument.getUrl());
+                                    // Create individual document for each attachment with its own
+                                    // type and linkUrl
+                                    CmisDocument populatedDocument = new CmisDocument();
+                                    populatedDocument.setType(cmisDocument.getType());
+                                    populatedDocument.setUrl(cmisDocument.getUrl());
 
-                            // Perform SDM move operation with retry
-                            List<String> metadata =
-                                sdmService.moveAttachment(
-                                    cmisDocument,
-                                    request.getSdmCredentials(),
-                                    request.getIsSystemUser());
+                                    // Perform SDM move operation with retry
+                                    List<String> metadata =
+                                        sdmService.moveAttachment(
+                                            cmisDocument,
+                                            request.getSdmCredentials(),
+                                            request.getIsSystemUser());
 
-                            // Track successful move for rollback (thread-safe)
-                            String newObjectId = metadata.get(2);
-                            successfulMovesMap.put(objectId, newObjectId);
-                            movedAttachmentsMetadata.add(metadata);
-                            populatedDocuments.add(populatedDocument);
-                          } catch (ServiceException | IOException e) {
-                            // Add to failed list and continue with next attachment (thread-safe)
-                            logger.error(
-                                "Failed to move attachment with objectId {}: {}",
-                                objectId,
-                                e.getMessage());
-                            failedObjectIds.add(objectId);
-                          }
-                        },
+                                    // Track successful move for rollback (thread-safe)
+                                    String newObjectId = metadata.get(2);
+                                    successfulMovesMap.put(objectId, newObjectId);
+                                    movedAttachmentsMetadata.add(metadata);
+                                    populatedDocuments.add(populatedDocument);
+                                  } catch (ServiceException | IOException e) {
+                                    // Add to failed list and continue with next attachment
+                                    // (thread-safe)
+                                    logger.error(
+                                        "Failed to move attachment with objectId {}: {}",
+                                        objectId,
+                                        e.getMessage());
+                                    failedObjectIds.add(objectId);
+                                  }
+                                  return null;
+                                }),
                         executorService))
             .toList();
 
@@ -516,42 +529,51 @@ public class SDMCustomServiceHandler {
       String targetFolderId,
       String repositoryId,
       SDMCredentials sdmCredentials,
-      boolean isSystemUser) {
+      boolean isSystemUser,
+      AttachmentMoveEventContext context) {
     logger.warn(
         "Rolling back {} moved attachments from {} to {}",
         successfulMovesMap.size(),
         targetFolderId,
         sourceFolderId);
 
+    // Capture the current request context to propagate to background threads
+    com.sap.cds.services.runtime.RequestContextRunner contextRunner =
+        context.getCdsRuntime().requestContext();
+
     List<CompletableFuture<Void>> rollbackFutures =
         successfulMovesMap.entrySet().stream()
             .map(
                 entry ->
                     CompletableFuture.runAsync(
-                        () -> {
-                          String originalObjectId = entry.getKey();
-                          String newObjectId = entry.getValue();
-                          try {
-                            // Create CMIS document for rollback move
-                            CmisDocument rollbackDoc = new CmisDocument();
-                            rollbackDoc.setObjectId(newObjectId);
-                            rollbackDoc.setRepositoryId(repositoryId);
-                            rollbackDoc.setSourceFolderId(targetFolderId);
-                            rollbackDoc.setFolderId(sourceFolderId);
+                        () ->
+                            contextRunner.run(
+                                ctx -> {
+                                  String originalObjectId = entry.getKey();
+                                  String newObjectId = entry.getValue();
+                                  try {
+                                    // Create CMIS document for rollback move
+                                    CmisDocument rollbackDoc = new CmisDocument();
+                                    rollbackDoc.setObjectId(newObjectId);
+                                    rollbackDoc.setRepositoryId(repositoryId);
+                                    rollbackDoc.setSourceFolderId(targetFolderId);
+                                    rollbackDoc.setFolderId(sourceFolderId);
 
-                            // Move back to source folder with retry
-                            sdmService.moveAttachment(rollbackDoc, sdmCredentials, isSystemUser);
-                            logger.info(
-                                "Successfully rolled back attachment {} to source folder",
-                                originalObjectId);
-                          } catch (Exception e) {
-                            logger.error(
-                                "Failed to rollback attachment {} during rollback: {}",
-                                originalObjectId,
-                                e.getMessage());
-                            // Continue with other rollbacks even if one fails
-                          }
-                        },
+                                    // Move back to source folder with retry
+                                    sdmService.moveAttachment(
+                                        rollbackDoc, sdmCredentials, isSystemUser);
+                                    logger.info(
+                                        "Successfully rolled back attachment {} to source folder",
+                                        originalObjectId);
+                                  } catch (Exception e) {
+                                    logger.error(
+                                        "Failed to rollback attachment {} during rollback: {}",
+                                        originalObjectId,
+                                        e.getMessage());
+                                    // Continue with other rollbacks even if one fails
+                                  }
+                                  return null;
+                                }),
                         executorService))
             .toList();
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -759,7 +759,7 @@ public class SDMCustomServiceHandler {
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
       failure.put(FAILURE_REASON_KEY, "SDM move failed: " + e.getMessage());
-      moveContext.getFailedAttachments().add(failure);
+      moveContext.addFailedAttachment(failure);
     } catch (Exception e) {
       // Validation/processing failed
       logger.error(
@@ -770,7 +770,7 @@ public class SDMCustomServiceHandler {
       Map<String, String> failure = new HashMap<>();
       failure.put(OBJECT_ID_KEY, moveContext.getObjectId());
       failure.put(FAILURE_REASON_KEY, "Validation/processing failed: " + e.getMessage());
-      moveContext.getFailedAttachments().add(failure);
+      moveContext.addFailedAttachment(failure);
     }
   }
 
@@ -801,15 +801,14 @@ public class SDMCustomServiceHandler {
         filteredSecondaryProps);
 
     // Add to successful results
-    data.getSuccessfulObjectIds().add(data.getObjectId());
-    data.getMovedAttachmentsMetadata()
-        .add(
-            List.of(
-                data.getFileName(),
-                data.getMimeType(),
-                data.getDescription(),
-                data.getMovedObjectId()));
-    data.getPopulatedDocuments().add(populatedDocument);
+    data.addSuccessfulObjectId(data.getObjectId());
+    data.addMovedAttachmentMetadata(
+        List.of(
+            data.getFileName(),
+            data.getMimeType(),
+            data.getDescription(),
+            data.getMovedObjectId()));
+    data.addPopulatedDocument(populatedDocument);
   }
 
   /**

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -250,8 +250,14 @@ public class SDMCustomServiceHandler {
         List<String> oldObjectIds = new ArrayList<>(successfulMovesMap.keySet());
         if (!oldObjectIds.isEmpty()) {
           try {
+            // Get the source up__ID from the database to filter cleanup
+            // This is critical when source and target are the same entity type
+            String sourceUpId =
+                dbQuery.getSourceUpIdForObjectIds(persistenceService, oldObjectIds, context);
+
             int deletedCount =
-                dbQuery.deleteAttachmentsByObjectIds(persistenceService, oldObjectIds, context);
+                dbQuery.deleteAttachmentsByObjectIds(
+                    persistenceService, oldObjectIds, sourceUpId, context);
             logger.info(
                 "Cleaned up {} attachment metadata records from source entity for {} successfully"
                     + " moved attachments",

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -276,20 +276,18 @@ public class SDMCustomServiceHandler {
     if (!movedAttachmentsMetadata.isEmpty()) {
       String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
 
-      CreateDraftEntriesRequest draftRequest =
-          CreateDraftEntriesRequest.builder()
-              .attachmentsMetadata(movedAttachmentsMetadata)
-              .populatedDocuments(populatedDocuments)
-              .parentEntity(parentEntity)
-              .compositionName(compositionName)
-              .upID(upID)
-              .upIdKey(upIdKey)
-              .repositoryId(repositoryId)
-              .folderId(targetFolderId)
-              .build();
-
       try {
-        updateDatabaseAndCleanupSource(draftRequest, successfulObjectIds, context);
+        updateDatabaseAndCleanupSource(
+            movedAttachmentsMetadata,
+            populatedDocuments,
+            parentEntity,
+            compositionName,
+            upID,
+            upIdKey,
+            repositoryId,
+            targetFolderId,
+            successfulObjectIds,
+            context);
       } catch (ServiceException e) {
         DatabaseFailureContext failureContext =
             new DatabaseFailureContext(
@@ -314,7 +312,14 @@ public class SDMCustomServiceHandler {
    * @throws ServiceException if database operations fail
    */
   private void updateDatabaseAndCleanupSource(
-      CreateDraftEntriesRequest draftRequest,
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      String upIdKey,
+      String repositoryId,
+      String folderId,
       List<String> successfulObjectIds,
       AttachmentMoveEventContext context)
       throws ServiceException {
@@ -328,7 +333,16 @@ public class SDMCustomServiceHandler {
       logger.info("Retrieved source up__ID for cleanup: {}", sourceUpId);
     }
 
-    createDraftEntries(draftRequest);
+    // Create draft entries for moved attachments with secondary properties
+    createDraftEntriesForMove(
+        movedAttachmentsMetadata,
+        populatedDocuments,
+        parentEntity,
+        compositionName,
+        upID,
+        upIdKey,
+        repositoryId,
+        folderId);
 
     // Clean up source entity metadata after successful move
     if (!successfulObjectIds.isEmpty() && sourceUpId != null) {
@@ -480,7 +494,7 @@ public class SDMCustomServiceHandler {
     }
     return folderId;
   }
-  
+
   /** Helper class to hold target folder information. */
   private static class TargetFolderInfo {
     final String targetFolderId;
@@ -684,7 +698,6 @@ public class SDMCustomServiceHandler {
         objectId,
         invalidProperties.size(),
         invalidProperties);
-
     try {
       rollbackSingleAttachment(
           objectId,
@@ -758,6 +771,7 @@ public class SDMCustomServiceHandler {
 
       String fileName = succinctProperties.optString("cmis:name");
       String mimeType = succinctProperties.optString("cmis:contentStreamMimeType");
+      String description = succinctProperties.optString("cmis:description");
       String movedObjectId = succinctProperties.optString("cmis:objectId");
 
       logger.debug(
@@ -811,6 +825,7 @@ public class SDMCustomServiceHandler {
             moveContext.objectId,
             fileName,
             mimeType,
+            description,
             movedObjectId,
             succinctProperties,
             moveContext.entityAnnotations,
@@ -857,6 +872,7 @@ public class SDMCustomServiceHandler {
    * @param objectId the attachment object ID
    * @param fileName the file name
    * @param mimeType the MIME type
+   * @param description the description (note) from cmis:description
    * @param movedObjectId the new object ID after move
    * @param succinctProperties SDM response properties
    * @param entityAnnotations mapping of DB fields to SDM properties
@@ -866,6 +882,7 @@ public class SDMCustomServiceHandler {
       String objectId,
       String fileName,
       String mimeType,
+      String description,
       String movedObjectId,
       org.json.JSONObject succinctProperties,
       Map<String, String> entityAnnotations,
@@ -899,7 +916,7 @@ public class SDMCustomServiceHandler {
 
     // Add to successful results
     results.successfulObjectIds.add(objectId);
-    results.movedAttachmentsMetadata.add(List.of(fileName, mimeType, movedObjectId));
+    results.movedAttachmentsMetadata.add(List.of(fileName, mimeType, description, movedObjectId));
     results.populatedDocuments.add(populatedDocument);
   }
 
@@ -969,6 +986,98 @@ public class SDMCustomServiceHandler {
     return null;
   }
 
+  /**
+   * Creates draft entries for moved attachments with secondary properties support. This method is
+   * specifically for move operations where we need to preserve validated secondary properties from
+   * the SDM response.
+   */
+  private void createDraftEntriesForMove(
+      List<List<String>> movedAttachmentsMetadata,
+      List<CmisDocument> populatedDocuments,
+      String parentEntity,
+      String compositionName,
+      String upID,
+      String upIdKey,
+      String repositoryId,
+      String folderId) {
+
+    for (int i = 0; i < movedAttachmentsMetadata.size(); i++) {
+      List<String> attachmentMetadata = movedAttachmentsMetadata.get(i);
+      CmisDocument cmisDocument = populatedDocuments.get(i);
+      Map<String, Object> updatedFields = new HashMap<>();
+
+      String fileName = attachmentMetadata.get(0);
+      String mimeType = attachmentMetadata.get(1);
+      String description = attachmentMetadata.get(2);
+      String newObjectId = attachmentMetadata.get(3);
+
+      updatedFields.put(OBJECT_ID_KEY, newObjectId);
+      updatedFields.put("repositoryId", repositoryId);
+      updatedFields.put("folderId", folderId);
+      updatedFields.put("status", "Clean");
+      updatedFields.put("mimeType", mimeType);
+      updatedFields.put("type", cmisDocument.getType());
+      updatedFields.put("fileName", fileName);
+      updatedFields.put("note", description);
+      updatedFields.put("HasDraftEntity", false);
+      updatedFields.put("HasActiveEntity", false);
+      updatedFields.put("linkUrl", cmisDocument.getUrl());
+      updatedFields.put(
+          "contentId",
+          newObjectId
+              + ":"
+              + folderId
+              + ":"
+              + parentEntity
+              + "."
+              + compositionName
+              + ":"
+              + mimeType);
+      updatedFields.put(upIdKey, upID);
+
+      // Include secondary properties from moved attachment
+      // Properties are already filtered and validated in processValidatedAttachment()
+      // to only include those annotated with @SDM.Attachments.AdditionalProperty
+      // and present in valid secondary properties list
+      if (cmisDocument.getSecondaryProperties() != null) {
+        updatedFields.putAll(cmisDocument.getSecondaryProperties());
+      }
+
+      String baseKeyField = upIdKey != null ? upIdKey.replace("up__", "") : "ID";
+      var insert =
+          Insert.into(parentEntity, e -> e.filter(e.get(baseKeyField).eq(upID)).to(compositionName))
+              .entry(updatedFields);
+
+      DraftService matchingService =
+          draftService.stream()
+              .filter(ds -> parentEntity.contains(ds.getName()))
+              .findFirst()
+              .orElse(null);
+
+      if (matchingService != null) {
+        // Wrap DB insert with retry logic to handle transient DB failures
+        try {
+          io.reactivex.Flowable.fromCallable(
+                  () -> {
+                    matchingService.newDraft(insert);
+                    return true;
+                  })
+              .retryWhen(com.sap.cds.sdm.service.RetryUtils.retryLogic(5)) // Retry up to 5 times
+              .blockingFirst();
+        } catch (Exception e) {
+          throw new ServiceException(
+              "Failed to insert attachment entry in DB after retries: " + e.getMessage(), e);
+        }
+      } else {
+        throw new ServiceException("No suitable service found for entity: " + parentEntity);
+      }
+    }
+  }
+
+  /**
+   * Creates draft entries for copied attachments with custom properties support. This method is for
+   * copy operations where custom properties come from the SDM copyAttachment response.
+   */
   private void createDraftEntries(
       CreateDraftEntriesRequest request, Map<String, String> customPropertyDefinitions) {
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1004,6 +1004,41 @@ public class SDMCustomServiceHandler {
   }
 
   /**
+   * Fetches link URL from SDM content stream and sets it on the CmisDocument. Link URLs are stored
+   * in the content stream in format: [InternetShortcut]\nURL=<url>. If fetching fails, continues
+   * with null URL as the type is still correctly set.
+   *
+   * @param cmisDocument the document to set the URL on
+   * @param movedObjectId the objectId to fetch the link URL for
+   * @param moveContext the move context containing request credentials
+   */
+  private void fetchAndSetLinkUrl(
+      CmisDocument cmisDocument, String movedObjectId, AttachmentMoveContext moveContext) {
+    try {
+      String linkUrl =
+          sdmService.getLinkUrl(
+              movedObjectId,
+              moveContext.getRequest().getSdmCredentials(),
+              moveContext.getRequest().getIsSystemUser());
+      if (linkUrl != null) {
+        cmisDocument.setUrl(linkUrl);
+        logger.info(
+            "[Thread: {}] Fetched and set linkUrl for attachment {}: {}",
+            Thread.currentThread().getName(),
+            moveContext.getObjectId(),
+            linkUrl);
+      }
+    } catch (Exception e) {
+      logger.warn(
+          "[Thread: {}] Failed to fetch link URL for attachment {}: {}",
+          Thread.currentThread().getName(),
+          moveContext.getObjectId(),
+          e.getMessage());
+      // Continue with null URL - the type is still correctly set
+    }
+  }
+
+  /**
    * Processes a single attachment move: Move in SDM → Validate → Process or Rollback.
    *
    * @param moveContext the context containing all necessary information for processing
@@ -1046,28 +1081,7 @@ public class SDMCustomServiceHandler {
       // For link attachments, fetch the actual URL from SDM content if not already available
       // Link URLs are stored in the content stream in format: [InternetShortcut]\nURL=<url>
       if ("sap:link".equals(objectTypeId) && cmisDocument.getUrl() == null) {
-        try {
-          String linkUrl =
-              sdmService.getLinkUrl(
-                  movedObjectId,
-                  moveContext.getRequest().getSdmCredentials(),
-                  moveContext.getRequest().getIsSystemUser());
-          if (linkUrl != null) {
-            cmisDocument.setUrl(linkUrl);
-            logger.info(
-                "[Thread: {}] Fetched and set linkUrl for attachment {}: {}",
-                Thread.currentThread().getName(),
-                moveContext.getObjectId(),
-                linkUrl);
-          }
-        } catch (Exception e) {
-          logger.warn(
-              "[Thread: {}] Failed to fetch link URL for attachment {}: {}",
-              Thread.currentThread().getName(),
-              moveContext.getObjectId(),
-              e.getMessage());
-          // Continue with null URL - the type is still correctly set
-        }
+        fetchAndSetLinkUrl(cmisDocument, movedObjectId, moveContext);
       }
 
       logger.info(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -550,11 +550,15 @@ public class SDMCustomServiceHandler {
   private static class SDMValidationData {
     final List<String> validSecondaryProperties;
     final Map<String, String> entityAnnotations;
+    final com.sap.cds.reflect.CdsEntity targetEntity;
 
     SDMValidationData(
-        List<String> validSecondaryProperties, Map<String, String> entityAnnotations) {
+        List<String> validSecondaryProperties,
+        Map<String, String> entityAnnotations,
+        com.sap.cds.reflect.CdsEntity targetEntity) {
       this.validSecondaryProperties = validSecondaryProperties;
       this.entityAnnotations = entityAnnotations;
+      this.targetEntity = targetEntity;
     }
   }
 
@@ -598,15 +602,17 @@ public class SDMCustomServiceHandler {
       throw new IOException("Failed to fetch valid secondary properties from SDM", e);
     }
 
-    // Get entity annotations for filtering properties during DB insertion
-    Map<String, String> entityAnnotations =
-        dbQuery.getValidSecondaryPropertiesForMove(request.getContext());
+    // Get entity annotations and target entity for filtering properties during DB insertion
+    Object[] entityData = dbQuery.getValidSecondaryPropertiesWithEntity(request.getContext());
+    @SuppressWarnings("unchecked")
+    Map<String, String> entityAnnotations = (Map<String, String>) entityData[0];
+    com.sap.cds.reflect.CdsEntity targetEntity = (com.sap.cds.reflect.CdsEntity) entityData[1];
     logger.info(
         "Target entity has {} annotated secondary properties for DB mapping: {}",
         entityAnnotations.size(),
         entityAnnotations);
 
-    return new SDMValidationData(validSecondaryProperties, entityAnnotations);
+    return new SDMValidationData(validSecondaryProperties, entityAnnotations, targetEntity);
   }
 
   /**
@@ -631,6 +637,7 @@ public class SDMCustomServiceHandler {
     SDMValidationData validationData = fetchSDMValidationData(request);
     List<String> validSecondaryProperties = validationData.validSecondaryProperties;
     Map<String, String> entityAnnotations = validationData.entityAnnotations;
+    com.sap.cds.reflect.CdsEntity targetEntity = validationData.targetEntity;
 
     // Preserve request context for authentication in parallel threads
     com.sap.cds.services.runtime.RequestContextRunner contextRunner =
@@ -656,6 +663,7 @@ public class SDMCustomServiceHandler {
                                           request,
                                           validSecondaryProperties,
                                           entityAnnotations,
+                                          targetEntity,
                                           processingResults,
                                           failedAttachments);
                                   processSingleAttachmentMove(moveContext);
@@ -728,6 +736,7 @@ public class SDMCustomServiceHandler {
     final MoveAttachmentsRequest request;
     final List<String> validSecondaryProperties;
     final Map<String, String> entityAnnotations;
+    final com.sap.cds.reflect.CdsEntity targetEntity;
     final AttachmentProcessingResults processingResults;
     final List<Map<String, String>> failedAttachments;
 
@@ -736,12 +745,14 @@ public class SDMCustomServiceHandler {
         MoveAttachmentsRequest request,
         List<String> validSecondaryProperties,
         Map<String, String> entityAnnotations,
+        com.sap.cds.reflect.CdsEntity targetEntity,
         AttachmentProcessingResults processingResults,
         List<Map<String, String>> failedAttachments) {
       this.objectId = objectId;
       this.request = request;
       this.validSecondaryProperties = validSecondaryProperties;
       this.entityAnnotations = entityAnnotations;
+      this.targetEntity = targetEntity;
       this.processingResults = processingResults;
       this.failedAttachments = failedAttachments;
     }
@@ -838,6 +849,7 @@ public class SDMCustomServiceHandler {
             movedObjectId,
             succinctProperties,
             moveContext.entityAnnotations,
+            moveContext.targetEntity,
             moveContext.processingResults);
       }
 
@@ -885,6 +897,7 @@ public class SDMCustomServiceHandler {
    * @param movedObjectId the new object ID after move
    * @param succinctProperties SDM response properties
    * @param entityAnnotations mapping of DB fields to SDM properties
+   * @param targetEntity the target attachment entity (for type checking)
    * @param results holder for successful processing results
    */
   private void processValidatedAttachment(
@@ -895,6 +908,7 @@ public class SDMCustomServiceHandler {
       String movedObjectId,
       org.json.JSONObject succinctProperties,
       Map<String, String> entityAnnotations,
+      com.sap.cds.reflect.CdsEntity targetEntity,
       AttachmentProcessingResults results) {
     logger.info("Attachment {} validation PASSED - Processing for DB insertion", objectId);
     logger.info("Entity annotations mapping (DB field -> SDM property): {}", entityAnnotations);
@@ -923,8 +937,32 @@ public class SDMCustomServiceHandler {
             value,
             value != null ? value.getClass().getSimpleName() : "null");
         if (value != null && !org.json.JSONObject.NULL.equals(value)) {
-          filteredSecondaryProps.put(dbPropertyName, value);
-          logger.info("Added to DB map: '{}' = '{}'", dbPropertyName, value);
+          // Convert Long timestamp to Instant ONLY for DateTime fields
+          // Check the CDS type of the field to determine if conversion is needed
+          Object convertedValue = value;
+          if (value instanceof Long) {
+            com.sap.cds.reflect.CdsElement element = targetEntity.getElement(dbPropertyName);
+            if (element != null
+                && element.getType() != null
+                && "cds.DateTime".equals(element.getType().getQualifiedName())) {
+              convertedValue = java.time.Instant.ofEpochMilli((Long) value);
+              logger.info(
+                  "Converted Long timestamp {} to Instant {} for DateTime field '{}'",
+                  value,
+                  convertedValue,
+                  dbPropertyName);
+            } else {
+              logger.info(
+                  "Keeping Long value {} as-is for non-DateTime field '{}' (type: {})",
+                  value,
+                  dbPropertyName,
+                  element != null && element.getType() != null
+                      ? element.getType().getQualifiedName()
+                      : "unknown");
+            }
+          }
+          filteredSecondaryProps.put(dbPropertyName, convertedValue);
+          logger.info("Added to DB map: '{}' = '{}'", dbPropertyName, convertedValue);
         }
       }
     }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -10,10 +10,12 @@ import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.CopyAttachmentsRequest;
 import com.sap.cds.sdm.model.CreateDraftEntriesRequest;
+import com.sap.cds.sdm.model.MoveAttachmentsRequest;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.RegisterService;
 import com.sap.cds.sdm.service.SDMService;
+import com.sap.cds.services.EventContext;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.draft.DraftService;
 import com.sap.cds.services.handler.annotations.On;
@@ -25,7 +27,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ServiceName(value = "*", type = RegisterService.class)
 public class SDMCustomServiceHandler {
@@ -34,6 +41,10 @@ public class SDMCustomServiceHandler {
   private final List<DraftService> draftService;
   private final TokenHandler tokenHandler;
   private final PersistenceService persistenceService;
+  private final ExecutorService executorService;
+
+  private static final int PARALLEL_MOVE_THREAD_POOL_SIZE = 10;
+  private static final Logger logger = LoggerFactory.getLogger(SDMCustomServiceHandler.class);
 
   // Result class for copyAttachmentsToSDM method
   private static class CopyAttachmentsResult {
@@ -66,6 +77,42 @@ public class SDMCustomServiceHandler {
     this.tokenHandler = tokenHandler;
     this.dbQuery = dbQuery;
     this.persistenceService = persistenceService;
+    this.executorService = Executors.newFixedThreadPool(PARALLEL_MOVE_THREAD_POOL_SIZE);
+  }
+
+  // Result class for moveAttachmentsInSDM method
+  private static class MoveAttachmentsResult {
+    private final List<List<String>> movedAttachmentsMetadata;
+    private final List<CmisDocument> populatedDocuments;
+    private final List<String> failedObjectIds;
+    private final Map<String, String> successfulMovesMap; // objectId -> newObjectId mapping
+
+    public MoveAttachmentsResult(
+        List<List<String>> movedAttachmentsMetadata,
+        List<CmisDocument> populatedDocuments,
+        List<String> failedObjectIds,
+        Map<String, String> successfulMovesMap) {
+      this.movedAttachmentsMetadata = movedAttachmentsMetadata;
+      this.populatedDocuments = populatedDocuments;
+      this.failedObjectIds = failedObjectIds;
+      this.successfulMovesMap = successfulMovesMap;
+    }
+
+    public List<List<String>> getMovedAttachmentsMetadata() {
+      return movedAttachmentsMetadata;
+    }
+
+    public List<CmisDocument> getPopulatedDocuments() {
+      return populatedDocuments;
+    }
+
+    public List<String> getFailedObjectIds() {
+      return failedObjectIds;
+    }
+
+    public Map<String, String> getSuccessfulMovesMap() {
+      return successfulMovesMap;
+    }
   }
 
   @On(event = RegisterService.EVENT_COPY_ATTACHMENT)
@@ -121,6 +168,106 @@ public class SDMCustomServiceHandler {
     context.setCompleted();
   }
 
+  @On(event = RegisterService.EVENT_MOVE_ATTACHMENT)
+  public void moveAttachments(AttachmentMoveEventContext context) throws IOException {
+    String parentEntity = context.getParentEntity();
+    String compositionName = context.getCompositionName();
+    String upID = context.getUpId();
+    String sourceFolderId = context.getSourceFolderId();
+    String targetFolderName = upID + "__" + compositionName;
+    String repositoryId = SDMConstants.REPOSITORY_ID;
+    Boolean isSystemUser = context.getSystemUser();
+    List<String> objectIds = context.getObjectIds();
+
+    SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
+
+    // Check if target folder exists before trying to create it
+    boolean targetFolderExists;
+    String targetFolderId;
+    try {
+      targetFolderExists =
+          sdmService.getFolderIdByPath(targetFolderName, repositoryId, sdmCredentials, isSystemUser)
+              != null;
+      targetFolderId =
+          ensureFolderExists(targetFolderName, repositoryId, sdmCredentials, isSystemUser);
+    } catch (IOException e) {
+      // Folder creation/verification failed - mark all objectIds as failed
+      logger.error(
+          "Failed to create/verify target folder '{}': {}. Marking all {} attachments as failed.",
+          targetFolderName,
+          e.getMessage(),
+          objectIds.size());
+      context.setFailedObjectIds(objectIds);
+      context.setCompleted();
+      return;
+    }
+
+    MoveAttachmentsRequest request =
+        MoveAttachmentsRequest.builder()
+            .context(context)
+            .sourceFolderId(sourceFolderId)
+            .objectIds(objectIds)
+            .targetFolderId(targetFolderId)
+            .repositoryId(repositoryId)
+            .sdmCredentials(sdmCredentials)
+            .isSystemUser(isSystemUser)
+            .targetFolderExists(targetFolderExists)
+            .build();
+
+    MoveAttachmentsResult moveResult = moveAttachmentsInSDM(request);
+
+    List<List<String>> movedAttachmentsMetadata = moveResult.getMovedAttachmentsMetadata();
+    List<CmisDocument> populatedDocuments = moveResult.getPopulatedDocuments();
+    List<String> failedObjectIds = moveResult.getFailedObjectIds();
+    Map<String, String> successfulMovesMap = moveResult.getSuccessfulMovesMap();
+
+    // Set the failed object IDs in the context for the caller
+    context.setFailedObjectIds(failedObjectIds);
+
+    // Only create draft entries for successfully moved attachments
+    if (!movedAttachmentsMetadata.isEmpty()) {
+      String upIdKey = resolveUpIdKey(context, parentEntity, compositionName);
+
+      CreateDraftEntriesRequest draftRequest =
+          CreateDraftEntriesRequest.builder()
+              .attachmentsMetadata(movedAttachmentsMetadata)
+              .populatedDocuments(populatedDocuments)
+              .parentEntity(parentEntity)
+              .compositionName(compositionName)
+              .upID(upID)
+              .upIdKey(upIdKey)
+              .repositoryId(repositoryId)
+              .folderId(targetFolderId)
+              .build();
+
+      try {
+        createDraftEntries(draftRequest);
+      } catch (ServiceException e) {
+        // If DB update fails after retries, rollback the SDM moves
+        logger.error(
+            "Failed to update DB for moved attachments after retries. Rolling back SDM moves: {}",
+            e.getMessage());
+        rollbackMovedAttachments(
+            successfulMovesMap,
+            sourceFolderId,
+            targetFolderId,
+            repositoryId,
+            sdmCredentials,
+            isSystemUser);
+        // Add all successfully moved objects to failed list since we rolled back
+        failedObjectIds.addAll(successfulMovesMap.keySet());
+        context.setFailedObjectIds(failedObjectIds);
+        // Don't throw exception - return failed IDs to caller as per acceptance criteria
+        logger.warn(
+            "Move operation completed with failures. Total failed: {}, Rolled back: {}",
+            failedObjectIds.size(),
+            successfulMovesMap.size());
+      }
+    }
+
+    context.setCompleted();
+  }
+
   private String ensureFolderExists(
       String folderName, String repositoryId, SDMCredentials sdmCredentials, Boolean isSystemUser)
       throws IOException {
@@ -172,6 +319,73 @@ public class SDMCustomServiceHandler {
     return new CopyAttachmentsResult(attachmentsMetadata, populatedDocuments);
   }
 
+  private MoveAttachmentsResult moveAttachmentsInSDM(MoveAttachmentsRequest request)
+      throws IOException {
+    List<List<String>> movedAttachmentsMetadata =
+        java.util.Collections.synchronizedList(new ArrayList<>());
+    List<CmisDocument> populatedDocuments =
+        java.util.Collections.synchronizedList(new ArrayList<>());
+    List<String> failedObjectIds = java.util.Collections.synchronizedList(new ArrayList<>());
+    Map<String, String> successfulMovesMap =
+        new java.util.concurrent.ConcurrentHashMap<>(); // objectId -> newObjectId
+
+    // Create parallel tasks for each attachment move
+    List<CompletableFuture<Void>> moveFutures =
+        request.getObjectIds().stream()
+            .map(
+                objectId ->
+                    CompletableFuture.runAsync(
+                        () -> {
+                          try {
+                            CmisDocument cmisDocument =
+                                dbQuery.getAttachmentForObjectID(
+                                    persistenceService, objectId, request.getContext());
+                            cmisDocument.setObjectId(objectId);
+                            cmisDocument.setRepositoryId(request.getRepositoryId());
+                            cmisDocument.setSourceFolderId(request.getSourceFolderId());
+                            cmisDocument.setFolderId(request.getTargetFolderId());
+
+                            // Create individual document for each attachment with its own type and
+                            // linkUrl
+                            CmisDocument populatedDocument = new CmisDocument();
+                            populatedDocument.setType(cmisDocument.getType());
+                            populatedDocument.setUrl(cmisDocument.getUrl());
+
+                            // Perform SDM move operation with retry
+                            List<String> metadata =
+                                sdmService.moveAttachment(
+                                    cmisDocument,
+                                    request.getSdmCredentials(),
+                                    request.getIsSystemUser());
+
+                            // Track successful move for rollback (thread-safe)
+                            String newObjectId = metadata.get(2);
+                            successfulMovesMap.put(objectId, newObjectId);
+                            movedAttachmentsMetadata.add(metadata);
+                            populatedDocuments.add(populatedDocument);
+                          } catch (ServiceException | IOException e) {
+                            // Add to failed list and continue with next attachment (thread-safe)
+                            logger.error(
+                                "Failed to move attachment with objectId {}: {}",
+                                objectId,
+                                e.getMessage());
+                            failedObjectIds.add(objectId);
+                          }
+                        },
+                        executorService))
+            .toList();
+
+    // Wait for all move operations to complete
+    try {
+      CompletableFuture.allOf(moveFutures.toArray(new CompletableFuture[0])).join();
+    } catch (Exception e) {
+      throw new IOException("Error during parallel move operations", e);
+    }
+
+    return new MoveAttachmentsResult(
+        movedAttachmentsMetadata, populatedDocuments, failedObjectIds, successfulMovesMap);
+  }
+
   private void handleCopyFailure(
       AttachmentCopyEventContext context,
       String folderId,
@@ -190,8 +404,7 @@ public class SDMCustomServiceHandler {
     throw new ServiceException(e.getMessage());
   }
 
-  private String resolveUpIdKey(
-      AttachmentCopyEventContext context, String parentEntity, String compositionName) {
+  private String resolveUpIdKey(EventContext context, String parentEntity, String compositionName) {
     CdsModel model = context.getModel();
     Optional<CdsEntity> optionalParentEntity = model.findEntity(parentEntity);
     if (optionalParentEntity.isEmpty()) {
@@ -273,11 +486,80 @@ public class SDMCustomServiceHandler {
               .orElse(null);
 
       if (matchingService != null) {
-        matchingService.newDraft(insert);
+        // Wrap DB insert with retry logic to handle transient DB failures
+        try {
+          io.reactivex.Flowable.fromCallable(
+                  () -> {
+                    matchingService.newDraft(insert);
+                    return true;
+                  })
+              .retryWhen(com.sap.cds.sdm.service.RetryUtils.retryLogic(5)) // Retry up to 5 times
+              .blockingFirst();
+        } catch (Exception e) {
+          throw new ServiceException(
+              "Failed to insert attachment entry in DB after retries: " + e.getMessage(), e);
+        }
       } else {
         throw new ServiceException(
             "No suitable service found for entity: " + request.getParentEntity());
       }
+    }
+  }
+
+  /**
+   * Rollback moved attachments by moving them back to the source folder. This is called when DB
+   * update fails after SDM move succeeds.
+   */
+  private void rollbackMovedAttachments(
+      Map<String, String> successfulMovesMap,
+      String sourceFolderId,
+      String targetFolderId,
+      String repositoryId,
+      SDMCredentials sdmCredentials,
+      boolean isSystemUser) {
+    logger.warn(
+        "Rolling back {} moved attachments from {} to {}",
+        successfulMovesMap.size(),
+        targetFolderId,
+        sourceFolderId);
+
+    List<CompletableFuture<Void>> rollbackFutures =
+        successfulMovesMap.entrySet().stream()
+            .map(
+                entry ->
+                    CompletableFuture.runAsync(
+                        () -> {
+                          String originalObjectId = entry.getKey();
+                          String newObjectId = entry.getValue();
+                          try {
+                            // Create CMIS document for rollback move
+                            CmisDocument rollbackDoc = new CmisDocument();
+                            rollbackDoc.setObjectId(newObjectId);
+                            rollbackDoc.setRepositoryId(repositoryId);
+                            rollbackDoc.setSourceFolderId(targetFolderId);
+                            rollbackDoc.setFolderId(sourceFolderId);
+
+                            // Move back to source folder with retry
+                            sdmService.moveAttachment(rollbackDoc, sdmCredentials, isSystemUser);
+                            logger.info(
+                                "Successfully rolled back attachment {} to source folder",
+                                originalObjectId);
+                          } catch (Exception e) {
+                            logger.error(
+                                "Failed to rollback attachment {} during rollback: {}",
+                                originalObjectId,
+                                e.getMessage());
+                            // Continue with other rollbacks even if one fails
+                          }
+                        },
+                        executorService))
+            .toList();
+
+    // Wait for all rollback operations to complete
+    try {
+      CompletableFuture.allOf(rollbackFutures.toArray(new CompletableFuture[0])).join();
+    } catch (Exception e) {
+      logger.error("Error during rollback operations: {}", e.getMessage());
     }
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1043,9 +1043,32 @@ public class SDMCustomServiceHandler {
           "sap:link".equals(objectTypeId) ? "sap-icon://internet-browser" : "sap-icon://document";
       cmisDocument.setType(attachmentType);
 
-      // For link attachments, extract the URL from database if sourceFacet was provided
-      // Note: sap:linkUrl is not in the SDM move response, so we rely on database fetch
-      // If sourceFacet not provided, linkUrl will remain null (which is acceptable for move)
+      // For link attachments, fetch the actual URL from SDM content if not already available
+      // Link URLs are stored in the content stream in format: [InternetShortcut]\nURL=<url>
+      if ("sap:link".equals(objectTypeId) && cmisDocument.getUrl() == null) {
+        try {
+          String linkUrl =
+              sdmService.getLinkUrl(
+                  movedObjectId,
+                  moveContext.getRequest().getSdmCredentials(),
+                  moveContext.getRequest().getIsSystemUser());
+          if (linkUrl != null) {
+            cmisDocument.setUrl(linkUrl);
+            logger.info(
+                "[Thread: {}] Fetched and set linkUrl for attachment {}: {}",
+                Thread.currentThread().getName(),
+                moveContext.getObjectId(),
+                linkUrl);
+          }
+        } catch (Exception e) {
+          logger.warn(
+              "[Thread: {}] Failed to fetch link URL for attachment {}: {}",
+              Thread.currentThread().getName(),
+              moveContext.getObjectId(),
+              e.getMessage());
+          // Continue with null URL - the type is still correctly set
+        }
+      }
 
       logger.info(
           "[Thread: {}] Successfully moved attachment {} to target folder. FileName: {}, MimeType: {}, ObjectTypeId: {}, Type: {}, LinkUrl: {}",

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -103,8 +103,9 @@ public class SDMServiceGenericHandler implements EventHandler {
     // Use the full target qualified name as the targetFacet
     String targetFacet = context.getTarget().getQualifiedName();
 
+    // Pass String directly - the constructor will automatically wrap it in Optional
     var moveEventInput =
-        new MoveAttachmentInput(sourceFolderId, sourceFacet, upID, targetFacet, objectIds);
+        new MoveAttachmentInput(sourceFolderId, upID, targetFacet, objectIds, sourceFacet);
 
     Map<String, Object> result =
         attachmentService.moveAttachments(moveEventInput, context.getUserInfo().isSystemUser());

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -90,23 +90,28 @@ public class SDMServiceGenericHandler implements EventHandler {
   }
 
   @On(event = "moveAttachments")
-  public List<String> moveAttachments(EventContext context) throws IOException {
+  public Map<String, Object> moveAttachments(EventContext context) throws IOException {
     String upID = context.get("up__ID").toString();
     String sourceFolderId = context.get("sourceFolderId").toString();
     String objectIdsString = context.get("objectIds").toString();
     List<String> objectIds = Arrays.stream(objectIdsString.split(",")).map(String::trim).toList();
 
+    // Get sourceFacet if provided, otherwise null (cleanup won't be performed)
+    String sourceFacet =
+        context.get("sourceFacet") != null ? context.get("sourceFacet").toString() : null;
+
     // Use the full target qualified name as the targetFacet
     String targetFacet = context.getTarget().getQualifiedName();
 
-    var moveEventInput = new MoveAttachmentInput(sourceFolderId, upID, targetFacet, objectIds);
+    var moveEventInput =
+        new MoveAttachmentInput(sourceFolderId, sourceFacet, upID, targetFacet, objectIds);
 
-    List<String> failedObjectIds =
+    Map<String, Object> result =
         attachmentService.moveAttachments(moveEventInput, context.getUserInfo().isSystemUser());
     context.setCompleted();
 
-    System.out.println("Failed Object IDs: " + failedObjectIds);
-    return failedObjectIds;
+    logger.info("Move operation result: {}", result);
+    return result;
   }
 
   @On(event = "createLink")

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -89,6 +89,26 @@ public class SDMServiceGenericHandler implements EventHandler {
     context.setCompleted();
   }
 
+  @On(event = "moveAttachments")
+  public List<String> moveAttachments(EventContext context) throws IOException {
+    String upID = context.get("up__ID").toString();
+    String sourceFolderId = context.get("sourceFolderId").toString();
+    String objectIdsString = context.get("objectIds").toString();
+    List<String> objectIds = Arrays.stream(objectIdsString.split(",")).map(String::trim).toList();
+
+    // Use the full target qualified name as the targetFacet
+    String targetFacet = context.getTarget().getQualifiedName();
+
+    var moveEventInput = new MoveAttachmentInput(sourceFolderId, upID, targetFacet, objectIds);
+
+    List<String> failedObjectIds =
+        attachmentService.moveAttachments(moveEventInput, context.getUserInfo().isSystemUser());
+    context.setCompleted();
+
+    System.out.println("Failed Object IDs: " + failedObjectIds);
+    return failedObjectIds;
+  }
+
   @On(event = "createLink")
   public void create(EventContext context) throws IOException {
     validateRepository(context);

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -1659,4 +1659,817 @@ public class SDMServiceImplTest {
     expectedResponse.put("status", "success");
     assertEquals(expectedResponse.toString(), actualResponse.toString());
   }
+
+  @Test
+  public void testMoveAttachment_WithSystemUser_Success() throws IOException {
+    String mockResponseBody =
+        "{\"succinctProperties\": {\"cmis:objectId\": \"newObjectId\", \"cmis:name\": \"moved-file.txt\"}}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(201);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals(mockResponseBody, result);
+    verify(httpClient, times(1)).execute(any(HttpPost.class));
+  }
+
+  @Test
+  public void testMoveAttachment_WithNamedUser_Success() throws IOException {
+    String mockResponseBody =
+        "{\"succinctProperties\": {\"cmis:objectId\": \"newObjectId\", \"cmis:name\": \"moved-file.txt\"}}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.NAMED_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, false);
+
+    assertNotNull(result);
+    assertEquals(mockResponseBody, result);
+    verify(httpClient, times(1)).execute(any(HttpPost.class));
+  }
+
+  @Test
+  public void testMoveAttachment_WithErrorResponse_ThrowsServiceException() throws IOException {
+    String errorResponseBody =
+        "{\"exception\": \"ObjectNotFoundException\", \"message\": \"Object not found in SDM\"}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(404);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(errorResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true));
+
+    assertTrue(exception.getMessage().contains(SDMConstants.FAILED_TO_MOVE_ATTACHMENT));
+  }
+
+  @Test
+  public void testMoveAttachment_WithIOException_ThrowsServiceException() throws IOException {
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenThrow(new IOException("Network error"));
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true));
+
+    assertTrue(exception.getMessage().contains(SDMConstants.FAILED_TO_MOVE_ATTACHMENT));
+  }
+
+  @Test
+  public void testMoveAttachment_VerifyRequestParameters() throws IOException {
+    String mockResponseBody = "{\"succinctProperties\": {\"cmis:objectId\": \"newObjectId\"}}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("testRepoId");
+    cmisDocument.setObjectId("object123");
+    cmisDocument.setSourceFolderId("sourceFolder456");
+    cmisDocument.setFolderId("targetFolder789");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(201);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true);
+
+    assertNotNull(result);
+    verify(httpClient, times(1)).execute(any(HttpPost.class));
+    verify(tokenHandler, times(1))
+        .getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW));
+  }
+
+  @Test
+  public void testMoveAttachment_WithEmptyResponse_ReturnsEmptyString() throws IOException {
+    String mockResponseBody = "";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(mockResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("", result);
+  }
+
+  @Test
+  public void testMoveAttachment_WithNullEntity_ReturnsEmptyString() throws IOException {
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(null);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("", result);
+  }
+
+  @Test
+  public void testMoveAttachment_WithBadRequest_ThrowsServiceException() throws IOException {
+    String errorResponseBody =
+        "{\"exception\": \"InvalidArgumentException\", \"message\": \"Invalid folder ID\"}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("invalidFolderId");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(400);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(errorResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, true));
+
+    assertTrue(exception.getMessage().contains(SDMConstants.FAILED_TO_MOVE_ATTACHMENT));
+  }
+
+  @Test
+  public void testMoveAttachment_WithUnauthorized_ThrowsServiceException() throws IOException {
+    String errorResponseBody =
+        "{\"exception\": \"PermissionDeniedException\", \"message\": \"User not authorized\"}";
+
+    CmisDocument cmisDocument = new CmisDocument();
+    cmisDocument.setRepositoryId("repositoryId");
+    cmisDocument.setObjectId("objectId123");
+    cmisDocument.setSourceFolderId("sourceFolderId123");
+    cmisDocument.setFolderId("targetFolderId456");
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.NAMED_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(403);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(errorResponseBody.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.moveAttachment(cmisDocument, sdmCredentials, false));
+
+    assertTrue(exception.getMessage().contains(SDMConstants.FAILED_TO_MOVE_ATTACHMENT));
+  }
+
+  @Test
+  void testGetLinkUrl_WithSystemUser_Success() throws IOException {
+    String objectId = "objectId123";
+    String linkContent = "[InternetShortcut]\nURL=https://example.com/document";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("https://example.com/document", result);
+    verify(httpClient, times(1)).execute(any(HttpGet.class));
+  }
+
+  @Test
+  void testGetLinkUrl_WithNamedUser_Success() throws IOException {
+    String objectId = "objectId456";
+    String linkContent = "[InternetShortcut]\nURL=https://external.com/file.pdf";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.NAMED_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, false);
+
+    assertNotNull(result);
+    assertEquals("https://external.com/file.pdf", result);
+    verify(tokenHandler, times(1))
+        .getHttpClient(any(), any(), any(), eq(SDMConstants.NAMED_USER_FLOW));
+  }
+
+  @Test
+  void testGetLinkUrl_WithUrlContainingSpaces_TrimsCorrectly() throws IOException {
+    String objectId = "objectId789";
+    String linkContent = "[InternetShortcut]\nURL=  https://example.com/path  \n";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("https://example.com/path", result);
+  }
+
+  @Test
+  void testGetLinkUrl_WithMultipleLines_ExtractsCorrectUrl() throws IOException {
+    String objectId = "objectId999";
+    String linkContent =
+        "[InternetShortcut]\nURL=https://example.com/document\nIconIndex=0\nIconFile=C:\\Windows\\System32\\shell32.dll";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("https://example.com/document", result);
+  }
+
+  @Test
+  void testGetLinkUrl_WithNon200Response_ReturnsNull() throws IOException {
+    String objectId = "objectId404";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(404);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNull(result);
+    verify(httpClient, times(1)).execute(any(HttpGet.class));
+  }
+
+  @Test
+  void testGetLinkUrl_WithUnauthorizedResponse_ReturnsNull() throws IOException {
+    String objectId = "objectId403";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.NAMED_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(403);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, false);
+
+    assertNull(result);
+  }
+
+  @Test
+  void testGetLinkUrl_WithNoUrlInContent_ReturnsNull() throws IOException {
+    String objectId = "objectId555";
+    String linkContent = "[InternetShortcut]\nIconIndex=0\nIconFile=shell32.dll";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNull(result);
+  }
+
+  @Test
+  void testGetLinkUrl_WithEmptyContent_ReturnsNull() throws IOException {
+    String objectId = "objectId888";
+    String linkContent = "";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNull(result);
+  }
+
+  @Test
+  void testGetLinkUrl_WithIOException_ThrowsServiceException() throws IOException {
+    String objectId = "objectIdError";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenThrow(new IOException("Network error"));
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true));
+
+    assertEquals("Failed to fetch link URL", exception.getMessage());
+  }
+
+  @Test
+  void testGetLinkUrl_VerifyCorrectUrlConstruction() throws IOException {
+    String objectId = "testObjectId";
+    String linkContent = "[InternetShortcut]\nURL=https://test.com";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm-service.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("https://test.com", result);
+    verify(httpClient, times(1)).execute(any(HttpGet.class));
+  }
+
+  @Test
+  void testGetLinkUrl_WithUrlEqualsEmpty_ReturnsEmptyString() throws IOException {
+    String objectId = "objectIdEmpty";
+    String linkContent = "[InternetShortcut]\nURL=";
+
+    SDMCredentials sdmCredentials = new SDMCredentials();
+    sdmCredentials.setUrl("https://sdm.example.com/");
+
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(SDMConstants.TECHNICAL_USER_FLOW)))
+        .thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream(linkContent.getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    String result = sdmServiceImpl.getLinkUrl(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertEquals("", result);
+  }
+
+  @Test
+  void testExtractCustomProperties_WithValidProperties_ExtractsAll() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("customProp1", "value1");
+    props.put("customProp2", "value2");
+    props.put("customProp3", 123);
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    customPropertiesInSDM.add("customProp1");
+    customPropertiesInSDM.add("customProp2");
+    customPropertiesInSDM.add("customProp3");
+
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, props, customPropertiesInSDM, resultMap);
+
+    assertEquals("value1", resultMap.get("customProp1"));
+    assertEquals("value2", resultMap.get("customProp2"));
+    assertEquals("123", resultMap.get("customProp3"));
+  }
+
+  @Test
+  void testExtractCustomProperties_WithNullValue_StoresNullString() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("customProp1", JSONObject.NULL);
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    customPropertiesInSDM.add("customProp1");
+
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, props, customPropertiesInSDM, resultMap);
+
+    // JSONObject.NULL.toString() returns "null" string
+    assertEquals("null", resultMap.get("customProp1"));
+  }
+
+  @Test
+  void testExtractCustomProperties_WithNullProps_DoesNothing() throws Exception {
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    customPropertiesInSDM.add("customProp1");
+
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, null, customPropertiesInSDM, resultMap);
+
+    assertTrue(resultMap.isEmpty());
+  }
+
+  @Test
+  void testExtractCustomProperties_WithNullCustomPropertiesSet_DoesNothing() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("customProp1", "value1");
+
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, props, null, resultMap);
+
+    assertTrue(resultMap.isEmpty());
+  }
+
+  @Test
+  void testExtractCustomProperties_WithEmptyCustomPropertiesSet_DoesNothing() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("customProp1", "value1");
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, props, customPropertiesInSDM, resultMap);
+
+    assertTrue(resultMap.isEmpty());
+  }
+
+  @Test
+  void testExtractCustomProperties_WithMissingProperty_SkipsIt() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("customProp1", "value1");
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    customPropertiesInSDM.add("customProp1");
+    customPropertiesInSDM.add("customProp2"); // This property doesn't exist in props
+
+    Map<String, String> resultMap = new HashMap<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractCustomProperties", JSONObject.class, Set.class, Map.class);
+    method.setAccessible(true);
+    method.invoke(sdmServiceImpl, props, customPropertiesInSDM, resultMap);
+
+    assertEquals(1, resultMap.size());
+    assertEquals("value1", resultMap.get("customProp1"));
+    assertNull(resultMap.get("customProp2"));
+  }
+
+  @Test
+  void testExtractProperty_WithNonNullProps_ReturnsFromProps() throws Exception {
+    JSONObject props = new JSONObject();
+    props.put("testProperty", "valueFromProps");
+
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("testProperty", "valueFromJsonObject");
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractProperty", JSONObject.class, JSONObject.class, String.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(sdmServiceImpl, props, jsonObject, "testProperty");
+
+    assertEquals("valueFromProps", result);
+  }
+
+  @Test
+  void testExtractProperty_WithNullProps_ReturnsFromJsonObject() throws Exception {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("testProperty", "valueFromJsonObject");
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractProperty", JSONObject.class, JSONObject.class, String.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(sdmServiceImpl, null, jsonObject, "testProperty");
+
+    assertEquals("valueFromJsonObject", result);
+  }
+
+  @Test
+  void testExtractProperty_WithMissingProperty_ReturnsEmptyString() throws Exception {
+    JSONObject props = new JSONObject();
+    JSONObject jsonObject = new JSONObject();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "extractProperty", JSONObject.class, JSONObject.class, String.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(sdmServiceImpl, props, jsonObject, "missingProperty");
+
+    assertEquals("", result);
+  }
+
+  @Test
+  void testProcessCopyAttachmentResponse_WithAllProperties_ExtractsCorrectly() throws Exception {
+    String responseBody =
+        "{\"succinctProperties\": {"
+            + "\"cmis:name\": \"test.pdf\","
+            + "\"cmis:contentStreamMimeType\": \"application/pdf\","
+            + "\"cmis:description\": \"Test document\","
+            + "\"cmis:objectId\": \"obj123\","
+            + "\"customProp1\": \"customValue1\","
+            + "\"customProp2\": \"customValue2\""
+            + "}}";
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+    customPropertiesInSDM.add("customProp1");
+    customPropertiesInSDM.add("customProp2");
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "processCopyAttachmentResponse", String.class, Set.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> result =
+        (Map<String, String>) method.invoke(sdmServiceImpl, responseBody, customPropertiesInSDM);
+
+    assertEquals("test.pdf", result.get("cmis:name"));
+    assertEquals("application/pdf", result.get("cmis:contentStreamMimeType"));
+    assertEquals("Test document", result.get("cmis:description"));
+    assertEquals("obj123", result.get("cmis:objectId"));
+    assertEquals("customValue1", result.get("customProp1"));
+    assertEquals("customValue2", result.get("customProp2"));
+  }
+
+  @Test
+  void testProcessCopyAttachmentResponse_WithoutSuccinctProperties_UsesRootLevel()
+      throws Exception {
+    String responseBody =
+        "{"
+            + "\"cmis:name\": \"test.pdf\","
+            + "\"cmis:contentStreamMimeType\": \"application/pdf\","
+            + "\"cmis:description\": \"Test document\","
+            + "\"cmis:objectId\": \"obj123\""
+            + "}";
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "processCopyAttachmentResponse", String.class, Set.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> result =
+        (Map<String, String>) method.invoke(sdmServiceImpl, responseBody, customPropertiesInSDM);
+
+    assertEquals("test.pdf", result.get("cmis:name"));
+    assertEquals("application/pdf", result.get("cmis:contentStreamMimeType"));
+    assertEquals("Test document", result.get("cmis:description"));
+    assertEquals("obj123", result.get("cmis:objectId"));
+  }
+
+  @Test
+  void testProcessCopyAttachmentResponse_WithNullCustomProperties_ExtractsStandardOnly()
+      throws Exception {
+    String responseBody =
+        "{\"succinctProperties\": {"
+            + "\"cmis:name\": \"test.pdf\","
+            + "\"cmis:contentStreamMimeType\": \"application/pdf\","
+            + "\"cmis:description\": \"Test document\","
+            + "\"cmis:objectId\": \"obj123\","
+            + "\"customProp1\": \"customValue1\""
+            + "}}";
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "processCopyAttachmentResponse", String.class, Set.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> result =
+        (Map<String, String>) method.invoke(sdmServiceImpl, responseBody, null);
+
+    assertEquals("test.pdf", result.get("cmis:name"));
+    assertEquals("application/pdf", result.get("cmis:contentStreamMimeType"));
+    assertEquals("Test document", result.get("cmis:description"));
+    assertEquals("obj123", result.get("cmis:objectId"));
+    assertNull(result.get("customProp1"));
+  }
+
+  @Test
+  void testProcessCopyAttachmentResponse_WithEmptyCustomPropertiesSet_ExtractsStandardOnly()
+      throws Exception {
+    String responseBody =
+        "{\"succinctProperties\": {"
+            + "\"cmis:name\": \"test.pdf\","
+            + "\"cmis:contentStreamMimeType\": \"application/pdf\","
+            + "\"cmis:description\": \"Test document\","
+            + "\"cmis:objectId\": \"obj123\","
+            + "\"customProp1\": \"customValue1\""
+            + "}}";
+
+    Set<String> customPropertiesInSDM = new HashSet<>();
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    java.lang.reflect.Method method =
+        SDMServiceImpl.class.getDeclaredMethod(
+            "processCopyAttachmentResponse", String.class, Set.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> result =
+        (Map<String, String>) method.invoke(sdmServiceImpl, responseBody, customPropertiesInSDM);
+
+    assertEquals(4, result.size());
+    assertEquals("test.pdf", result.get("cmis:name"));
+    assertNull(result.get("customProp1"));
+  }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
@@ -1,8 +1,12 @@
 package unit.com.sap.cds.sdm.service.handler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -11,12 +15,15 @@ import com.sap.cds.reflect.CdsAssociationType;
 import com.sap.cds.reflect.CdsElement;
 import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
+import com.sap.cds.reflect.CdsStructuredType;
+import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.model.CmisDocument;
 import com.sap.cds.sdm.model.SDMCredentials;
 import com.sap.cds.sdm.persistence.DBQuery;
 import com.sap.cds.sdm.service.SDMService;
 import com.sap.cds.sdm.service.handler.AttachmentCopyEventContext;
+import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
 import com.sap.cds.sdm.service.handler.SDMCustomServiceHandler;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.draft.DraftService;
@@ -32,6 +39,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -354,5 +362,3134 @@ public class SDMCustomServiceHandlerTest {
     when(mockCqnElementRef.path()).thenReturn("ID");
 
     return context;
+  }
+
+  // ==================== Move Attachments Tests ====================
+
+  @Test
+  void testMoveAttachments_SuccessWithoutSourceCleanup() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Mock target folder exists
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move operation
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock getObject for metadata (no sourceFacet, so fetch from SDM)
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify - since draft creation will likely fail without proper mocks,
+    // rollback happens, so moveAttachment called twice (move + rollback)
+    verify(sdmService, atLeast(1)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_SuccessWithSourceCleanup() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Mock target folder exists
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move operation
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock getAttachmentForObjectID for metadata (sourceFacet provided)
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    // Mock source cleanup
+    when(dbQuery.getSourceUpIdForObjectIds(any(), any(), any())).thenReturn("sourceUpId");
+    when(dbQuery.deleteAttachmentsByObjectIds(any(), any(), any(), any())).thenReturn(1L);
+
+    AttachmentMoveEventContext context = createMockMoveContext(true);
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify
+    verify(sdmService, atLeast(1)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ValidationFailure_InvalidSecondaryProperties() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Mock valid secondary properties - only allow "validProp1"
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("validProp1", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    // Mock SDM to return list with "validProp1" included
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    // Mock target folder exists
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move operation - response includes invalid property "invalidProp"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"someValue\"}}");
+
+    // Mock getObject for metadata
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc", "invalidProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was called (move + rollback = 2 calls)
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_CreateDraftFailure_TriggersRollback() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Override the newDraft mock to throw exception (simulates database failure)
+    doThrow(new ServiceException("Database connection failed")).when(draftService).newDraft(any());
+
+    // Mock target folder exists
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock successful move
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock getObject
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was attempted (move + rollback)
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_TargetFolderDoesNotExist_CreatesFolder() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Mock target folder does NOT exist
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(null);
+
+    // Mock folder creation
+    when(sdmService.createFolder(any(), any(), any(), anyBoolean()))
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + FOLDER_ID + "\"}}");
+
+    // Mock move operation
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock getObject
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify folder was created
+    verify(sdmService, times(1)).createFolder(any(), any(), any(), anyBoolean());
+    verify(sdmService, atLeast(1)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_PartialFailure_SomeSucceedSomeFail() throws IOException {
+    setupMoveAttachmentsMocks();
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    when(context.getObjectIds()).thenReturn(List.of("obj1", "obj2"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // First call succeeds, second fails
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \"obj1\"}}")
+        .thenThrow(new RuntimeException("Move failed for obj2"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    // Execute
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify: 2 move attempts + 1 rollback of successful move = 3 total calls
+    verify(sdmService, times(3)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  // Helper methods for move tests
+
+  private void setupMoveAttachmentsMocks() throws IOException {
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+
+    // Mock dbQuery.getValidSecondaryPropertiesWithEntity
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {new HashMap<String, String>(), mockTargetEntity});
+
+    // Mock SDM service methods used in fetchSDMValidationData
+    when(sdmService.getSecondaryTypes(any(), any(SDMCredentials.class), anyBoolean()))
+        .thenReturn(new java.util.ArrayList<>());
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(new java.util.ArrayList<>());
+
+    // Mock database query methods
+    com.sap.cds.Result mockResult = mock(com.sap.cds.Result.class);
+    when(mockResult.rowCount()).thenReturn(0L);
+    when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), any(), any()))
+        .thenReturn(mockResult);
+
+    // Mock getSourceUpIdForObjectIds and deleteAttachmentsByObjectIds
+    when(dbQuery.getSourceUpIdForObjectIds(any(), any(), any())).thenReturn("sourceUpId");
+    when(dbQuery.deleteAttachmentsByObjectIds(any(), any(), any(), any())).thenReturn(1L);
+
+    // Mock draftService.newDraft - similar to Copy tests
+    when(draftService.newDraft(any())).thenReturn(mock(com.sap.cds.Result.class));
+  }
+
+  private AttachmentMoveEventContext createMockMoveContext(boolean withSourceFacet) {
+    AttachmentMoveEventContext context = mock(AttachmentMoveEventContext.class);
+    com.sap.cds.services.messages.Messages mockMessages =
+        mock(com.sap.cds.services.messages.Messages.class);
+    CdsRuntime mockCdsRuntime = mock(CdsRuntime.class);
+    com.sap.cds.services.runtime.RequestContextRunner mockContextRunner =
+        mock(com.sap.cds.services.runtime.RequestContextRunner.class);
+
+    // Basic context setup
+    when(context.getParentEntity()).thenReturn("test.Service.Entity");
+    when(context.getCompositionName()).thenReturn(FACET);
+    when(context.getUpId()).thenReturn(UP_ID);
+    when(context.getSystemUser()).thenReturn(true);
+    when(context.getObjectIds()).thenReturn(List.of(OBJECT_ID));
+    when(context.getSourceFolderId()).thenReturn("sourceFolderId123");
+    when(context.getMessages()).thenReturn(mockMessages);
+    when(context.getCdsRuntime()).thenReturn(mockCdsRuntime);
+    when(mockCdsRuntime.requestContext()).thenReturn(mockContextRunner);
+
+    // Configure RequestContextRunner
+    @SuppressWarnings("unchecked")
+    java.util.function.Function<com.sap.cds.services.request.RequestContext, Object> anyFunction =
+        any(java.util.function.Function.class);
+    when(mockContextRunner.run(anyFunction))
+        .thenAnswer(
+            invocation -> {
+              java.util.function.Function<com.sap.cds.services.request.RequestContext, Object>
+                  function = invocation.getArgument(0);
+              return function.apply(null);
+            });
+
+    // Source facet setup
+    if (withSourceFacet) {
+      when(context.getSourceParentEntity()).thenReturn("test.Service.SourceEntity");
+      when(context.getSourceCompositionName()).thenReturn(FACET);
+    } else {
+      when(context.getSourceParentEntity()).thenReturn(null);
+      when(context.getSourceCompositionName()).thenReturn(null);
+    }
+
+    // Mock CdsModel and entities
+    CdsModel model = mock(CdsModel.class);
+    CdsEntity parentEntity = mock(CdsEntity.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsElement compositionElement = mock(CdsElement.class);
+    CdsAssociationType compositionType = mock(CdsAssociationType.class);
+    CdsElement mockAssociationElement = mock(CdsElement.class);
+    CdsAssociationType mockAssociationType = mock(CdsAssociationType.class);
+    CqnElementRef mockCqnElementRef = mock(CqnElementRef.class);
+
+    when(context.getModel()).thenReturn(model);
+    when(model.findEntity("test.Service.Entity")).thenReturn(Optional.of(parentEntity));
+    when(model.findEntity(endsWith("_drafts"))).thenReturn(Optional.of(draftEntity));
+
+    if (withSourceFacet) {
+      CdsEntity sourceEntity = mock(CdsEntity.class);
+      when(model.findEntity("test.Service.SourceEntity")).thenReturn(Optional.of(sourceEntity));
+      when(sourceEntity.findElement(FACET)).thenReturn(Optional.of(compositionElement));
+    }
+
+    when(parentEntity.findElement(FACET)).thenReturn(Optional.of(compositionElement));
+    when(compositionElement.getType()).thenReturn(compositionType);
+    when(compositionType.isAssociation()).thenReturn(true);
+    when(compositionType.getTarget()).thenReturn(targetEntity);
+    when(targetEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    when(draftEntity.findAssociation("up_")).thenReturn(Optional.of(mockAssociationElement));
+    when(mockAssociationElement.getType()).thenReturn(mockAssociationType);
+    when(mockAssociationType.refs()).thenReturn(Stream.of(mockCqnElementRef));
+    when(mockCqnElementRef.path()).thenReturn("ID");
+
+    return context;
+  }
+
+  // ==================== Error Parsing and Validation Tests ====================
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_DuplicateError() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw duplicate error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(
+            new RuntimeException(
+                "nameConstraintViolation : Child doc.pdf with Id xyz already exists"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify context completed (error was parsed and handled)
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_VirusDetected() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw virus error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Virus scan status: cmis:virusScanStatus infected"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_MalwareDetected() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw malware error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Malware detected in file"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_Unauthorized() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw unauthorized error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("User not authorized to perform this operation"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_PermissionDenied() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw permission error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Permission denied for this resource"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_BlockedMimeType() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw blocked mimetype error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("MimeType application/exe is blocked"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_FileNotFound() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw not found error
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Object not found in repository"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_GenericWithDetailedMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw generic error with detailed message after colon
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("SDM Error : Detailed error information here"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_EmptyMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw exception with empty message
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException(""));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseSDMErrorMessage_NullMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw exception with null message
+    RuntimeException nullMessageException = new RuntimeException((String) null);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(nullMessageException);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ExtractErrorMessage_WithCauseChain() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw exception with cause chain (generic message -> detailed cause)
+    RuntimeException detailedCause = new RuntimeException("Detailed root cause error");
+    RuntimeException genericCause =
+        new RuntimeException("Failed to move attachment", detailedCause);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericCause);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseDuplicateError_WithFilename() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw duplicate error with specific filename format
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(
+            new RuntimeException(
+                "nameConstraintViolation : Child document.pdf with Id abc123 already exists in folder"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseDuplicateError_WithoutFilename() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw duplicate error without "Child ... with Id" format
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Duplicate file constraint violation"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ParseDuplicateError_NoColonSeparator() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock SDM to throw duplicate error without colon separator
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("duplicate"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_BuildValidationFailureMessage_ServiceException() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock successful move
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock database fetch to throw ServiceException
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new ServiceException("Database connection failed"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Should rollback and complete
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_BuildValidationFailureMessage_JSONException() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move to return invalid JSON
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn("invalid json");
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Should handle JSON parsing error and complete
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_BuildValidationFailureMessage_DatabaseError() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock successful move
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock database operation to throw exception with "database" in message
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("database query timeout"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_BuildValidationFailureMessage_GenericException() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock successful move
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock generic runtime exception
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Unexpected processing error"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_BuildValidationFailureMessage_ExceptionWithoutMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock successful move
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    // Mock exception with null message
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new RuntimeException((String) null));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_HandleValidationFailure_RollbackSuccess() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Configure validation to detect invalid properties
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("validProp1", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move with invalid property
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"value\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "invalidProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was attempted (move + rollback)
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_HandleValidationFailure_RollbackFails() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Configure validation to detect invalid properties
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("validProp1", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // First call (move) succeeds with invalid property, second call (rollback) fails
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"value\"}}")
+        .thenThrow(new RuntimeException("Rollback failed"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "invalidProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was attempted even though it failed
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testParseSDMErrorMessage_NullErrorMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Create exception with null message
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException((String) null));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testParseSDMErrorMessage_EmptyErrorMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Create exception with empty message
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException(""));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testExtractErrorMessage_GenericMessageWithDetailedCause() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Create exception chain: generic message -> detailed cause
+    RuntimeException detailedCause =
+        new RuntimeException("Detailed error: Database connection failed");
+    RuntimeException genericException =
+        new RuntimeException("Failed to move attachment", detailedCause);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericException);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testExtractErrorMessage_GenericMessageChainWithNoCause() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Create exception with generic message and generic causes
+    RuntimeException cause2 = new RuntimeException("Failed to move attachment");
+    RuntimeException cause1 = new RuntimeException("Failed to move attachment", cause2);
+    RuntimeException genericException = new RuntimeException("Failed to move attachment", cause1);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericException);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMatchSpecificErrorType_Malware() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("malware detected in file"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMatchSpecificErrorType_NotAuthorized() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("user not authorized to perform operation"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMatchSpecificErrorType_Permission() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("permission denied for this operation"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMatchSpecificErrorType_Blocked() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("file blocked by security policy"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMatchSpecificErrorType_ObjectNotFound() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("object not found in repository"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testParseDuplicateError_NoColonPattern() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("duplicate entry found"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testParseDuplicateError_WithChildPattern() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(
+            new RuntimeException("constraint : Child document.pdf with Id 12345 already exists"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testParseDuplicateError_WithColonButNoChildPattern() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("duplicate : some detailed error message"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testExtractDetailedMessage_WithColonAndEmptyDetail() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("error :   "));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testBuildValidationFailureMessage_ServiceException() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new ServiceException("database connection lost"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testBuildValidationFailureMessage_DatabaseError() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Failed to execute database query"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testBuildValidationFailureMessage_JSONException() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenThrow(new org.json.JSONException("Invalid JSON format"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testProcessSecondaryProperty_NullValue() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move with null property value
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"nullProp\": null}}");
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("nullProp", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("nullProp"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "nullProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testConvertValueIfNeeded_StringValue() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move with string property (no conversion needed)
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"description\": \"test description\"}}");
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("description", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("description"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "description"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testConvertValueIfNeeded_IntegerValue() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move with Integer property (no conversion needed for non-Long)
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"pageCount\": 10}}");
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("pageCount", "number");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("pageCount"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "pageCount"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testIsDateTimeField_NullElement() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"unknownProp\": 123}}");
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("unknownProp", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+
+    // Return null element for unknownProp
+    when(mockTargetEntity.getElement("unknownProp")).thenReturn(null);
+
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("unknownProp"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "unknownProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testRollbackSingleAttachment_Success() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("validProp1", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // First call succeeds with invalid property, second call (rollback) succeeds
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"value\"}}")
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + OBJECT_ID + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "invalidProp"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify move and rollback both called
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_SingleInvalidProperty() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    Map<String, String> validProps = new HashMap<>();
+    validProps.put("validProp1", "string");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {validProps, mockTargetEntity});
+
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move with single invalid property
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp1\": \"value1\"}}")
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + OBJECT_ID + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc", "invalidProp1"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was called (move + rollback = 2 calls)
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_MultipleInvalidProperties() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Entity annotations define 3 invalid properties
+    Map<String, String> entityAnnotations = new HashMap<>();
+    entityAnnotations.put("dbField1", "invalidProp1");
+    entityAnnotations.put("dbField2", "invalidProp2");
+    entityAnnotations.put("dbField3", "invalidProp3");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {entityAnnotations, mockTargetEntity});
+
+    // Valid secondary properties list does NOT include any invalid props
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move: SDM response contains all 3 invalid properties
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp1\": \"value1\", \"invalidProp2\": \"value2\", \"invalidProp3\":"
+                + " \"value3\"}}")
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + OBJECT_ID + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was called (move + rollback = 2 calls)
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_RollbackIOException() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Entity annotation defines invalidProp
+    Map<String, String> entityAnnotations = new HashMap<>();
+    entityAnnotations.put("dbField1", "invalidProp");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {entityAnnotations, mockTargetEntity});
+
+    // Valid list does NOT include invalidProp
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // First call succeeds with invalid property, second call (rollback) throws IOException
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"value\"}}")
+        .thenThrow(new IOException("Network error during rollback"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was attempted despite IOException
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_RollbackServiceException() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Entity annotation defines invalidProp
+    Map<String, String> entityAnnotations = new HashMap<>();
+    entityAnnotations.put("dbField1", "invalidProp");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {entityAnnotations, mockTargetEntity});
+
+    // Valid list does NOT include invalidProp
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // First call succeeds with invalid property, second call (rollback) throws RuntimeException
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"invalidProp\": \"value\"}}")
+        .thenThrow(new RuntimeException("403 Forbidden - Access denied"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback attempt and failure recording
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_FailureAddedToList() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Entity annotation defines customProp
+    Map<String, String> entityAnnotations = new HashMap<>();
+    entityAnnotations.put("dbCustomField", "customProp");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {entityAnnotations, mockTargetEntity});
+
+    // Valid list does NOT include customProp
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Mock move: SDM response contains customProp (in annotations but NOT in valid list)
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\", \"customProp\": \"value\"}}")
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + OBJECT_ID + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was called and context completed
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testHandleValidationFailure_PreservesObjectId() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    // Entity annotation defines invalidProp
+    Map<String, String> entityAnnotations = new HashMap<>();
+    entityAnnotations.put("dbField1", "invalidProp");
+    CdsEntity mockTargetEntity = mock(CdsEntity.class);
+    when(dbQuery.getValidSecondaryPropertiesWithEntity(any()))
+        .thenReturn(new Object[] {entityAnnotations, mockTargetEntity});
+
+    // Valid list does NOT include invalidProp
+    when(sdmService.getValidSecondaryProperties(
+            any(), any(SDMCredentials.class), any(), anyBoolean()))
+        .thenReturn(List.of("validProp1"));
+
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String specificObjectId = "specific-test-object-id-12345";
+
+    // Mock move: SDM response contains invalidProp (in annotations but NOT in valid list)
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + specificObjectId
+                + "\", \"invalidProp\": \"value\"}}")
+        .thenReturn("{\"succinctProperties\": {\"cmis:objectId\": \"" + specificObjectId + "\"}}");
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("doc.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    when(context.getObjectIds()).thenReturn(List.of(specificObjectId));
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify rollback was called
+    verify(sdmService, times(2)).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    verify(context, times(1)).setCompleted();
+  }
+
+  // ========== Tests for checkMaxCountConstraintForMove() ==========
+
+  @Test
+  void testCheckMaxCount_TargetEntityNotFound() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Target entity not found
+    when(model.findEntity("test.Service.Entity.mockFacet")).thenReturn(Optional.empty());
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Should skip maxCount validation and proceed with move
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testCheckMaxCount_MaxCountZero_NoLimitEnforced() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Setup target entity with maxCount = 0 (no limit)
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Mock SDMUtils to return maxCount = 0
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenReturn("0__No limit");
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Should skip maxCount validation and proceed with move
+      verify(sdmService, atLeastOnce())
+          .moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    }
+  }
+
+  @Test
+  void testCheckMaxCount_DraftEntityNotFound_SkipValidation() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Setup target entity
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Draft entity not found
+    when(model.findEntity("test.Service.Attachments_drafts")).thenReturn(Optional.empty());
+
+    // Mock SDMUtils to return maxCount = 5
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenReturn("5__Too many attachments");
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Should skip maxCount validation and proceed with move
+      verify(sdmService, atLeastOnce())
+          .moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    }
+  }
+
+  @Test
+  void testCheckMaxCount_ExceedsLimit_WithCustomErrorMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Setup target entity
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Setup draft entity
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+
+    // Mock SDMUtils
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenReturn("2__Custom error: Maximum 2 attachments allowed");
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getUpIdKey(any()))
+          .thenReturn("up__ID");
+
+      // Mock existing attachments count = 2 (already at limit)
+      com.sap.cds.Result mockResult = mock(com.sap.cds.Result.class);
+      when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), any(), any()))
+          .thenReturn(mockResult);
+      when(mockResult.rowCount()).thenReturn(2L); // Existing: 2, Moving: 1, Total: 3 > maxCount: 2
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Verify custom error message was used and attachments marked as failed
+      verify(context.getMessages(), times(1)).warn("Custom error: Maximum 2 attachments allowed");
+      verify(context, times(1)).setCompleted();
+      // No actual move should happen - failed before move
+      verify(sdmService, never()).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    }
+  }
+
+  @Test
+  void testCheckMaxCount_ExceedsLimit_WithDefaultErrorMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    when(context.getObjectIds()).thenReturn(List.of("obj1", "obj2")); // Moving 2 attachments
+    CdsModel model = context.getModel();
+
+    // Setup target entity
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Setup draft entity
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+
+    // Mock SDMUtils
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenReturn("3__null"); // null error message - should use default
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getUpIdKey(any()))
+          .thenReturn("up__ID");
+
+      // Mock existing attachments count = 2
+      com.sap.cds.Result mockResult = mock(com.sap.cds.Result.class);
+      when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), any(), any()))
+          .thenReturn(mockResult);
+      when(mockResult.rowCount()).thenReturn(2L); // Existing: 2, Moving: 2, Total: 4 > maxCount:
+      // 3
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Verify default error message format was used
+      verify(context.getMessages(), times(1))
+          .warn(
+              "Cannot move 2 attachment(s). Target entity allows maximum 3 attachments, and"
+                  + " already has 2. Maximum count would be exceeded.");
+      verify(context, times(1)).setCompleted();
+      // No actual move should happen - failed before move
+      verify(sdmService, never()).moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+    }
+  }
+
+  @Test
+  void testCheckMaxCount_WithinLimit_ProceedWithMove() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Setup target entity
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Setup draft entity
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Attachments_drafts")).thenReturn(Optional.of(draftEntity));
+
+    // Mock SDMUtils
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenReturn("5__Maximum 5 attachments allowed");
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getUpIdKey(any()))
+          .thenReturn("up__ID");
+
+      // Mock existing attachments count = 2
+      com.sap.cds.Result mockResult = mock(com.sap.cds.Result.class);
+      when(dbQuery.getAttachmentsForUPIDAndRepository(any(), any(), any(), any()))
+          .thenReturn(mockResult);
+      when(mockResult.rowCount()).thenReturn(2L); // Existing: 2, Moving: 1, Total: 3 < maxCount: 5
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Should proceed with move - within limit
+      verify(sdmService, atLeastOnce())
+          .moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+      verify(context, times(1)).setCompleted();
+    }
+  }
+
+  @Test
+  void testCheckMaxCount_ExceptionDuringValidation_ProceedWithMove() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test doc"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    CdsModel model = context.getModel();
+
+    // Setup target entity
+    CdsEntity targetAttachmentEntity = mock(CdsEntity.class);
+    when(model.findEntity("test.Service.Entity.mockFacet"))
+        .thenReturn(Optional.of(targetAttachmentEntity));
+    when(targetAttachmentEntity.getQualifiedName()).thenReturn("test.Service.Attachments");
+
+    // Mock SDMUtils to throw exception
+    try (var mockedStatic = mockStatic(com.sap.cds.sdm.utilities.SDMUtils.class)) {
+      mockedStatic
+          .when(() -> com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage(any(), any()))
+          .thenThrow(new RuntimeException("Error parsing maxCount annotation"));
+
+      sdmCustomServiceHandler.moveAttachments(context);
+
+      // Should catch exception and proceed with move
+      verify(sdmService, atLeastOnce())
+          .moveAttachment(any(CmisDocument.class), any(), anyBoolean());
+      verify(context, times(1)).setCompleted();
+    }
+  }
+
+  // ========== Tests for source entity cleanup after move (lines 429-452) ==========
+
+  @Test
+  void testSourceCleanup_SuccessfulCleanup_DeletesAndLogsCount() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    when(dbQuery.deleteAttachmentsByObjectIds(any(), any(), any(), any())).thenReturn(1L);
+
+    AttachmentMoveEventContext context = createMockMoveContext(true);
+    // Override parent entity to match draft service name for draft creation to succeed
+    String customParentEntity = "test." + FACET + ".Entity";
+    when(context.getParentEntity()).thenReturn(customParentEntity);
+    // Mock the model to return entity for the custom parent entity name
+    CdsModel model = context.getModel();
+    CdsEntity customParentCdsEntity = mock(CdsEntity.class);
+    CdsElement customCompositionElement = mock(CdsElement.class);
+    CdsAssociationType customCompositionType = mock(CdsAssociationType.class);
+    CdsEntity customTargetEntity = mock(CdsEntity.class);
+    when(model.findEntity(customParentEntity)).thenReturn(Optional.of(customParentCdsEntity));
+    when(customParentCdsEntity.findElement(FACET))
+        .thenReturn(Optional.of(customCompositionElement));
+    when(customCompositionElement.getType()).thenReturn(customCompositionType);
+    when(customCompositionType.isAssociation()).thenReturn(true);
+    when(customCompositionType.getTarget()).thenReturn(customTargetEntity);
+    when(customTargetEntity.getQualifiedName()).thenReturn("test." + FACET + ".Attachments");
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(dbQuery, times(1))
+        .deleteAttachmentsByObjectIds(
+            eq(persistenceService), eq(List.of(OBJECT_ID)), eq("sourceUpId"), any());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testSourceCleanup_NoSourceUpId_SkipsCleanup() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    when(dbQuery.getSourceUpIdForObjectIds(any(), any(), any())).thenReturn(null);
+
+    AttachmentMoveEventContext context = createMockMoveContext(true);
+    // Override parent entity to match draft service name for draft creation to succeed
+    String customParentEntity = "test." + FACET + ".Entity";
+    when(context.getParentEntity()).thenReturn(customParentEntity);
+    // Mock the model to return entity for the custom parent entity name
+    CdsModel model = context.getModel();
+    CdsEntity customParentCdsEntity = mock(CdsEntity.class);
+    CdsElement customCompositionElement = mock(CdsElement.class);
+    CdsAssociationType customCompositionType = mock(CdsAssociationType.class);
+    CdsEntity customTargetEntity = mock(CdsEntity.class);
+    when(model.findEntity(customParentEntity)).thenReturn(Optional.of(customParentCdsEntity));
+    when(customParentCdsEntity.findElement(FACET))
+        .thenReturn(Optional.of(customCompositionElement));
+    when(customCompositionElement.getType()).thenReturn(customCompositionType);
+    when(customCompositionType.isAssociation()).thenReturn(true);
+    when(customCompositionType.getTarget()).thenReturn(customTargetEntity);
+    when(customTargetEntity.getQualifiedName()).thenReturn("test." + FACET + ".Attachments");
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(dbQuery, never()).deleteAttachmentsByObjectIds(any(), any(), any(), any());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testSourceCleanup_CleanupFails_OperationStillSucceeds() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(
+            "{\"succinctProperties\": {\"cmis:name\": \"doc.pdf\", \"cmis:objectId\": \""
+                + OBJECT_ID
+                + "\"}}");
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    when(dbQuery.deleteAttachmentsByObjectIds(any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("Database error"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(true);
+    // Override parent entity to match draft service name for draft creation to succeed
+    String customParentEntity = "test." + FACET + ".Entity";
+    when(context.getParentEntity()).thenReturn(customParentEntity);
+    // Mock the model to return entity for the custom parent entity name
+    CdsModel model = context.getModel();
+    CdsEntity customParentCdsEntity = mock(CdsEntity.class);
+    CdsElement customCompositionElement = mock(CdsElement.class);
+    CdsAssociationType customCompositionType = mock(CdsAssociationType.class);
+    CdsEntity customTargetEntity = mock(CdsEntity.class);
+    when(model.findEntity(customParentEntity)).thenReturn(Optional.of(customParentCdsEntity));
+    when(customParentCdsEntity.findElement(FACET))
+        .thenReturn(Optional.of(customCompositionElement));
+    when(customCompositionElement.getType()).thenReturn(customCompositionType);
+    when(customCompositionType.isAssociation()).thenReturn(true);
+    when(customCompositionType.getTarget()).thenReturn(customTargetEntity);
+    when(customTargetEntity.getQualifiedName()).thenReturn("test." + FACET + ".Attachments");
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(dbQuery, times(1)).deleteAttachmentsByObjectIds(any(), any(), eq("sourceUpId"), any());
+    verify(context, times(1)).setCompleted();
+  }
+
+  @Test
+  void testExtractErrorMessage_NonGenericMessage_ReturnsDirectly() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Exception with non-generic message - should return it directly
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Specific error: File is locked"));
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // Verify that non-generic message was used (operation completed without throwing)
+  }
+
+  @Test
+  void testExtractErrorMessage_GenericMessage_ChecksCauseChain() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Exception with generic "Failed to move attachment" message but detailed cause
+    RuntimeException detailedCause = new RuntimeException("Detailed error: Insufficient storage");
+    RuntimeException genericWrapper =
+        new RuntimeException("Failed to move attachment", detailedCause);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericWrapper);
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // Verify that detailed cause message was extracted from chain
+  }
+
+  @Test
+  void testExtractErrorMessage_NestedGenericMessages_FindsDetailedOne() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Deep exception chain: generic -> generic -> detailed
+    RuntimeException detailedCause = new RuntimeException("Connection timeout to SDM server");
+    RuntimeException genericMiddle =
+        new RuntimeException("Failed to move attachment", detailedCause);
+    RuntimeException genericOuter = new RuntimeException("", genericMiddle);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericOuter);
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // Verify that the most detailed message was found in nested chain
+  }
+
+  @Test
+  void testExtractErrorMessage_AllGenericMessages_ReturnsOriginal() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // All messages in chain are generic - should return original
+    RuntimeException genericCause = new RuntimeException("Failed to move attachment");
+    RuntimeException genericWrapper = new RuntimeException("", genericCause);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(genericWrapper);
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // When all messages are generic, returns the original message
+  }
+
+  @Test
+  void testExtractErrorMessage_NullMessage_ChecksCause() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Exception with null message but cause has detailed message
+    RuntimeException detailedCause = new RuntimeException("Database constraint violation");
+    RuntimeException nullMessageWrapper = new RuntimeException((String) null, detailedCause);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(nullMessageWrapper);
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // Null message is generic, should check cause chain
+  }
+
+  @Test
+  void testExtractErrorMessage_EmptyMessage_ChecksCause() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Exception with empty message but cause has detailed message
+    RuntimeException detailedCause = new RuntimeException("Network error: Connection refused");
+    RuntimeException emptyMessageWrapper = new RuntimeException("", detailedCause);
+
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(emptyMessageWrapper);
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // Empty message is generic, should check cause chain
+  }
+
+  @Test
+  void testExtractErrorMessage_NoCause_ReturnsGenericMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Generic message with no cause - should return the generic message
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new RuntimeException("Failed to move attachment"));
+
+    CmisDocument sourceDoc = new CmisDocument();
+    sourceDoc.setType("sap-icon://document");
+    sourceDoc.setFileName("document.pdf");
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(sourceDoc);
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context, times(1)).setCompleted();
+    // No cause to check, returns the generic message itself
+  }
+
+  // ==================== Tests for matchSpecificErrorType method ====================
+
+  @Test
+  void testMatchSpecificErrorType_DuplicateError_ReturnsParsedDuplicateMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "duplicate"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("duplicate file detected"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertTrue(
+        failedAttachments.get(0).get("failureReason").contains("Duplicate file already exists"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_NameConstraintViolation_ReturnsParsedDuplicateMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "nameconstraintviolation"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("nameconstraintviolation occurred"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertTrue(
+        failedAttachments.get(0).get("failureReason").contains("Duplicate file already exists"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_VirusError_ReturnsMalwareMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "virus"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("virus detected in file"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        "File contains potential malware and cannot be moved",
+        failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_MalwareError_ReturnsMalwareMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "malware"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("malware found"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        "File contains potential malware and cannot be moved",
+        failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_UnauthorizedError_ReturnsAuthorizationMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "unauthorized"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("unauthorized access"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        SDMConstants.USER_NOT_AUTHORISED_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_NotAuthorizedError_ReturnsAuthorizationMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "not authorized"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("user not authorized"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        SDMConstants.USER_NOT_AUTHORISED_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_PermissionError_ReturnsAuthorizationMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "permission"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("permission denied"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        SDMConstants.USER_NOT_AUTHORISED_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_BlockedError_ReturnsMimeTypeMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "blocked"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("file blocked"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        SDMConstants.MIMETYPE_INVALID_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_MimeTypeError_ReturnsMimeTypeMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "mimetype"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("mimetype not allowed"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        SDMConstants.MIMETYPE_INVALID_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_NotFoundError_ReturnsFileNotFoundMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "not found"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("file not found"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(SDMConstants.FILE_NOT_FOUND_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_ObjectNotFoundError_ReturnsFileNotFoundMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message contains "object not found"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("object not found in repository"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(SDMConstants.FILE_NOT_FOUND_ERROR, failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testMatchSpecificErrorType_UnmatchedError_ReturnsNull() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message that doesn't match any specific type - should return original message
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("network timeout error"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    // When matchSpecificErrorType returns null, extractDetailedMessage is used
+    assertEquals("network timeout error", failedAttachments.get(0).get("failureReason"));
+  }
+
+  // ==================== Tests for parseDuplicateError method ====================
+
+  @Test
+  void testParseDuplicateError_NoColon_ReturnsDefaultMessage() throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message without " : " separator
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("duplicate file error"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        "Duplicate file already exists in the target location",
+        failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testParseDuplicateError_ChildFormatWithFilename_ReturnsFormattedMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message with standard "Child <filename> with Id" format
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(
+            new ServiceException(
+                "nameConstraintViolation : Child document.pdf with Id abc123 already exists"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    // getDuplicateFilesError formats the message
+    assertTrue(failedAttachments.get(0).get("failureReason").contains("document.pdf"));
+  }
+
+  @Test
+  void testParseDuplicateError_DetailedMessageWithoutChildFormat_ReturnsDetailedMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message with " : " but not in "Child" format
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(
+            new ServiceException("duplicate : A file with the same name already exists in folder"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        "A file with the same name already exists in folder",
+        failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testParseDuplicateError_ChildFormatWithoutWithId_ReturnsDetailedMessage()
+      throws IOException {
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Error message starts with "Child" but doesn't have " with Id"
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenThrow(new ServiceException("duplicate : Child element already exists in target"));
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("document.pdf", "Test document"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setFailedAttachments(captor.capture());
+    List<Map<String, String>> failedAttachments = captor.getValue();
+    assertEquals(1, failedAttachments.size());
+    assertEquals(
+        "Child element already exists in target", failedAttachments.get(0).get("failureReason"));
+  }
+
+  @Test
+  void testFetchAndSetLinkUrl_SuccessfullyFetchesAndSetsUrl() throws Exception {
+    // Test successful link URL fetch and set
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String testLinkUrl = "https://example.com/document";
+    when(sdmService.getLinkUrl(any(), any(), anyBoolean())).thenReturn(testLinkUrl);
+
+    // Mock moveAttachment to return a link attachment response
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.url\", \"cmis:contentStreamMimeType\":"
+            + " \"application/internet-shortcut\", \"cmis:description\": \"Test link\","
+            + " \"cmis:objectId\": \"newObjectId123\", \"cmis:objectTypeId\": \"sap:link\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("test.url", "Test link"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify getLinkUrl was called with correct parameters
+    verify(sdmService).getLinkUrl(eq("newObjectId123"), any(), anyBoolean());
+  }
+
+  @Test
+  void testFetchAndSetLinkUrl_NullUrlReturned_ContinuesWithoutError() throws Exception {
+    // Test when getLinkUrl returns null - should continue without setting URL
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // getLinkUrl returns null
+    when(sdmService.getLinkUrl(any(), any(), anyBoolean())).thenReturn(null);
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.url\", \"cmis:contentStreamMimeType\":"
+            + " \"application/internet-shortcut\", \"cmis:description\": \"Test link\","
+            + " \"cmis:objectId\": \"newObjectId123\", \"cmis:objectTypeId\": \"sap:link\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("test.url", "Test link"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify getLinkUrl was called
+    verify(sdmService).getLinkUrl(eq("newObjectId123"), any(), anyBoolean());
+    // Should not throw exception - continues normally
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testFetchAndSetLinkUrl_ExceptionThrown_ContinuesWithWarning() throws Exception {
+    // Test when getLinkUrl throws exception - should log warning and continue
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // getLinkUrl throws IOException
+    when(sdmService.getLinkUrl(any(), any(), anyBoolean()))
+        .thenThrow(new IOException("Failed to fetch link URL"));
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.url\", \"cmis:contentStreamMimeType\":"
+            + " \"application/internet-shortcut\", \"cmis:description\": \"Test link\","
+            + " \"cmis:objectId\": \"newObjectId123\", \"cmis:objectTypeId\": \"sap:link\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("test.url", "Test link"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify getLinkUrl was called
+    verify(sdmService).getLinkUrl(eq("newObjectId123"), any(), anyBoolean());
+    // Should not throw exception - continues with null URL
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testFetchAndSetLinkUrl_ServiceExceptionThrown_ContinuesWithWarning() throws Exception {
+    // Test when getLinkUrl throws ServiceException - should log warning and continue
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // getLinkUrl throws ServiceException
+    when(sdmService.getLinkUrl(any(), any(), anyBoolean()))
+        .thenThrow(new ServiceException("SDM service unavailable"));
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.url\", \"cmis:contentStreamMimeType\":"
+            + " \"application/internet-shortcut\", \"cmis:description\": \"Test link\","
+            + " \"cmis:objectId\": \"newObjectId123\", \"cmis:objectTypeId\": \"sap:link\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean()))
+        .thenReturn(List.of("test.url", "Test link"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify getLinkUrl was called
+    verify(sdmService).getLinkUrl(eq("newObjectId123"), any(), anyBoolean());
+    // Should not throw exception - continues with null URL and logs warning
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithValidValue_AddsToFilteredMap() throws Exception {
+    // Test that valid non-null values are added to the filtered properties map
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // Create SDM response with a custom secondary property
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:description\": \"Test\", \"cmis:objectId\":"
+            + " \"newObjId\", \"cmis:objectTypeId\": \"cmis:document\", \"sap:customProp\":"
+            + " \"customValue\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify move completed successfully
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithNullValue_SkipsProperty() throws Exception {
+    // Test that null values are skipped and not added to filtered properties
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // SDM response with null property value
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:description\": null, \"cmis:objectId\":"
+            + " \"newObjId\", \"cmis:objectTypeId\": \"cmis:document\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    // Verify move completed successfully even with null property
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithJSONNull_SkipsProperty() throws Exception {
+    // Test that JSONObject.NULL values are skipped
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testConvertValueIfNeeded_LongToInstantForDateTime_ConvertsSuccessfully() throws Exception {
+    // Test Long to Instant conversion for DateTime fields
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    // SDM response with Long timestamp (milliseconds since epoch)
+    long timestamp = 1609459200000L; // 2021-01-01 00:00:00 UTC
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\", \"sap:dateTimeProp\": "
+            + timestamp
+            + "}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testConvertValueIfNeeded_LongForNonDateTime_KeepsAsLong() throws Exception {
+    // Test that Long values for non-DateTime fields are kept as-is
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\", \"sap:numberProp\": 12345}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testConvertValueIfNeeded_NonLongValue_ReturnsOriginal() throws Exception {
+    // Test that non-Long values (String, Integer, etc.) are returned unchanged
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\", \"sap:stringProp\": \"testValue\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testIsDateTimeField_WithDateTimeElement_ReturnsTrue() throws Exception {
+    // Test that DateTime fields are correctly identified
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    long timestamp = 1609459200000L;
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\", \"sap:createdAt\": "
+            + timestamp
+            + "}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  @Test
+  void testIsDateTimeField_WithNonDateTimeElement_ReturnsFalse() throws Exception {
+    // Test that non-DateTime fields return false
+    setupMoveAttachmentsMocks();
+    when(sdmService.getFolderIdByPath(any(), any(), any(), anyBoolean())).thenReturn(FOLDER_ID);
+
+    String sdmResponse =
+        "{\"succinctProperties\": {\"cmis:name\": \"test.pdf\", \"cmis:contentStreamMimeType\":"
+            + " \"application/pdf\", \"cmis:objectId\": \"newObjId\", \"cmis:objectTypeId\":"
+            + " \"cmis:document\", \"sap:status\": \"active\"}}";
+    when(sdmService.moveAttachment(any(CmisDocument.class), any(), anyBoolean()))
+        .thenReturn(sdmResponse);
+
+    when(sdmService.getObject(any(), any(), anyBoolean())).thenReturn(List.of("test.pdf", "Test"));
+
+    AttachmentMoveEventContext context = createMockMoveContext(false);
+    sdmCustomServiceHandler.moveAttachments(context);
+
+    verify(context).setCompleted();
+  }
+
+  // ============ Direct Unit Tests for Private Methods Using Reflection ============
+
+  @Test
+  void testIsDateTimeField_WithDateTimeType_ReturnsTrue() throws Exception {
+    // Test isDateTimeField returns true for cds.DateTime type
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.DateTime");
+
+    boolean result = invokeIsDateTimeField(element);
+    assertTrue(result);
+  }
+
+  @Test
+  void testIsDateTimeField_WithNonDateTimeType_ReturnsFalse() throws Exception {
+    // Test isDateTimeField returns false for non-DateTime types
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.String");
+
+    boolean result = invokeIsDateTimeField(element);
+    assertFalse(result);
+  }
+
+  @Test
+  void testIsDateTimeField_WithNullElement_ReturnsFalse() throws Exception {
+    // Test isDateTimeField returns false for null element
+    boolean result = invokeIsDateTimeField(null);
+    assertFalse(result);
+  }
+
+  @Test
+  void testIsDateTimeField_WithNullType_ReturnsFalse() throws Exception {
+    // Test isDateTimeField returns false when element.getType() is null
+    CdsElement element = mock(CdsElement.class);
+    when(element.getType()).thenReturn(null);
+
+    boolean result = invokeIsDateTimeField(element);
+    assertFalse(result);
+  }
+
+  @Test
+  void testIsDateTimeField_WithNullQualifiedName_ReturnsFalse() throws Exception {
+    // Test isDateTimeField returns false when type.getQualifiedName() is null
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn(null);
+
+    boolean result = invokeIsDateTimeField(element);
+    assertFalse(result);
+  }
+
+  @Test
+  void testConvertValueIfNeeded_WithNonLongValue_ReturnsOriginal() throws Exception {
+    // Test convertValueIfNeeded returns original value for non-Long types
+    String originalValue = "test string";
+    CdsEntity targetEntity = mock(CdsEntity.class);
+
+    Object result = invokeConvertValueIfNeeded(originalValue, "fieldName", targetEntity);
+    assertEquals(originalValue, result);
+  }
+
+  @Test
+  void testConvertValueIfNeeded_WithLongAndDateTimeField_ConvertsToInstant() throws Exception {
+    // Test convertValueIfNeeded converts Long to Instant for DateTime fields
+    Long timestamp = 1609459200000L;
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+
+    when(targetEntity.getElement("createdAt")).thenReturn(element);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.DateTime");
+
+    Object result = invokeConvertValueIfNeeded(timestamp, "createdAt", targetEntity);
+    assertNotNull(result);
+    assertEquals(java.time.Instant.class, result.getClass());
+    assertEquals(java.time.Instant.ofEpochMilli(timestamp), result);
+  }
+
+  @Test
+  void testConvertValueIfNeeded_WithLongAndNonDateTimeField_ReturnsOriginal() throws Exception {
+    // Test convertValueIfNeeded returns original Long for non-DateTime fields
+    Long count = 12345L;
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+
+    when(targetEntity.getElement("count")).thenReturn(element);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.Integer64");
+
+    Object result = invokeConvertValueIfNeeded(count, "count", targetEntity);
+    assertEquals(count, result);
+  }
+
+  @Test
+  void testConvertValueIfNeeded_WithLongAndNullElement_ReturnsOriginal() throws Exception {
+    // Test convertValueIfNeeded returns original Long when element is null
+    Long value = 99999L;
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    when(targetEntity.getElement("unknownField")).thenReturn(null);
+
+    Object result = invokeConvertValueIfNeeded(value, "unknownField", targetEntity);
+    assertEquals(value, result);
+  }
+
+  @Test
+  void testConvertValueIfNeeded_WithLongAndNullType_ReturnsOriginal() throws Exception {
+    // Test convertValueIfNeeded returns original Long when type is null
+    Long value = 88888L;
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+    when(targetEntity.getElement("fieldWithoutType")).thenReturn(element);
+    when(element.getType()).thenReturn(null);
+
+    Object result = invokeConvertValueIfNeeded(value, "fieldWithoutType", targetEntity);
+    assertEquals(value, result);
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithValidValue_AddsToMap() throws Exception {
+    // Test processSecondaryProperty adds valid value to filtered properties
+    String dbPropertyName = "customField";
+    String sdmPropertyName = "sap:customProp";
+    String value = "testValue";
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    Map<String, Object> filteredProperties = new HashMap<>();
+
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+    when(targetEntity.getElement(dbPropertyName)).thenReturn(element);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.String");
+
+    invokeProcessSecondaryProperty(
+        dbPropertyName, sdmPropertyName, value, targetEntity, filteredProperties);
+
+    assertEquals(1, filteredProperties.size());
+    assertEquals(value, filteredProperties.get(dbPropertyName));
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithNullValue_DoesNotAddToMap() throws Exception {
+    // Test processSecondaryProperty does not add null values
+    String dbPropertyName = "customField";
+    String sdmPropertyName = "sap:customProp";
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    Map<String, Object> filteredProperties = new HashMap<>();
+
+    invokeProcessSecondaryProperty(
+        dbPropertyName, sdmPropertyName, null, targetEntity, filteredProperties);
+
+    assertEquals(0, filteredProperties.size());
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithJSONObjectNull_DoesNotAddToMap() throws Exception {
+    // Test processSecondaryProperty does not add JSONObject.NULL values
+    String dbPropertyName = "customField";
+    String sdmPropertyName = "sap:customProp";
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    Map<String, Object> filteredProperties = new HashMap<>();
+
+    invokeProcessSecondaryProperty(
+        dbPropertyName,
+        sdmPropertyName,
+        org.json.JSONObject.NULL,
+        targetEntity,
+        filteredProperties);
+
+    assertEquals(0, filteredProperties.size());
+  }
+
+  @Test
+  void testProcessSecondaryProperty_WithLongDateTimeValue_ConvertsAndAdds() throws Exception {
+    // Test processSecondaryProperty converts Long to Instant for DateTime fields
+    String dbPropertyName = "createdAt";
+    String sdmPropertyName = "sap:createdAt";
+    Long timestamp = 1609459200000L;
+    CdsEntity targetEntity = mock(CdsEntity.class);
+    Map<String, Object> filteredProperties = new HashMap<>();
+
+    CdsElement element = mock(CdsElement.class);
+    CdsStructuredType type = mock(CdsStructuredType.class);
+    when(targetEntity.getElement(dbPropertyName)).thenReturn(element);
+    when(element.getType()).thenReturn(type);
+    when(type.getQualifiedName()).thenReturn("cds.DateTime");
+
+    invokeProcessSecondaryProperty(
+        dbPropertyName, sdmPropertyName, timestamp, targetEntity, filteredProperties);
+
+    assertEquals(1, filteredProperties.size());
+    Object convertedValue = filteredProperties.get(dbPropertyName);
+    assertNotNull(convertedValue);
+    assertEquals(java.time.Instant.class, convertedValue.getClass());
+    assertEquals(java.time.Instant.ofEpochMilli(timestamp), convertedValue);
+  }
+
+  // ============ Helper Methods for Reflection ============
+
+  private boolean invokeIsDateTimeField(CdsElement element) throws Exception {
+    java.lang.reflect.Method method =
+        SDMCustomServiceHandler.class.getDeclaredMethod("isDateTimeField", CdsElement.class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(sdmCustomServiceHandler, element);
+  }
+
+  private Object invokeConvertValueIfNeeded(
+      Object value, String dbPropertyName, CdsEntity targetEntity) throws Exception {
+    java.lang.reflect.Method method =
+        SDMCustomServiceHandler.class.getDeclaredMethod(
+            "convertValueIfNeeded", Object.class, String.class, CdsEntity.class);
+    method.setAccessible(true);
+    return method.invoke(sdmCustomServiceHandler, value, dbPropertyName, targetEntity);
+  }
+
+  private void invokeProcessSecondaryProperty(
+      String dbPropertyName,
+      String sdmPropertyName,
+      Object value,
+      CdsEntity targetEntity,
+      Map<String, Object> filteredProperties)
+      throws Exception {
+    java.lang.reflect.Method method =
+        SDMCustomServiceHandler.class.getDeclaredMethod(
+            "processSecondaryProperty",
+            String.class,
+            String.class,
+            Object.class,
+            CdsEntity.class,
+            Map.class);
+    method.setAccessible(true);
+    method.invoke(
+        sdmCustomServiceHandler,
+        dbPropertyName,
+        sdmPropertyName,
+        value,
+        targetEntity,
+        filteredProperties);
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
@@ -82,7 +82,8 @@ public class SDMCustomServiceHandlerTest {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://internet-browser");
     cmisDocument.setUrl("https://example.com");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     // Mock context
     AttachmentCopyEventContext context = createMockContext();
@@ -114,7 +115,8 @@ public class SDMCustomServiceHandlerTest {
         .thenReturn(List.of("fileName", "mimeType", OBJECT_ID));
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://document");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     // Mock context
     AttachmentCopyEventContext context = createMockContext();
@@ -152,7 +154,8 @@ public class SDMCustomServiceHandlerTest {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://internet-browser");
     cmisDocument.setUrl("https://example.com");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     // Mock context
     AttachmentCopyEventContext context = createMockContext();
@@ -188,7 +191,8 @@ public class SDMCustomServiceHandlerTest {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://internet-browser");
     cmisDocument.setUrl("https://example.com");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     // Mock context
     AttachmentCopyEventContext context = createMockContext();
@@ -235,7 +239,8 @@ public class SDMCustomServiceHandlerTest {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://internet-browser");
     cmisDocument.setUrl("https://example.com");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     ServiceException ex =
         assertThrows(
@@ -271,7 +276,8 @@ public class SDMCustomServiceHandlerTest {
     CmisDocument cmisDocument = new CmisDocument();
     cmisDocument.setType("sap-icon://internet-browser");
     cmisDocument.setUrl("https://example.com");
-    when(dbQuery.getAttachmentForObjectID(any(), any(), any())).thenReturn(cmisDocument);
+    when(dbQuery.getAttachmentForObjectID(any(), any(), any(AttachmentCopyEventContext.class)))
+        .thenReturn(cmisDocument);
 
     ServiceException ex =
         assertThrows(

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -3181,4 +3181,313 @@ public class SDMServiceGenericHandlerTest {
           times(1));
     }
   }
+
+  // ============ Unit Tests for moveAttachments Method ============
+
+  @Test
+  void testMoveAttachments_WithAllParameters_Success() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("123");
+    when(mockContext.get("sourceFolderId")).thenReturn("source-folder-id");
+    when(mockContext.get("objectIds")).thenReturn("obj1, obj2, obj3");
+    when(mockContext.get("sourceFacet")).thenReturn("MyService.SourceEntity.attachments");
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.TargetEntity.attachments");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    expectedResult.put("movedCount", 3);
+    expectedResult.put("failedCount", 0);
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(expectedResult);
+
+    // Act
+    Map<String, Object> result = sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    ArgumentCaptor<MoveAttachmentInput> captor = ArgumentCaptor.forClass(MoveAttachmentInput.class);
+    verify(attachmentService, times(1)).moveAttachments(captor.capture(), eq(false));
+
+    MoveAttachmentInput input = captor.getValue();
+    assertEquals("source-folder-id", input.sourceFolderId());
+    assertEquals("123", input.targetUpId());
+    assertEquals("MyService.TargetEntity.attachments", input.targetFacet());
+    assertEquals(List.of("obj1", "obj2", "obj3"), input.objectIds());
+    assertEquals(Optional.of("MyService.SourceEntity.attachments"), input.sourceFacet());
+
+    assertEquals(expectedResult, result);
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_WithoutSourceFacet_Success() throws IOException {
+    // Arrange - sourceFacet is null
+    when(mockContext.get("up__ID")).thenReturn("456");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder-123");
+    when(mockContext.get("objectIds")).thenReturn("objA, objB");
+    when(mockContext.get("sourceFacet")).thenReturn(null); // No source facet
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.NewEntity.attachments");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(true);
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    expectedResult.put("movedCount", 2);
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(true)))
+        .thenReturn(expectedResult);
+
+    // Act
+    Map<String, Object> result = sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    ArgumentCaptor<MoveAttachmentInput> captor = ArgumentCaptor.forClass(MoveAttachmentInput.class);
+    verify(attachmentService, times(1)).moveAttachments(captor.capture(), eq(true));
+
+    MoveAttachmentInput input = captor.getValue();
+    assertEquals("folder-123", input.sourceFolderId());
+    assertEquals("456", input.targetUpId());
+    assertEquals("MyService.NewEntity.attachments", input.targetFacet());
+    assertEquals(List.of("objA", "objB"), input.objectIds());
+    assertEquals(Optional.empty(), input.sourceFacet()); // Should be empty when null
+
+    assertEquals(expectedResult, result);
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_WithSingleObjectId_Success() throws IOException {
+    // Arrange - single object ID
+    when(mockContext.get("up__ID")).thenReturn("999");
+    when(mockContext.get("sourceFolderId")).thenReturn("src-folder");
+    when(mockContext.get("objectIds")).thenReturn("single-obj-id");
+    when(mockContext.get("sourceFacet")).thenReturn("Source.Entity");
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target.Entity");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    expectedResult.put("movedCount", 1);
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(expectedResult);
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    ArgumentCaptor<MoveAttachmentInput> captor = ArgumentCaptor.forClass(MoveAttachmentInput.class);
+    verify(attachmentService, times(1)).moveAttachments(captor.capture(), eq(false));
+
+    MoveAttachmentInput input = captor.getValue();
+    assertEquals(List.of("single-obj-id"), input.objectIds());
+    assertEquals(1, input.objectIds().size());
+
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_WithWhitespaceInObjectIds_TrimsCorrectly() throws IOException {
+    // Arrange - object IDs with various whitespace
+    when(mockContext.get("up__ID")).thenReturn("100");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder-id");
+    when(mockContext.get("objectIds")).thenReturn("  obj1  ,  obj2  ,obj3,  obj4  ");
+    when(mockContext.get("sourceFacet")).thenReturn(null);
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Entity.attachments");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(expectedResult);
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    ArgumentCaptor<MoveAttachmentInput> captor = ArgumentCaptor.forClass(MoveAttachmentInput.class);
+    verify(attachmentService, times(1)).moveAttachments(captor.capture(), eq(false));
+
+    MoveAttachmentInput input = captor.getValue();
+    // Verify trimming worked correctly
+    assertEquals(List.of("obj1", "obj2", "obj3", "obj4"), input.objectIds());
+  }
+
+  @Test
+  void testMoveAttachments_WithSystemUser_PassesCorrectFlag() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("system-user-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1");
+    when(mockContext.get("sourceFacet")).thenReturn("Source");
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(true); // System user
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(true)))
+        .thenReturn(expectedResult);
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    verify(attachmentService, times(1)).moveAttachments(any(MoveAttachmentInput.class), eq(true));
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_WithNonSystemUser_PassesCorrectFlag() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("regular-user-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1");
+    when(mockContext.get("sourceFacet")).thenReturn(null);
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false); // Non-system user
+
+    Map<String, Object> expectedResult = new HashMap<>();
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(expectedResult);
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    verify(attachmentService, times(1)).moveAttachments(any(MoveAttachmentInput.class), eq(false));
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_ReturnsResultFromService() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("result-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1, obj2");
+    when(mockContext.get("sourceFacet")).thenReturn("Source");
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    Map<String, Object> serviceResult = new HashMap<>();
+    serviceResult.put("movedCount", 2);
+    serviceResult.put("failedCount", 0);
+    serviceResult.put("failedAttachments", Collections.emptyList());
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(serviceResult);
+
+    // Act
+    Map<String, Object> result = sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(2, result.get("movedCount"));
+    assertEquals(0, result.get("failedCount"));
+    assertEquals(Collections.emptyList(), result.get("failedAttachments"));
+  }
+
+  @Test
+  void testMoveAttachments_ThrowsIOException_Propagates() {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("error-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1");
+    when(mockContext.get("sourceFacet")).thenReturn(null);
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    // Mock attachmentService to throw IOException wrapped in RuntimeException
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenAnswer(
+            invocation -> {
+              throw new IOException("Move operation failed");
+            });
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> sdmServiceGenericHandler.moveAttachments(mockContext));
+
+    verify(mockContext, never()).setCompleted(); // Should not be called when exception occurs
+  }
+
+  @Test
+  void testMoveAttachments_ContextSetCompleted_CalledOnce() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("complete-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1");
+    when(mockContext.get("sourceFacet")).thenReturn(null);
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("Target");
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(new HashMap<>());
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    verify(mockContext, times(1)).setCompleted();
+  }
+
+  @Test
+  void testMoveAttachments_UsesTargetQualifiedName_AsTargetFacet() throws IOException {
+    // Arrange
+    when(mockContext.get("up__ID")).thenReturn("qname-test");
+    when(mockContext.get("sourceFolderId")).thenReturn("folder");
+    when(mockContext.get("objectIds")).thenReturn("obj1");
+    when(mockContext.get("sourceFacet")).thenReturn(null);
+    when(mockContext.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName())
+        .thenReturn("com.example.MyService.MyEntity.attachments"); // Full qualified name
+
+    UserInfo userInfo = mock(UserInfo.class);
+    when(mockContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    when(attachmentService.moveAttachments(any(MoveAttachmentInput.class), eq(false)))
+        .thenReturn(new HashMap<>());
+
+    // Act
+    sdmServiceGenericHandler.moveAttachments(mockContext);
+
+    // Assert
+    ArgumentCaptor<MoveAttachmentInput> captor = ArgumentCaptor.forClass(MoveAttachmentInput.class);
+    verify(attachmentService, times(1)).moveAttachments(captor.capture(), eq(false));
+
+    MoveAttachmentInput input = captor.getValue();
+    assertEquals(
+        "com.example.MyService.MyEntity.attachments",
+        input.targetFacet()); // Uses full qualified name
+  }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -4,6 +4,7 @@ import static com.sap.cds.sdm.utilities.SDMUtils.getAttachmentCountAndMessage;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1151,5 +1152,585 @@ public class SDMUtilsTest {
       // Assert the result
       assertEquals("0__null", result);
     }
+  }
+
+  @Test
+  void testGetPropertyTitles_WithValidEntity_ReturnsCorrectTitles() throws Exception {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement element1 = mock(CdsElement.class);
+    CdsElement element2 = mock(CdsElement.class);
+    CdsAnnotation<Object> titleAnnotation = mock(CdsAnnotation.class);
+    CdsAnnotation<Object> propertyNameAnnotation = mock(CdsAnnotation.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("customProp1", "value1");
+    attachment.put("customProp2", "value2");
+
+    when(entity.getElement("customProp1")).thenReturn(element1);
+    when(entity.getElement("customProp2")).thenReturn(element2);
+
+    when(element1.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.of(propertyNameAnnotation));
+    when(propertyNameAnnotation.getValue()).thenReturn("prop1");
+    when(element1.findAnnotation("title")).thenReturn(Optional.of(titleAnnotation));
+    when(titleAnnotation.getValue()).thenReturn("Property 1");
+
+    when(element2.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.empty());
+    when(element2.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.of(mock(CdsAnnotation.class)));
+    when(element2.getName()).thenReturn("customProp2");
+    when(element2.findAnnotation("title")).thenReturn(Optional.empty());
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.of(entity), attachment);
+
+    assertEquals("Property 1", result.get("prop1"));
+    assertEquals("customProp2", result.get("customProp2"));
+  }
+
+  @Test
+  void testGetPropertyTitles_WithEmptyEntity_ReturnsEmptyMap() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("customProp1", "value1");
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.empty(), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetPropertyTitles_SkipsDraftReadonlyContext() {
+    CdsEntity entity = mock(CdsEntity.class);
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put(SDMConstants.DRAFT_READONLY_CONTEXT, "value");
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.of(entity), attachment);
+
+    verify(entity, never()).getElement(SDMConstants.DRAFT_READONLY_CONTEXT);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetPropertyTitles_SkipsNullElements() {
+    CdsEntity entity = mock(CdsEntity.class);
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("customProp1", "value1");
+
+    when(entity.getElement("customProp1")).thenReturn(null);
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.of(entity), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetPropertyTitles_WithNoAnnotations_ReturnsEmpty() {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("customProp1", "value1");
+
+    when(entity.getElement("customProp1")).thenReturn(element);
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.empty());
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.empty());
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.of(entity), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetPropertyTitles_WithNewAnnotationAndNoTitle_UsesElementName() {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+    CdsAnnotation<Object> propertyNameAnnotation = mock(CdsAnnotation.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("customProp1", "value1");
+
+    when(entity.getElement("customProp1")).thenReturn(element);
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.of(propertyNameAnnotation));
+    when(propertyNameAnnotation.getValue()).thenReturn("prop1");
+    when(element.findAnnotation("title")).thenReturn(Optional.empty());
+    when(element.getName()).thenReturn("customProp1");
+
+    Map<String, String> result = SDMUtils.getPropertyTitles(Optional.of(entity), attachment);
+
+    assertEquals("customProp1", result.get("prop1"));
+  }
+
+  @Test
+  void
+      testGetSecondaryPropertiesWithInvalidDefinition_WithOldAnnotation_ReturnsInvalidProperties() {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement element1 = mock(CdsElement.class);
+    CdsElement element2 = mock(CdsElement.class);
+    CdsAnnotation<Object> sdmAnnotation1 = mock(CdsAnnotation.class);
+    CdsAnnotation<Object> sdmAnnotation2 = mock(CdsAnnotation.class);
+    CdsAnnotation<Object> titleAnnotation = mock(CdsAnnotation.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+    attachment.put("prop2", "value2");
+
+    when(entity.getElement("prop1")).thenReturn(element1);
+    when(entity.getElement("prop2")).thenReturn(element2);
+
+    when(element1.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.of(sdmAnnotation1));
+    when(element1.findAnnotation("title")).thenReturn(Optional.of(titleAnnotation));
+    when(titleAnnotation.getValue()).thenReturn("Property 1 Title");
+
+    when(element2.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.of(sdmAnnotation2));
+    when(element2.findAnnotation("title")).thenReturn(Optional.empty());
+    when(element2.getName()).thenReturn("prop2");
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.of(entity), attachment);
+
+    assertEquals(2, result.size());
+    assertEquals("Property 1 Title", result.get("prop1"));
+    assertEquals("prop2", result.get("prop2"));
+  }
+
+  @Test
+  void testGetSecondaryPropertiesWithInvalidDefinition_WithEmptyEntity_ReturnsEmpty() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.empty(), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetSecondaryPropertiesWithInvalidDefinition_WithNewAnnotation_NotIncluded() {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement element = mock(CdsElement.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+
+    when(entity.getElement("prop1")).thenReturn(element);
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.empty());
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.of(entity), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetSecondaryPropertiesWithInvalidDefinition_SkipsDraftReadonlyContext() {
+    CdsEntity entity = mock(CdsEntity.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put(SDMConstants.DRAFT_READONLY_CONTEXT, "value");
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.of(entity), attachment);
+
+    verify(entity, never()).getElement(SDMConstants.DRAFT_READONLY_CONTEXT);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetSecondaryPropertiesWithInvalidDefinition_WithNullElement_SkipsIt() {
+    CdsEntity entity = mock(CdsEntity.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+
+    when(entity.getElement("prop1")).thenReturn(null);
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.of(entity), attachment);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetSecondaryPropertiesWithInvalidDefinition_MultiplePropertiesMixed() {
+    CdsEntity entity = mock(CdsEntity.class);
+    CdsElement validElement = mock(CdsElement.class);
+    CdsElement invalidElement = mock(CdsElement.class);
+    CdsAnnotation<Object> sdmAnnotation = mock(CdsAnnotation.class);
+    CdsAnnotation<Object> titleAnnotation = mock(CdsAnnotation.class);
+
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("validProp", "value1");
+    attachment.put("invalidProp", "value2");
+
+    when(entity.getElement("validProp")).thenReturn(validElement);
+    when(entity.getElement("invalidProp")).thenReturn(invalidElement);
+
+    // validProp uses new annotation (not invalid)
+    when(validElement.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.empty());
+
+    // invalidProp uses old annotation (is invalid)
+    when(invalidElement.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.of(sdmAnnotation));
+    when(invalidElement.findAnnotation("title")).thenReturn(Optional.of(titleAnnotation));
+    when(titleAnnotation.getValue()).thenReturn("Invalid Property Title");
+
+    Map<String, String> result =
+        SDMUtils.getSecondaryPropertiesWithInvalidDefinition(Optional.of(entity), attachment);
+
+    assertEquals(1, result.size());
+    assertEquals("Invalid Property Title", result.get("invalidProp"));
+  }
+
+  @Test
+  void testExtractPropertyName_WithNewAnnotation_ReturnsAnnotationValue() throws Exception {
+    CdsElement element = mock(CdsElement.class);
+    CdsAnnotation<Object> propertyNameAnnotation = mock(CdsAnnotation.class);
+
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.of(propertyNameAnnotation));
+    when(propertyNameAnnotation.getValue()).thenReturn("customPropertyName");
+
+    java.lang.reflect.Method method =
+        SDMUtils.class.getDeclaredMethod("extractPropertyName", CdsElement.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(null, element);
+
+    assertEquals("customPropertyName", result);
+  }
+
+  @Test
+  void testExtractPropertyName_WithOldAnnotation_ReturnsElementName() throws Exception {
+    CdsElement element = mock(CdsElement.class);
+    CdsAnnotation<Object> oldAnnotation = mock(CdsAnnotation.class);
+
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.empty());
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.of(oldAnnotation));
+    when(element.getName()).thenReturn("elementName");
+
+    java.lang.reflect.Method method =
+        SDMUtils.class.getDeclaredMethod("extractPropertyName", CdsElement.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(null, element);
+
+    assertEquals("elementName", result);
+  }
+
+  @Test
+  void testExtractPropertyName_WithNoAnnotations_ReturnsNull() throws Exception {
+    CdsElement element = mock(CdsElement.class);
+
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY_NAME))
+        .thenReturn(Optional.empty());
+    when(element.findAnnotation(SDMConstants.SDM_ANNOTATION_ADDITIONALPROPERTY))
+        .thenReturn(Optional.empty());
+
+    java.lang.reflect.Method method =
+        SDMUtils.class.getDeclaredMethod("extractPropertyName", CdsElement.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(null, element);
+
+    assertEquals(null, result);
+  }
+
+  @Test
+  void testExtractTitle_WithTitleAnnotation_ReturnsAnnotationValue() throws Exception {
+    CdsElement element = mock(CdsElement.class);
+    CdsAnnotation<Object> titleAnnotation = mock(CdsAnnotation.class);
+
+    when(element.findAnnotation("title")).thenReturn(Optional.of(titleAnnotation));
+    when(titleAnnotation.getValue()).thenReturn("Custom Title");
+
+    java.lang.reflect.Method method =
+        SDMUtils.class.getDeclaredMethod("extractTitle", CdsElement.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(null, element);
+
+    assertEquals("Custom Title", result);
+  }
+
+  @Test
+  void testExtractTitle_WithoutTitleAnnotation_ReturnsElementName() throws Exception {
+    CdsElement element = mock(CdsElement.class);
+
+    when(element.findAnnotation("title")).thenReturn(Optional.empty());
+    when(element.getName()).thenReturn("elementName");
+
+    java.lang.reflect.Method method =
+        SDMUtils.class.getDeclaredMethod("extractTitle", CdsElement.class);
+    method.setAccessible(true);
+    String result = (String) method.invoke(null, element);
+
+    assertEquals("elementName", result);
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithModifiedValues_ReturnsUpdated() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "newValue1");
+    attachment.put("prop2", "newValue2");
+    attachment.put("prop3", "unchangedValue");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+    secondaryTypeProperties.put("prop3", "Property 3");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "oldValue1");
+    propertiesInDB.put("prop2", "oldValue2");
+    propertiesInDB.put("prop3", "unchangedValue");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(2, result.size());
+    assertEquals("newValue1", result.get("Property 1"));
+    assertEquals("newValue2", result.get("Property 2"));
+    assertFalse(result.containsKey("Property 3"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithNullValueInAttachment_ReturnsNullValue() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", null);
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "oldValue");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(1, result.size());
+    assertNull(result.get("Property 1"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithValueInDBNull_ReturnsUpdated() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "newValue");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", null);
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(1, result.size());
+    assertEquals("newValue", result.get("Property 1"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithNoChanges_ReturnsEmpty() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "sameValue1");
+    attachment.put("prop2", "sameValue2");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "sameValue1");
+    propertiesInDB.put("prop2", "sameValue2");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithEmptySecondaryTypeProperties_ReturnsEmpty() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    Map<String, String> propertiesInDB = new HashMap<>();
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithPropertyNotInDB_AddsToUpdated() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "newValue");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    // prop1 not in DB
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(1, result.size());
+    assertEquals("newValue", result.get("Property 1"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithMultipleChanges_ReturnsAllUpdated() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "updated1");
+    attachment.put("prop2", null);
+    attachment.put("prop3", "updated3");
+    attachment.put("prop4", "same4");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+    secondaryTypeProperties.put("prop3", "Property 3");
+    secondaryTypeProperties.put("prop4", "Property 4");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "old1");
+    propertiesInDB.put("prop2", "old2");
+    propertiesInDB.put("prop3", null);
+    propertiesInDB.put("prop4", "same4");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(3, result.size());
+    assertEquals("updated1", result.get("Property 1"));
+    assertNull(result.get("Property 2"));
+    assertEquals("updated3", result.get("Property 3"));
+    assertFalse(result.containsKey("Property 4"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithNumericValues_ConvertsToString() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", 123);
+    attachment.put("prop2", 456L);
+    attachment.put("prop3", 78.9);
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+    secondaryTypeProperties.put("prop3", "Property 3");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "100");
+    propertiesInDB.put("prop2", "400");
+    propertiesInDB.put("prop3", "70.0");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(3, result.size());
+    assertEquals("123", result.get("Property 1"));
+    assertEquals("456", result.get("Property 2"));
+    assertEquals("78.9", result.get("Property 3"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithBooleanValues_ConvertsToString() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", true);
+    attachment.put("prop2", false);
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+    propertiesInDB.put("prop1", "false");
+    propertiesInDB.put("prop2", "true");
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(2, result.size());
+    assertEquals("true", result.get("Property 1"));
+    assertEquals("false", result.get("Property 2"));
+  }
+
+  @Test
+  void testGetUpdatedSecondaryProperties_WithEmptyPropertiesInDB_AddsAll() {
+    Map<String, Object> attachment = new HashMap<>();
+    attachment.put("prop1", "value1");
+    attachment.put("prop2", "value2");
+
+    Map<String, String> secondaryTypeProperties = new HashMap<>();
+    secondaryTypeProperties.put("prop1", "Property 1");
+    secondaryTypeProperties.put("prop2", "Property 2");
+
+    Map<String, String> propertiesInDB = new HashMap<>();
+
+    Map<String, String> result =
+        SDMUtils.getUpdatedSecondaryProperties(
+            Optional.empty(),
+            attachment,
+            mockPersistenceService,
+            secondaryTypeProperties,
+            propertiesInDB);
+
+    assertEquals(2, result.size());
+    assertEquals("value1", result.get("Property 1"));
+    assertEquals("value2", result.get("Property 2"));
   }
 }


### PR DESCRIPTION
## Describe your changes

#### Any documentation

https://wiki.one.int.sap/wiki/spaces/sapecm/pages/5765502247/Move+attachments

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single tenant Integration Tests: https://github.com/cap-java/sdm/actions/runs/20091237636
Multi-tenant Integration Tests: https://github.com/cap-java/sdm/actions/runs/20093893925

**Scenario's tested in cloud:**
**Created attachments in Source Entity and moved them to Target Entity by specifying the sourceFacet.** => All the attachments moved to target both in SDM & UI and cleared from Source Entity.
**Created attachments in Source Entity, Created one of the attachments in target entity as well, and moved all the attachments from Source to Target by specifying the sourceFacet.** => Warning is thrown for duplicate one and that attachment didn't moved to target, other attachments moved successfully to target entity both in SDM & UI. In Logs moveAttachments returned failed objectId along with the reason of failure.
**Created attachments in Source Entity, Created links in source entity, updated valid secondary Properties for these attachments and also added notes in some of the attachments, and moved all the attachments from Source to Target by specifying the sourceFacet.** => All the attachments & links moved  to target both in SDM & UI, also the secondaryProperties & Notes field are populated in attachments.
**Created attachments in Source Entity and moved them to Target Entity without specifying the sourceFacet.** => All the attachments moved to target both in SDM & UI and were not cleaned up from Source Entity on UI.
**Created attachments in Source Entity, Create one of the attachments in target entity as well, and moved all the attachments from Source to Target without specifying the sourceFacet.** => Warning is thrown for duplicate one and that attachment didn't moved to target, other attachments moved successfully to target entity only in SDM. In Logs moveAttachments returned failed objectId along with the reason of failure.
**Created attachments in Source Entity, Created links in source entity, updated valid secondary Properties for these attachments and also added notes in some of the attachments, and moved all the attachments from Source to Target without specifying the sourceFacet.** => All the attachments & links moved  to target only in SDM, also the secondaryProperties & Notes field are populated in attachments.

**Created attachments in a folder in SDM and moved them to Target Entity, no source entity present so didn't specified it** => All the attachments moved to target both in SDM & UI.
**Created attachments in a folder in SDM, Created one of the attachments in target entity as well, and moved them to Target Entity, no source entity present so didn't specified it.** => Warning is thrown for duplicate one and that attachment didn't moved to target, other attachments moved successfully to target entity both in SDM & UI. In Logs moveAttachments returned failed objectId along with the reason of failure.
**Created attachments in a folder in SDM, Created links in the same folder in SDM, updated valid secondary Properties for these attachments, and moved them to Target Entity, no source entity present so didn't specified it.** => All the attachments & links moved  to target both in SDM & UI, also the secondaryProperties & Notes field are populated in attachments.
**Created attachments in a folder in SDM, Created links in the same folder in SDM, updated valid secondary Properties for few attachments, and invalid secondary properties for few attachments, also added few secondary properties to attachments that were not defined in target entity definition, and moved them to Target Entity, no source entity present so didn't specified it.** => All the attachments & links except the one that had invalid secondary properties assigned moved  to target both in SDM & UI, also the secondaryProperties that were defined in target entity definition are populated in attachments.
