### PR TITLE
Adding timeout for integration tests

### DIFF
--- a/sdm/src/test/java/integration/com/sap/cds/sdm/Api.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/Api.java
@@ -3,6 +3,7 @@ package integration.com.sap.cds.sdm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import okhttp3.*;
 import okio.ByteString;
 
@@ -15,7 +16,12 @@ public class Api implements ApiInterface {
 
   public Api(Map<String, String> config) {
     this.config = new HashMap<>(config);
-    this.httpClient = new OkHttpClient();
+    this.httpClient =
+        new OkHttpClient.Builder()
+            .connectTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .build();
     this.token = this.config.get("Authorization");
     this.serviceName = this.config.get("serviceName");
   }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/ApiMT.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/ApiMT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import okhttp3.*;
 import okio.ByteString;
 
@@ -15,7 +16,12 @@ public class ApiMT implements ApiInterface {
 
   public ApiMT(Map<String, String> config) {
     this.config = new HashMap<>(config);
-    this.httpClient = new OkHttpClient();
+    this.httpClient =
+        new OkHttpClient.Builder()
+            .connectTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .build();
     this.token = this.config.get("Authorization");
   }
 

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -102,7 +102,12 @@ class IntegrationTest_MultipleFacet {
     String basicAuth =
         "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-    OkHttpClient client = new OkHttpClient().newBuilder().build();
+    OkHttpClient client =
+        new OkHttpClient.Builder()
+            .connectTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .build();
     MediaType mediaType = MediaType.parse("text/plain");
     RequestBody body = RequestBody.create(mediaType, "");
     Request request;

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -106,7 +106,12 @@ class IntegrationTest_SingleFacet {
     String basicAuth =
         "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-    OkHttpClient client = new OkHttpClient().newBuilder().build();
+    OkHttpClient client =
+        new OkHttpClient.Builder()
+            .connectTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .build();
     MediaType mediaType = MediaType.parse("text/plain");
     RequestBody body = RequestBody.create(mediaType, "");
     Request request;


### PR DESCRIPTION
Integration tests were always failing due to timeout, so this PR adds 2 minute wait in the http client