### PR TITLE
Support Attachment size restriction during upload

### DIFF
--- a/.github/workflows/cfdeploy.yml
+++ b/.github/workflows/cfdeploy.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Verify and Checkout Deploy Branch 🔄
         run: |
           git fetch origin
-          echo "📂 Verifying 'local_deploy' branch..."
-          if git rev-parse --verify origin/local_deploy; then
-            git checkout local_deploy
+          echo "📂 Verifying 'maxAnnotation' branch..."
+          if git rev-parse --verify origin/maxAnnotation; then
+            git checkout maxAnnotation
             echo "✅ Branch checked out successfully!"
           else
-            echo "❌ Branch 'local_deploy' not found. Please verify the branch name."
+            echo "❌ Branch 'maxAnnotation' not found. Please verify the branch name."
             exit 1
           fi
 

--- a/.github/workflows/cfdeploy.yml
+++ b/.github/workflows/cfdeploy.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Verify and Checkout Deploy Branch 🔄
         run: |
           git fetch origin
-          echo "📂 Verifying 'maxAnnotation' branch..."
-          if git rev-parse --verify origin/maxAnnotation; then
-            git checkout maxAnnotation
+          echo "📂 Verifying 'local_deploy' branch..."
+          if git rev-parse --verify origin/local_deploy; then
+            git checkout local_deploy
             echo "✅ Branch checked out successfully!"
           else
-            echo "❌ Branch 'maxAnnotation' not found. Please verify the branch name."
+            echo "❌ Branch 'local_deploy' not found. Please verify the branch name."
             exit 1
           fi
 

--- a/.github/workflows/multiTenancyDeployLocal.yml
+++ b/.github/workflows/multiTenancyDeployLocal.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Clone the cloud-cap-samples-java repo 🌐
         run: |
             echo "🔄 Cloning repository..."
-            git clone --depth 1 --branch attachmentSize https://github.com/vibhutikumar07/cloud-cap-samples-java.git
+            git clone --depth 1 --branch local_mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
             echo "✅ Repository cloned!"
       
       - name: Override cds.services.version (runtime only)

--- a/.github/workflows/multiTenancyDeployLocal.yml
+++ b/.github/workflows/multiTenancyDeployLocal.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Clone the cloud-cap-samples-java repo 🌐
         run: |
             echo "🔄 Cloning repository..."
-            git clone --depth 1 --branch local_mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
+            git clone --depth 1 --branch attachmentSize https://github.com/vibhutikumar07/cloud-cap-samples-java.git
             echo "✅ Repository cloned!"
       
       - name: Override cds.services.version (runtime only)

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ annotate Books.attachments with {
   content @Validation.Maximum : '200MB';
 }
 ```
+Supports both decimal (KB, MB, GB, TB) and binary (KiB, MiB, GiB, TiB) units with comprehensive validation and error handling.
 
 ## Support for Multiple attachment facets
 The plugin supports creating multiple attachment facets or sections, each allowing various documents to be uploaded. The names of these facets are fully customizable. All existing operations available for the default attachment facet are also supported for any additional facets you create.

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ SDM.maxCountErrorMessage = Maximale Anzahl von Anhängen erreicht
 
 ## Support for Maximum File Size
 
-This plugin allows you to specify the maximum file size for attachments by using the `@Validation.Maximum` annotation on the attachments content property. When a user attempts to upload a file that exceeds the defined limit, the upload will be rejected with "AttachmentSizeExceeded" error.
+This plugin allows you to customize the maximum file size for attachments that a user can upload. Once the defined file size limit is exceeded, the upload is rejected and an error is triggered. The error message displayed to the user is fully customizable. The `@Validation.Maximum` annotation is used to define the maximum allowed file size.
 
 Refer the following example from a sample Bookshop app:
 
@@ -508,10 +508,20 @@ entity Books {
 }
 
 annotate Books.attachments with {
-  content @Validation.Maximum : '200MB';
+  content @Validation.Maximum : '30MB';
 }
 ```
