### PR TITLE
fix Heap Out of memory issue in large file upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.6.3-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.6.3-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -4,7 +4,6 @@ import static com.sap.cds.sdm.constants.SDMConstants.NAMED_USER_FLOW;
 import static com.sap.cds.sdm.constants.SDMConstants.TECHNICAL_USER_FLOW;
 
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
-import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.constants.SDMErrorMessages;
 import com.sap.cds.sdm.handler.TokenHandler;

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -4,7 +4,6 @@ import static com.sap.cds.sdm.constants.SDMConstants.NAMED_USER_FLOW;
 import static com.sap.cds.sdm.constants.SDMConstants.TECHNICAL_USER_FLOW;
 
 import com.sap.cds.feature.attachments.service.model.servicehandler.AttachmentCreateEventContext;
-import com.sap.cds.reflect.CdsEntity;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.constants.SDMErrorMessages;
@@ -67,9 +66,6 @@ public class DocumentUploadService {
       }
       long totalSize = cmisDocument.getContentLength();
       int chunkSize = SDMConstants.CHUNK_SIZE;
-      CdsModel model = eventContext.getModel();
-      Optional<CdsEntity> attachmentDraftEntity =
-          model.findEntity(eventContext.getAttachmentEntity() + "_drafts");
       cmisDocument.setUploadStatus(SDMConstants.UPLOAD_STATUS_IN_PROGRESS);
       if (totalSize <= 400 * 1024 * 1024) {
 
@@ -278,15 +274,27 @@ public class DocumentUploadService {
 
         // Step 7: Append Chunk. Call cmis api to append content stream
         if (bytesRead > 0) {
-          responseBody =
-              appendContentStream(
-                  cmisDocument,
-                  sdmUrl,
-                  chunkBuffer,
-                  bytesRead,
-                  isLastChunk,
-                  chunkIndex,
-                  isSystemUser);
+          // Only capture response from the last chunk to avoid unnecessary object allocation
+          if (isLastChunk) {
+            responseBody =
+                appendContentStream(
+                    cmisDocument,
+                    sdmUrl,
+                    chunkBuffer,
+                    bytesRead,
+                    isLastChunk,
+                    chunkIndex,
+                    isSystemUser);
+          } else {
+            appendContentStream(
+                cmisDocument,
+                sdmUrl,
+                chunkBuffer,
+                bytesRead,
+                isLastChunk,
+                chunkIndex,
+                isSystemUser);
+          }
         }
 
         long endChunkUploadTime = System.currentTimeMillis();

--- a/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/ReadAheadInputStream.java
@@ -2,9 +2,7 @@ package com.sap.cds.sdm.service;
 
 import com.sap.cds.sdm.constants.SDMConstants;
 import com.sap.cds.sdm.service.exceptions.InsufficientDataException;
-import io.reactivex.Flowable;
 import java.io.*;
-import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,7 +23,8 @@ public class ReadAheadInputStream extends InputStream {
   private final ExecutorService executor =
       Executors.newFixedThreadPool(2); // Thread pool to Read next chunk
   private final BlockingQueue<byte[]> chunkQueue =
-      new LinkedBlockingQueue<>(50); // Next chunk is read to a queue
+      new LinkedBlockingQueue<>(
+          4); // Reduced from 50 to 4 (80MB) - balances read-ahead performance with heap constraints
 
   public ReadAheadInputStream(InputStream inputStream, long totalSize) throws IOException {
     if (inputStream == null) {
@@ -91,42 +90,50 @@ public class ReadAheadInputStream extends InputStream {
 
   private void readChunk(AtomicReference<byte[]> bufferRef, AtomicLong bytesReadAtomic)
       throws IOException {
+    int maxRetries = 5;
+    int retryCount = 0;
+
     while (bytesReadAtomic.get() < CHUNK_SIZE) {
       try {
-        List<Integer> results =
-            Flowable.fromCallable(
-                    () -> {
-                      byte[] buffer = bufferRef.get();
-                      // Read from stream and update bytesReadAtomic
-                      int result =
-                          originalStream.read(
-                              buffer,
-                              (int) bytesReadAtomic.get(),
-                              CHUNK_SIZE - (int) bytesReadAtomic.get());
-                      if (result > 0) {
-                        bytesReadAtomic.addAndGet(result);
-                      } else if (result == 0) {
-                        throw new InsufficientDataException("Read returned 0 bytes");
-                      }
-                      return result;
-                    })
-                .retryWhen(RetryUtils.retryLogic(5)) // Apply retry logic with 5 attempts
-                .toList()
-                .blockingGet();
+        byte[] buffer = bufferRef.get();
+        int result =
+            originalStream.read(
+                buffer, (int) bytesReadAtomic.get(), CHUNK_SIZE - (int) bytesReadAtomic.get());
 
-        if (results == null || results.isEmpty())
-          throw new IOException("Failed to read chunk: results is null or empty");
-        // Check if the read was successful
-
-        int readAttempt = results.get(0);
-
-        if (readAttempt == -1) {
+        if (result > 0) {
+          bytesReadAtomic.addAndGet(result);
+          retryCount = 0; // Reset retry count on successful read
+        } else if (result == -1) {
           logger.info("EOF reached while reading the stream.");
           break;
+        } else if (result == 0) {
+          // Treat 0 bytes read as InsufficientDataException (matches original behavior)
+          throw new InsufficientDataException("Read returned 0 bytes");
         }
-      } catch (Exception e) {
-        logger.error("Failed to read chunk after retries: {}", e.getMessage(), e);
-        throw new IOException("Failed to read chunk", e);
+      } catch (EOFException | InsufficientDataException e) {
+        // These exceptions should be retried (matching RetryUtils.shouldRetry())
+        retryCount++;
+        if (retryCount >= maxRetries) {
+          logger.error("Failed to read chunk after {} retries: {}", maxRetries, e.getMessage(), e);
+          throw new IOException("Failed to read chunk after retries", e);
+        }
+        long delaySeconds =
+            (long) Math.pow(2, retryCount); // Exponential backoff: 2, 4, 8, 16, 32 seconds
+        logger.info(
+            "Retry attempt {} failed. Retrying in {} seconds. Error: {}",
+            retryCount,
+            delaySeconds,
+            e.getMessage());
+        try {
+          Thread.sleep(delaySeconds * 1000); // Convert to milliseconds
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted during retry backoff", ie);
+        }
+      } catch (IOException e) {
+        // Other IOExceptions should fail immediately (not retried in original)
+        logger.error("Non-retryable IOException: {}", e.getMessage(), e);
+        throw e;
       }
     }
   }


### PR DESCRIPTION
## Describe your changes
**Fix for Large File Upload Out of Memory issue**
This was a classic producer-consumer problem.

**What was happening:**

When we upload large files, we're using 2 threads:
One thread reads chunks from the file and puts them in a queue
Another thread takes chunks from the queue and uploads them to SDM
The problem was that reading chunks became really fast recently (2-3 seconds per chunk), but uploading still takes time. So the reader thread was running way ahead of the uploader, filling up the queue.
The queue was set to hold up to 50 chunks. With each chunk being 20MB, that's potentially 1GB of memory just sitting in the queue - but our heap is only 305MB. That's why we were running out of memory around chunk 10-15.

**The fix:**

I changed the queue size from 50 down to 4 chunks. This gives us about 80MB max queue size, which is much more reasonable. Used BlockingQueue which handles this automatically - when the queue fills up, the reader thread just waits until the uploader catches up. So they naturally stay in sync now.
I also cleaned up some retry logic that was using RxJava and creating a bunch of temporary objects. Replaced it with a simpler retry loop.
**Result:** Memory usage went from ~1GB down to ~100MB per upload. This change should handle even multi-GB files now without issues.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

EU12 - AWS (Repository without trendmicro)
<img width="1274" height="692" alt="Screenshot 2026-01-17 at 10 52 06 AM" src="https://github.com/user-attachments/assets/648cd6f3-8177-462a-b746-4a7f0c66e777" />

US31 - GCP (Repository with trendmicro)
<img width="1419" height="961" alt="Screenshot 2026-01-17 at 12 31 47 AM" src="https://github.com/user-attachments/assets/7cfbf5d0-2f99-4a2d-87f9-42c1fffb95d6" />

Single-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/21087767783

Multi-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/21087862188
