### PR TITLE
Modify field widths and add uploadStatus field

### DIFF
--- a/cap-notebook/demoapp/app/common.cds
+++ b/cap-notebook/demoapp/app/common.cds
@@ -69,7 +69,14 @@ annotate my.Books.attachments with @UI: {
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
     {Value: createdAt, @HTML5.CssDefaults: {width: '20%'}},
     {Value: createdBy, @HTML5.CssDefaults: {width: '20%'}},
-    {Value: note, @HTML5.CssDefaults: {width: '25%'}},
+    {Value: note, @HTML5.CssDefaults: {width: '20%'}},
+{
+        Value             : uploadStatus,
+        Criticality: statusNav.criticality,
+        @Common.FieldControl: #ReadOnly,
+        @HTML5.CssDefaults: {width: '20%'},
+        @UI.Hidden: IsActiveEntity
+      },
     {
       $Type : 'UI.DataFieldForAction',
       Label : 'Copy Attachments',


### PR DESCRIPTION
Adjusted the width of the 'note' field and added 'uploadStatus' field with properties.

## Describe your changes

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description