+
+#### Customizing the Maximum File Size Error Message
+
+To customize the error message displayed when the file upload size limit is exceeded, add the following key to your `messages.properties` file under `srv/src/main/resources`:
+
+```properties
+AttachmentSizeExceeded = File size exceeds the limit of {0}.
+```
+
 Supports both decimal (KB, MB, GB, TB) and binary (KiB, MiB, GiB, TiB) units with comprehensive validation and error handling.
+
 
 ## Support for Multiple attachment facets
 The plugin supports creating multiple attachment facets or sections, each allowing various documents to be uploaded. The names of these facets are fully customizable. All existing operations available for the default attachment facet are also supported for any additional facets you create.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - Display attachments specific to repository: Lists attachments contained in the repository that is configured with the CAP application.
 - Custom properties : Provides the capability to define custom properties for attachments.
 - Maximum allowed uploads: Provides the capability to define the maximum number of uploads allowed for the user.
+- Maximum file size: Provides the capability to specify the maximum file size for attachments.
 - Multiple attachment facets: Provides the capability to define multiple attachment facets/sections in the CAP Entity.
 - Technical user support: Provides the capability to consume the plugin using technical user.
 - Copy attachments: Provides the capability to copy attachments from one entity to another entity.
@@ -34,6 +35,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - [Support for Multitenancy](#support-for-multitenancy)
 - [Support for Custom Properties](#support-for-custom-properties)
 - [Support for Maximum allowed uploads](#support-for-maximum-allowed-uploads)
+- [Support for Maximum File Size](#support-for-maximum-file-size)
 - [Support for Multiple attachment facets](#support-for-multiple-attachment-facets)
 - [Support for Technical user](#support-for-technical-user)
 - [Support for Copy attachments](#support-for-copy-attachments)
@@ -491,6 +493,24 @@ SDM.maxCountErrorMessage = Maximale Anzahl von Anhängen erreicht
 > **Note**
 >
 > Once the maxCount is configured, it is recommended not to alter it. If the maxCount is altered, the previously uploaded documents will still be visible.
+
+## Support for Maximum File Size
+
+This plugin allows you to specify the maximum file size for attachments by using the `@Validation.Maximum` annotation on the attachments content property. When a user attempts to upload a file that exceeds the defined limit, the upload will be rejected with "AttachmentSizeExceeded" error.
+
+Refer the following example from a sample Bookshop app:
+
+```cds
+
+entity Books {
+  ...
+  attachments: Composition of many Attachments;
+}
+
+annotate Books.attachments with {
+  content @Validation.Maximum : '200MB';
+}
+```
 
 ## Support for Multiple attachment facets
 The plugin supports creating multiple attachment facets or sections, each allowing various documents to be uploaded. The names of these facets are fully customizable. All existing operations available for the default attachment facet are also supported for any additional facets you create.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.7.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.7.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <test-spring-boot-version>3.2.5</test-spring-boot-version>
         <sdk-bom-version>5.21.0</sdk-bom-version>
         <mockito-bom-version>5.15.2</mockito-bom-version>
-        <assertj-core-version>3.27.3</assertj-core-version>
+        <assertj-core-version>3.27.7</assertj-core-version>
         <mockito-core-version>5.15.2</mockito-core-version>
     </properties>
 

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -34,7 +34,7 @@
         <test-generation-folder>src/test/gen</test-generation-folder>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <attachments_version>1.2.4</attachments_version>
+        <attachments_version>1.3.0</attachments_version>
         <lombok.version>1.18.36</lombok.version>
         <jacoco.version>0.8.7</jacoco.version>
         <ehcache-version>3.10.8</ehcache-version>

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -7210,4 +7210,61 @@ class IntegrationTest_MultipleFacet {
       api.deleteEntity(appUrl, entityName, moveSourceEntity);
     }
   }
+
+  @Test
+  @Order(76)
+  void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
+    System.out.println(
+        "Test (76) : Upload attachment exceeding maximum file size in references facet");
+
+    // Create a new entity
+    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (response.equals("Could not create entity")) {
+      fail("Could not create entity");
+    }
+    String testEntityID = response;
+
+    // Load the 150MB sample file
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
+
+    for (int i = 0; i < facet.length; i++) {
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", testEntityID);
+      postData.put("mimeType", "application/pdf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      List<String> createResponse =
+          api.createAttachment(appUrl, entityName, facet[i], testEntityID, srvpath, postData, file);
+      String check = createResponse.get(0);
+
+      // Only 'references' facet has 100MB limit, others should succeed
+      if (facet[i].equals("references")) {
+        // The upload should fail with AttachmentSizeExceeded error
+        if (!check.equals("Attachment created")) {
+          try {
+            JSONObject json = new JSONObject(check);
+            String errorCode = json.getJSONObject("error").getString("code");
+            String errorMessage = json.getJSONObject("error").getString("message");
+            assertEquals("413", errorCode);
+            assertEquals("AttachmentSizeExceeded", errorMessage);
+          } catch (Exception e) {
+            fail("Failed to parse error response for references facet: " + e.getMessage());
+          }
+        } else {
+          fail("Attachment got created in references facet with file size exceeding maximum limit");
+        }
+      } else {
+        // For attachments and footnotes, expect success
+        if (!check.equals("Attachment created")) {
+          fail("Attachment upload failed in " + facet[i] + " facet: " + check);
+        }
+      }
+    }
+
+    // delete the draft entity
+    api.deleteEntityDraft(appUrl, entityName, testEntityID);
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -7211,60 +7211,62 @@ class IntegrationTest_MultipleFacet {
     }
   }
 
-  @Test
-  @Order(76)
-  void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
-    System.out.println(
-        "Test (76) : Upload attachment exceeding maximum file size in references facet");
+  // @Test
+  // @Order(76)
+  // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
+  //   System.out.println(
+  //       "Test (76) : Upload attachment exceeding maximum file size in references facet");
 
-    // Create a new entity
-    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
-    if (response.equals("Could not create entity")) {
-      fail("Could not create entity");
-    }
-    String testEntityID = response;
+  //   // Create a new entity
+  //   String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+  //   if (response.equals("Could not create entity")) {
+  //     fail("Could not create entity");
+  //   }
+  //   String testEntityID = response;
 
-    // Load the 150MB sample file
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
+  //   // Load the 150MB sample file
+  //   ClassLoader classLoader = getClass().getClassLoader();
+  //   File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
 
-    for (int i = 0; i < facet.length; i++) {
-      Map<String, Object> postData = new HashMap<>();
-      postData.put("up__ID", testEntityID);
-      postData.put("mimeType", "application/pdf");
-      postData.put("createdAt", new Date().toString());
-      postData.put("createdBy", "test@test.com");
-      postData.put("modifiedBy", "test@test.com");
+  //   for (int i = 0; i < facet.length; i++) {
+  //     Map<String, Object> postData = new HashMap<>();
+  //     postData.put("up__ID", testEntityID);
+  //     postData.put("mimeType", "application/pdf");
+  //     postData.put("createdAt", new Date().toString());
+  //     postData.put("createdBy", "test@test.com");
+  //     postData.put("modifiedBy", "test@test.com");
 
-      List<String> createResponse =
-          api.createAttachment(appUrl, entityName, facet[i], testEntityID, srvpath, postData, file);
-      String check = createResponse.get(0);
+  //     List<String> createResponse =
+  //         api.createAttachment(appUrl, entityName, facet[i], testEntityID, srvpath, postData,
+  // file);
+  //     String check = createResponse.get(0);
 
-      // Only 'references' facet has 100MB limit, others should succeed
-      if (facet[i].equals("references")) {
-        // The upload should fail with AttachmentSizeExceeded error
-        if (!check.equals("Attachment created")) {
-          try {
-            JSONObject json = new JSONObject(check);
-            String errorCode = json.getJSONObject("error").getString("code");
-            String errorMessage = json.getJSONObject("error").getString("message");
-            assertEquals("413", errorCode);
-            assertEquals("AttachmentSizeExceeded", errorMessage);
-          } catch (Exception e) {
-            fail("Failed to parse error response for references facet: " + e.getMessage());
-          }
-        } else {
-          fail("Attachment got created in references facet with file size exceeding maximum limit");
-        }
-      } else {
-        // For attachments and footnotes, expect success
-        if (!check.equals("Attachment created")) {
-          fail("Attachment upload failed in " + facet[i] + " facet: " + check);
-        }
-      }
-    }
+  //     // Only 'references' facet has 30MB limit, others should succeed
+  //     if (facet[i].equals("references")) {
+  //       // The upload should fail with AttachmentSizeExceeded error
+  //       if (!check.equals("Attachment created")) {
+  //         try {
+  //           JSONObject json = new JSONObject(check);
+  //           String errorCode = json.getJSONObject("error").getString("code");
+  //           String errorMessage = json.getJSONObject("error").getString("message");
+  //           assertEquals("413", errorCode);
+  //           assertEquals("File size exceeds the limit of 30MB.", errorMessage);
+  //         } catch (Exception e) {
+  //           fail("Failed to parse error response for references facet: " + e.getMessage());
+  //         }
+  //       } else {
+  //         fail("Attachment got created in references facet with file size exceeding maximum
+  // limit");
+  //       }
+  //     } else {
+  //       // For attachments and footnotes, expect success
+  //       if (!check.equals("Attachment created")) {
+  //         fail("Attachment upload failed in " + facet[i] + " facet: " + check);
+  //       }
+  //     }
+  //   }
 
-    // delete the draft entity
-    api.deleteEntityDraft(appUrl, entityName, testEntityID);
-  }
+  //   // delete the draft entity
+  //   api.deleteEntityDraft(appUrl, entityName, testEntityID);
+  // }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6651,53 +6651,53 @@ class IntegrationTest_SingleFacet {
     api.deleteEntity(appUrl, entityName, moveSourceEntity);
   }
 
-  @Test
-  @Order(76)
-  void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
-    System.out.println(
-        "Test (76) : Upload attachment exceeding maximum file size in references facet");
+  // @Test
+  // @Order(76)
+  // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
+  //   System.out.println(
+  //       "Test (76) : Upload attachment exceeding maximum file size in references facet");
 
-    // Create a new entity
-    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
-    if (response.equals("Could not create entity")) {
-      fail("Could not create entity");
-    }
-    String testEntityID = response;
+  //   // Create a new entity
+  //   String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+  //   if (response.equals("Could not create entity")) {
+  //     fail("Could not create entity");
+  //   }
+  //   String testEntityID = response;
 
-    // Load the 150MB sample file
-    ClassLoader classLoader = getClass().getClassLoader();
-    File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
+  //   // Load the 150MB sample file
+  //   ClassLoader classLoader = getClass().getClassLoader();
+  //   File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
 
-    Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", testEntityID);
-    postData.put("mimeType", "application/pdf");
-    postData.put("createdAt", new Date().toString());
-    postData.put("createdBy", "test@test.com");
-    postData.put("modifiedBy", "test@test.com");
+  //   Map<String, Object> postData = new HashMap<>();
+  //   postData.put("up__ID", testEntityID);
+  //   postData.put("mimeType", "application/pdf");
+  //   postData.put("createdAt", new Date().toString());
+  //   postData.put("createdBy", "test@test.com");
+  //   postData.put("modifiedBy", "test@test.com");
 
-    // Try to upload to the 'references' facet which has the 100MB limit
-    String referencesFacet = "references";
-    List<String> createResponse =
-        api.createAttachment(
-            appUrl, entityName, referencesFacet, testEntityID, srvpath, postData, file);
-    String check = createResponse.get(0);
+  //   // Try to upload to the 'references' facet which has the 100MB limit
+  //   String referencesFacet = "references";
+  //   List<String> createResponse =
+  //       api.createAttachment(
+  //           appUrl, entityName, referencesFacet, testEntityID, srvpath, postData, file);
+  //   String check = createResponse.get(0);
 
-    // The upload should fail with AttachmentSizeExceeded error
-    if (!check.equals("Attachment created")) {
-      try {
-        JSONObject json = new JSONObject(check);
-        String errorCode = json.getJSONObject("error").getString("code");
-        String errorMessage = json.getJSONObject("error").getString("message");
-        assertEquals("413", errorCode);
-        assertEquals("AttachmentSizeExceeded", errorMessage);
-      } catch (Exception e) {
-        fail("Failed to parse error response: " + e.getMessage());
-      }
-    } else {
-      fail("Attachment got created with file size exceeding maximum limit");
-    }
+  //   // The upload should fail with AttachmentSizeExceeded error
+  //   if (!check.equals("Attachment created")) {
+  //     try {
+  //       JSONObject json = new JSONObject(check);
+  //       String errorCode = json.getJSONObject("error").getString("code");
+  //       String errorMessage = json.getJSONObject("error").getString("message");
+  //       assertEquals("413", errorCode);
+  //       assertEquals("File size exceeds the limit of 30MB.", errorMessage);
+  //     } catch (Exception e) {
+  //       fail("Failed to parse error response: " + e.getMessage());
+  //     }
+  //   } else {
+  //     fail("Attachment got created with file size exceeding maximum limit");
+  //   }
 
-    // delete the test entity draft
-    api.deleteEntityDraft(appUrl, entityName, testEntityID);
-  }
+  //   // delete the test entity draft
+  //   api.deleteEntityDraft(appUrl, entityName, testEntityID);
+  // }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6650,4 +6650,53 @@ class IntegrationTest_SingleFacet {
     api.deleteEntity(appUrl, entityName, moveTargetEntity);
     api.deleteEntity(appUrl, entityName, moveSourceEntity);
   }
+  @Test
+  @Order(76)
+  void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
+    System.out.println(
+        "Test (76) : Upload attachment exceeding maximum file size in references facet");
+
+    // Create a new entity
+    String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (response.equals("Could not create entity")) {
+      fail("Could not create entity");
+    }
+    String testEntityID = response;
+
+    // Load the 150MB sample file
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
+
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", testEntityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
+
+    // Try to upload to the 'references' facet which has the 100MB limit
+    String referencesFacet = "references";
+    List<String> createResponse =
+        api.createAttachment(
+            appUrl, entityName, referencesFacet, testEntityID, srvpath, postData, file);
+    String check = createResponse.get(0);
+
+    // The upload should fail with AttachmentSizeExceeded error
+    if (!check.equals("Attachment created")) {
+      try {
+        JSONObject json = new JSONObject(check);
+        String errorCode = json.getJSONObject("error").getString("code");
+        String errorMessage = json.getJSONObject("error").getString("message");
+        assertEquals("413", errorCode);
+        assertEquals("AttachmentSizeExceeded", errorMessage);
+      } catch (Exception e) {
+        fail("Failed to parse error response: " + e.getMessage());
+      }
+    } else {
+      fail("Attachment got created with file size exceeding maximum limit");
+    }
+
+    // delete the test entity draft
+    api.deleteEntityDraft(appUrl, entityName, testEntityID);
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6650,6 +6650,7 @@ class IntegrationTest_SingleFacet {
     api.deleteEntity(appUrl, entityName, moveTargetEntity);
     api.deleteEntity(appUrl, entityName, moveSourceEntity);
   }
+
   @Test
   @Order(76)
   void testUploadAttachmentExceedingMaximumFileSize() throws IOException {


### PR DESCRIPTION
## Describe your changes

This PR introduces README update for file size validation functionality to the SDM CAP plugin, allowing developers to enforce maximum attachment sizes during upload operations

As the cds-feature-attachments module introduced Enhanced File Attachment Validation with a Maximum Size annotation in its 1.3.0 release.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [ ] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="2056" height="1329" alt="Screenshot 2026-01-27 at 3 53 59 PM" src="https://github.com/user-attachments/assets/44bf8c36-4833-4fcb-8549-6e48d8e5e103" />

Single tenant Integration tests

https://github.com/cap-java/sdm/actions/runs/21627090683

Multi tenant Integration tests

https://github.com/cap-java/sdm/actions/runs/21626862265
