### PR TITLE
added maxSizeAnnotation for Books.references

### DIFF
--- a/cap-notebook/demoapp/app/admin-books/fiori-service.cds
+++ b/cap-notebook/demoapp/app/admin-books/fiori-service.cds
@@ -48,7 +48,7 @@ annotate AdminService.Books with @(UI: {
       $Type : 'UI.ReferenceFacet',
       Label : '{i18n>Chapters}',
       ID : 'i18nChapters',
-      Target : 'chapters/@UI.LineItem#i18nChapters',
+      Target : 'cHapters/@UI.LineItem#i18nChapters',
     },
     {
       $Type : 'UI.ReferenceFacet',

--- a/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
+++ b/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
@@ -85,7 +85,7 @@
           "target": "AuthorsDetails"
         },
         {
-          "pattern": "Books({key})/chapters({key2}):?query:",
+          "pattern": "Books({key})/cHapters({key2}):?query:",
           "name": "chaptersObjectPage",
           "target": "ChaptersObjectPage"
         },

--- a/cap-notebook/demoapp/app/index.html
+++ b/cap-notebook/demoapp/app/index.html
@@ -15,7 +15,7 @@
 	</script>
 
 	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-    <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.138.1/resources/sap-ui-core.js"
+    <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/resources/sap-ui-core.js"
       data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
       data-sap-ui-compatVersion="edge"
       data-sap-ui-async="true"

--- a/cap-notebook/demoapp/db/schema.cds
+++ b/cap-notebook/demoapp/db/schema.cds
@@ -18,7 +18,7 @@ currency : Currency;
 image : LargeBinary @Core.MediaType: 'image/png';
 
 // top-level chapters composition (root of the nested hierarchy)
-chapters : Composition of many Chapters on chapters.book = $self;
+cHapters : Composition of many Chapters on cHapters.book = $self;
 
 // top-level pages composition (same pattern as chapters)
 pages : Composition of many Pages on pages.book = $self;

--- a/cap-notebook/demoapp/srv/attachment-extension.cds
+++ b/cap-notebook/demoapp/srv/attachment-extension.cds
@@ -50,7 +50,7 @@ annotate Books.attachments with {
 
 
 annotate Books.references with {
-  content @Validation.Maximum : '100MB';
+  content @Validation.Maximum : '30MB';
   status @(
     Common.Text: {
       $value: ![statusText.text],

--- a/cap-notebook/demoapp/srv/attachment-extension.cds
+++ b/cap-notebook/demoapp/srv/attachment-extension.cds
@@ -50,6 +50,7 @@ annotate Books.attachments with {
 
 
 annotate Books.references with {
+  content @Validation.Maximum : '100MB';
   status @(
     Common.Text: {
       $value: ![statusText.text],


### PR DESCRIPTION
Added maxSize annotation for Books.references with a limit of 30 MB for testing purposes.