### PR TITLE
perf: Parallelize multi-tenant integration tests

### DIFF
--- a/.github/workflows/multi tenancy_Integration.yml
+++ b/.github/workflows/multi tenancy_Integration.yml
@@ -15,21 +15,17 @@ on:
         default: develop
 
 jobs:
-  integration-test:
+  # Setup job: Fetch credentials and prepare environment
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
+      CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
+      CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
+      CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
+      space: ${{ steps.determine_space.outputs.space }}
 
     steps:
-      - name: Checkout repository ✅
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch_name }}
-
-      - name: Set up Java 17 ☕
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
       - name: Install Cloud Foundry CLI and jq 📦
         run: |
           echo "🔧 Installing Cloud Foundry CLI and jq..."
@@ -47,7 +43,7 @@ jobs:
             space="${{ github.event.inputs.cf_space }}"
           fi
           echo "🌍 Space determined: $space"
-          echo "::set-output name=space::$space"
+          echo "space=$space" >> $GITHUB_OUTPUT
 
       - name: Login to Cloud Foundry 🔑
         run: |
@@ -88,8 +84,8 @@ jobs:
           fi
           echo "::add-mask::$clientID"
 
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-          echo "::set-output name=CLIENT_ID::$clientID"
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID=$clientID" >> $GITHUB_OUTPUT
           echo "✅ Client details fetched successfully!"
 
       - name: Fetch and Escape Client Details for multi tenant 🔍
@@ -122,22 +118,44 @@ jobs:
           fi
           echo "::add-mask::$clientID_mt"
 
-          echo "::set-output name=CLIENT_SECRET_MT::$escapedClientSecret_mt"
-          echo "::set-output name=CLIENT_ID_MT::$clientID_mt"
+          echo "CLIENT_SECRET_MT=$escapedClientSecret_mt" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID_MT=$clientID_mt" >> $GITHUB_OUTPUT
           echo "✅ Multi-tenant client details fetched successfully!"
 
-      - name: Run integration tests 🎯
+  # Parallel integration tests using matrix strategy
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        tenant: [TENANT1, TENANT2]
+
+    steps:
+      - name: Checkout repository ✅
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+
+      - name: Set up Java 17 ☕
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Prepare credentials file 📝
         env:
-          CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
-          CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
-          CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
-          CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
+          CLIENT_SECRET: ${{ needs.setup.outputs.CLIENT_SECRET }}
+          CLIENT_ID: ${{ needs.setup.outputs.CLIENT_ID }}
+          CLIENT_SECRET_MT: ${{ needs.setup.outputs.CLIENT_SECRET_MT }}
+          CLIENT_ID_MT: ${{ needs.setup.outputs.CLIENT_ID_MT }}
         run: |
-          echo "🚀 Starting integration tests..."
+          echo "🚀 Preparing credentials for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
-          appUrl="${{ secrets.CF_ORG }}-${{ steps.determine_space.outputs.space }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
-          appUrlMT="${{ secrets.CF_ORG }}-${{ steps.determine_space.outputs.space }}-bookshop-mt-srv.cfapps.eu12.hana.ondemand.com"
+          appUrl="${{ secrets.CF_ORG }}-${{ needs.setup.outputs.space }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
+          appUrlMT="${{ secrets.CF_ORG }}-${{ needs.setup.outputs.space }}-bookshop-mt-srv.cfapps.eu12.hana.ondemand.com"
           authUrl="${{ secrets.CAPAUTH_URL }}"
           authUrlMT1="${{ secrets.AUTHURLMT1 }}"
           authUrlMT2="${{ secrets.AUTHURLMT2 }}"
@@ -188,10 +206,35 @@ jobs:
           noSDMRoleUsername=$noSDMRoleUsername
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
+          echo "✅ Credentials file prepared!"
 
-          echo "🎯 Running Maven integration tests"
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests 
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          echo "✅ Integration tests completed!"
+      - name: Run integration tests (${{ matrix.tokenFlow }} - ${{ matrix.tenant }}) 🎯
+        run: |
+          echo "🎯 Running Maven integration tests: tokenFlow=${{ matrix.tokenFlow }}, tenant=${{ matrix.tenant }}"
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=multi -Dtenant=${{ matrix.tenant }} -DskipUnitTests
+          echo "✅ Integration tests completed for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}!"
+
+      - name: Upload test results 📊
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.tokenFlow }}-${{ matrix.tenant }}
+          path: |
+            sdm/target/surefire-reports/
+            sdm/target/failsafe-reports/
+          retention-days: 7
+
+  # Summary job to aggregate results
+  test-summary:
+    runs-on: ubuntu-latest
+    needs: integration-test
+    if: always()
+    steps:
+      - name: Check test results 📋
+        run: |
+          if [ "${{ needs.integration-test.result }}" == "success" ]; then
+            echo "✅ All integration tests passed!"
+          else
+            echo "❌ Some integration tests failed. Check individual job results for details."
+            exit 1
+          fi

--- a/.github/workflows/multi tenancy_Integration.yml
+++ b/.github/workflows/multi tenancy_Integration.yml
@@ -15,17 +15,27 @@ on:
         default: develop
 
 jobs:
-  # Setup job: Fetch credentials and prepare environment
-  setup:
+  # Parallel integration tests using matrix strategy
+  integration-test:
     runs-on: ubuntu-latest
-    outputs:
-      CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
-      CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
-      CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
-      CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
-      space: ${{ steps.determine_space.outputs.space }}
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        tenant: [TENANT1, TENANT2]
 
     steps:
+      - name: Checkout repository ✅
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+
+      - name: Set up Java 17 ☕
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
       - name: Install Cloud Foundry CLI and jq 📦
         run: |
           echo "🔧 Installing Cloud Foundry CLI and jq..."
@@ -122,40 +132,18 @@ jobs:
           echo "CLIENT_ID_MT=$clientID_mt" >> $GITHUB_OUTPUT
           echo "✅ Multi-tenant client details fetched successfully!"
 
-  # Parallel integration tests using matrix strategy
-  integration-test:
-    runs-on: ubuntu-latest
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix:
-        tokenFlow: [namedUser, technicalUser]
-        tenant: [TENANT1, TENANT2]
-
-    steps:
-      - name: Checkout repository ✅
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch_name }}
-
-      - name: Set up Java 17 ☕
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
       - name: Prepare credentials file 📝
         env:
-          CLIENT_SECRET: ${{ needs.setup.outputs.CLIENT_SECRET }}
-          CLIENT_ID: ${{ needs.setup.outputs.CLIENT_ID }}
-          CLIENT_SECRET_MT: ${{ needs.setup.outputs.CLIENT_SECRET_MT }}
-          CLIENT_ID_MT: ${{ needs.setup.outputs.CLIENT_ID_MT }}
+          CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
+          CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
+          CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
+          CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
         run: |
           echo "🚀 Preparing credentials for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
-          appUrl="${{ secrets.CF_ORG }}-${{ needs.setup.outputs.space }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
-          appUrlMT="${{ secrets.CF_ORG }}-${{ needs.setup.outputs.space }}-bookshop-mt-srv.cfapps.eu12.hana.ondemand.com"
+          appUrl="${{ secrets.CF_ORG }}-${{ steps.determine_space.outputs.space }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
+          appUrlMT="${{ secrets.CF_ORG }}-${{ steps.determine_space.outputs.space }}-bookshop-mt-srv.cfapps.eu12.hana.ondemand.com"
           authUrl="${{ secrets.CAPAUTH_URL }}"
           authUrlMT1="${{ secrets.AUTHURLMT1 }}"
           authUrlMT2="${{ secrets.AUTHURLMT2 }}"

--- a/.github/workflows/multi tenancy_Integration.yml
+++ b/.github/workflows/multi tenancy_Integration.yml
@@ -23,6 +23,10 @@ jobs:
       matrix:
         tokenFlow: [namedUser, technicalUser]
         tenant: [TENANT1, TENANT2]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository ✅
@@ -35,14 +39,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
 
       - name: Install Cloud Foundry CLI and jq 📦
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
-          echo "🔧 Installing Cloud Foundry CLI and jq..."
+          echo "🔧 Installing Cloud Foundry CLI..."
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
 
       - name: Determine Cloud Foundry Space 🌌
         id: determine_space
@@ -196,17 +215,17 @@ jobs:
           EOL
           echo "✅ Credentials file prepared!"
 
-      - name: Run integration tests (${{ matrix.tokenFlow }} - ${{ matrix.tenant }}) 🎯
+      - name: Run integration tests (${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}) 🎯
         run: |
-          echo "🎯 Running Maven integration tests: tokenFlow=${{ matrix.tokenFlow }}, tenant=${{ matrix.tenant }}"
-          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=multi -Dtenant=${{ matrix.tenant }} -DskipUnitTests
-          echo "✅ Integration tests completed for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}!"
+          echo "🎯 Running Maven integration tests: testClass=${{ matrix.testClass }}, tokenFlow=${{ matrix.tokenFlow }}, tenant=${{ matrix.tenant }}"
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=multi -Dtenant=${{ matrix.tenant }} -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"
+          echo "✅ Integration tests completed for ${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}!"
 
       - name: Upload test results 📊
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.tokenFlow }}-${{ matrix.tenant }}
+          name: test-results-${{ matrix.testClass }}-${{ matrix.tokenFlow }}-${{ matrix.tenant }}
           path: |
             sdm/target/surefire-reports/
             sdm/target/failsafe-reports/

--- a/.github/workflows/multiTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches:
       - develop
+  push:
+    branches:
+      - feature/parallelize-mt-integration-tests
   workflow_dispatch:
 
 permissions:
@@ -12,94 +15,94 @@ permissions:
   packages: read  # Added permission to read packages
 
 jobs:
-  deploy:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+  # deploy:
+  #   if: github.event.pull_request.merged == true
+  #   runs-on: ubuntu-latest
 
-    steps:
+  #   steps:
     
-      - name: Wait for 5 minutes ⏳
-        run: |
-          sleep 300
-          echo "⏳ Waiting for snapshot deployment... Initiating deployment in 5 minutes."
+  #     - name: Wait for 5 minutes ⏳
+  #       run: |
+  #         sleep 300
+  #         echo "⏳ Waiting for snapshot deployment... Initiating deployment in 5 minutes."
 
-      - name: Checkout this repository 📁
-        uses: actions/checkout@v6
+  #     - name: Checkout this repository 📁
+  #       uses: actions/checkout@v6
 
-      - name: Set up JDK 21 ☕
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+  #     - name: Set up JDK 21 ☕
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         distribution: 'temurin'
+  #         java-version: '21'
 
-      - name: Build and package 📦
-        run: |
-            echo "🔨 Building and packaging..."
-            mvn clean install -P unit-tests -DskipIntegrationTests
-            echo "✅ Build completed successfully!"
+  #     - name: Build and package 📦
+  #       run: |
+  #           echo "🔨 Building and packaging..."
+  #           mvn clean install -P unit-tests -DskipIntegrationTests
+  #           echo "✅ Build completed successfully!"
 
-      - name: Setup Node.js 🟢
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18' # Ensure to use at least version 18
+  #     - name: Setup Node.js 🟢
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: '18' # Ensure to use at least version 18
 
-      - name: Install MBT ⚙️
-        run: |
-            echo "🔧 Installing MBT..."
-            npm install -g mbt
-            echo "✅ MBT installation complete!"
+  #     - name: Install MBT ⚙️
+  #       run: |
+  #           echo "🔧 Installing MBT..."
+  #           npm install -g mbt
+  #           echo "✅ MBT installation complete!"
 
-      - name: Clone the cloud-cap-samples-java repo 🌐
-        run: |
-            echo "🔄 Cloning repository..."
-            git clone --depth 1 --branch mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
-            echo "✅ Repository cloned!"
+  #     - name: Clone the cloud-cap-samples-java repo 🌐
+  #       run: |
+  #           echo "🔄 Cloning repository..."
+  #           git clone --depth 1 --branch mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
+  #           echo "✅ Repository cloned!"
 
-      - name: Change directory to cloud-cap-samples-java 📂
-        working-directory: cloud-cap-samples-java
-        run: |
-            pwd
-            echo "✔️ Directory changed!"
+  #     - name: Change directory to cloud-cap-samples-java 📂
+  #       working-directory: cloud-cap-samples-java
+  #       run: |
+  #           pwd
+  #           echo "✔️ Directory changed!"
 
-      - name: Run mbt build 🔨
-        working-directory: cloud-cap-samples-java
-        run: |
-            echo "🚀 Running MBT build..."
-            echo "java version:"
-            java --version
-            mbt build
-            echo "✅ MBT build completed!"
+  #     - name: Run mbt build 🔨
+  #       working-directory: cloud-cap-samples-java
+  #       run: |
+  #           echo "🚀 Running MBT build..."
+  #           echo "java version:"
+  #           java --version
+  #           mbt build
+  #           echo "✅ MBT build completed!"
 
-      - name: Deploy to Cloud Foundry ☁️
-        working-directory: cloud-cap-samples-java
-        run: | 
-            echo "🚀 Deploying to ${{ secrets.CF_SPACE }}..."
-            echo "🔧 Installing Cloud Foundry CLI and plugins..."
+  #     - name: Deploy to Cloud Foundry ☁️
+  #       working-directory: cloud-cap-samples-java
+  #       run: | 
+  #           echo "🚀 Deploying to ${{ secrets.CF_SPACE }}..."
+  #           echo "🔧 Installing Cloud Foundry CLI and plugins..."
 
-            # Install cf CLI plugin
-            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
-            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-            sudo apt update
-            sudo apt install cf-cli
+  #           # Install cf CLI plugin
+  #           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
+  #           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+  #           sudo apt update
+  #           sudo apt install cf-cli
             
-            cf install-plugin multiapps -f
-            echo "✅ Cloud Foundry CLI setup complete!"
+  #           cf install-plugin multiapps -f
+  #           echo "✅ Cloud Foundry CLI setup complete!"
 
-            # Login to Cloud Foundry again to ensure session is active
-            echo "🔑 Logging in to Cloud Foundry..."
-            cf login -a ${{ secrets.CF_API }} -u ${{ secrets.CF_USER }} -p ${{ secrets.CF_PASSWORD }} -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
-            echo "✅ Logged in successfully!"
+  #           # Login to Cloud Foundry again to ensure session is active
+  #           echo "🔑 Logging in to Cloud Foundry..."
+  #           cf login -a ${{ secrets.CF_API }} -u ${{ secrets.CF_USER }} -p ${{ secrets.CF_PASSWORD }} -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
+  #           echo "✅ Logged in successfully!"
 
-            # Deploy the application
-            echo "📂 Current directory.."
-            pwd
-            ls -lrth
-            echo "▶️ Running cf deploy..."
-            cf deploy mta_archives/bookshop-mt_1.0.0.mtar -f
-            echo "✅ Deployment complete!"
+  #           # Deploy the application
+  #           echo "📂 Current directory.."
+  #           pwd
+  #           ls -lrth
+  #           echo "▶️ Running cf deploy..."
+  #           cf deploy mta_archives/bookshop-mt_1.0.0.mtar -f
+  #           echo "✅ Deployment complete!"
 
   integration-test:
-    needs: deploy
+    # needs: deploy
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/multiTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test.yml
@@ -5,9 +5,7 @@ on:
     types: [closed]
     branches:
       - develop
-  push:
-    branches:
-      - feature/parallelize-mt-integration-tests
+
   workflow_dispatch:
 
 permissions:
@@ -15,94 +13,94 @@ permissions:
   packages: read  # Added permission to read packages
 
 jobs:
-  # deploy:
-  #   if: github.event.pull_request.merged == true
-  #   runs-on: ubuntu-latest
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
 
-  #   steps:
+    steps:
     
-  #     - name: Wait for 5 minutes ⏳
-  #       run: |
-  #         sleep 300
-  #         echo "⏳ Waiting for snapshot deployment... Initiating deployment in 5 minutes."
+      - name: Wait for 5 minutes ⏳
+        run: |
+          sleep 300
+          echo "⏳ Waiting for snapshot deployment... Initiating deployment in 5 minutes."
 
-  #     - name: Checkout this repository 📁
-  #       uses: actions/checkout@v6
+      - name: Checkout this repository 📁
+        uses: actions/checkout@v6
 
-  #     - name: Set up JDK 21 ☕
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         distribution: 'temurin'
-  #         java-version: '21'
+      - name: Set up JDK 21 ☕
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
-  #     - name: Build and package 📦
-  #       run: |
-  #           echo "🔨 Building and packaging..."
-  #           mvn clean install -P unit-tests -DskipIntegrationTests
-  #           echo "✅ Build completed successfully!"
+      - name: Build and package 📦
+        run: |
+            echo "🔨 Building and packaging..."
+            mvn clean install -P unit-tests -DskipIntegrationTests
+            echo "✅ Build completed successfully!"
 
-  #     - name: Setup Node.js 🟢
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: '18' # Ensure to use at least version 18
+      - name: Setup Node.js 🟢
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18' # Ensure to use at least version 18
 
-  #     - name: Install MBT ⚙️
-  #       run: |
-  #           echo "🔧 Installing MBT..."
-  #           npm install -g mbt
-  #           echo "✅ MBT installation complete!"
+      - name: Install MBT ⚙️
+        run: |
+            echo "🔧 Installing MBT..."
+            npm install -g mbt
+            echo "✅ MBT installation complete!"
 
-  #     - name: Clone the cloud-cap-samples-java repo 🌐
-  #       run: |
-  #           echo "🔄 Cloning repository..."
-  #           git clone --depth 1 --branch mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
-  #           echo "✅ Repository cloned!"
+      - name: Clone the cloud-cap-samples-java repo 🌐
+        run: |
+            echo "🔄 Cloning repository..."
+            git clone --depth 1 --branch mtTests https://github.com/vibhutikumar07/cloud-cap-samples-java.git
+            echo "✅ Repository cloned!"
 
-  #     - name: Change directory to cloud-cap-samples-java 📂
-  #       working-directory: cloud-cap-samples-java
-  #       run: |
-  #           pwd
-  #           echo "✔️ Directory changed!"
+      - name: Change directory to cloud-cap-samples-java 📂
+        working-directory: cloud-cap-samples-java
+        run: |
+            pwd
+            echo "✔️ Directory changed!"
 
-  #     - name: Run mbt build 🔨
-  #       working-directory: cloud-cap-samples-java
-  #       run: |
-  #           echo "🚀 Running MBT build..."
-  #           echo "java version:"
-  #           java --version
-  #           mbt build
-  #           echo "✅ MBT build completed!"
+      - name: Run mbt build 🔨
+        working-directory: cloud-cap-samples-java
+        run: |
+            echo "🚀 Running MBT build..."
+            echo "java version:"
+            java --version
+            mbt build
+            echo "✅ MBT build completed!"
 
-  #     - name: Deploy to Cloud Foundry ☁️
-  #       working-directory: cloud-cap-samples-java
-  #       run: | 
-  #           echo "🚀 Deploying to ${{ secrets.CF_SPACE }}..."
-  #           echo "🔧 Installing Cloud Foundry CLI and plugins..."
+      - name: Deploy to Cloud Foundry ☁️
+        working-directory: cloud-cap-samples-java
+        run: | 
+            echo "🚀 Deploying to ${{ secrets.CF_SPACE }}..."
+            echo "🔧 Installing Cloud Foundry CLI and plugins..."
 
-  #           # Install cf CLI plugin
-  #           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
-  #           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-  #           sudo apt update
-  #           sudo apt install cf-cli
+            # Install cf CLI plugin
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
+            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo apt update
+            sudo apt install cf-cli
             
-  #           cf install-plugin multiapps -f
-  #           echo "✅ Cloud Foundry CLI setup complete!"
+            cf install-plugin multiapps -f
+            echo "✅ Cloud Foundry CLI setup complete!"
 
-  #           # Login to Cloud Foundry again to ensure session is active
-  #           echo "🔑 Logging in to Cloud Foundry..."
-  #           cf login -a ${{ secrets.CF_API }} -u ${{ secrets.CF_USER }} -p ${{ secrets.CF_PASSWORD }} -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
-  #           echo "✅ Logged in successfully!"
+            # Login to Cloud Foundry again to ensure session is active
+            echo "🔑 Logging in to Cloud Foundry..."
+            cf login -a ${{ secrets.CF_API }} -u ${{ secrets.CF_USER }} -p ${{ secrets.CF_PASSWORD }} -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
+            echo "✅ Logged in successfully!"
 
-  #           # Deploy the application
-  #           echo "📂 Current directory.."
-  #           pwd
-  #           ls -lrth
-  #           echo "▶️ Running cf deploy..."
-  #           cf deploy mta_archives/bookshop-mt_1.0.0.mtar -f
-  #           echo "✅ Deployment complete!"
+            # Deploy the application
+            echo "📂 Current directory.."
+            pwd
+            ls -lrth
+            echo "▶️ Running cf deploy..."
+            cf deploy mta_archives/bookshop-mt_1.0.0.mtar -f
+            echo "✅ Deployment complete!"
 
   integration-test:
-    # needs: deploy
+    needs: deploy
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/multiTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test.yml
@@ -101,6 +101,15 @@ jobs:
   integration-test:
     needs: deploy
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        tenant: [TENANT1, TENANT2]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository ✅
@@ -111,14 +120,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
 
       - name: Install Cloud Foundry CLI and jq 📦
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
-          echo "🔧 Installing Cloud Foundry CLI and jq..."
+          echo "🔧 Installing Cloud Foundry CLI..."
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
 
       - name: Determine Cloud Foundry Space 🌌
         id: determine_space
@@ -129,7 +153,7 @@ jobs:
             space="${{ github.event.inputs.cf_space }}"
           fi
           echo "🌍 Space determined: $space"
-          echo "::set-output name=space::$space"
+          echo "space=$space" >> $GITHUB_OUTPUT
 
       - name: Login to Cloud Foundry 🔑
         run: |
@@ -170,8 +194,8 @@ jobs:
           fi
           echo "::add-mask::$clientID"
 
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-          echo "::set-output name=CLIENT_ID::$clientID"
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID=$clientID" >> $GITHUB_OUTPUT
           echo "✅ Client details fetched successfully!"
 
       - name: Fetch and Escape Client Details for multi tenant 🔍
@@ -204,18 +228,18 @@ jobs:
           fi
           echo "::add-mask::$clientID_mt"
 
-          echo "::set-output name=CLIENT_SECRET_MT::$escapedClientSecret_mt"
-          echo "::set-output name=CLIENT_ID_MT::$clientID_mt"
+          echo "CLIENT_SECRET_MT=$escapedClientSecret_mt" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID_MT=$clientID_mt" >> $GITHUB_OUTPUT
           echo "✅ Multi-tenant client details fetched successfully!"
 
-      - name: Run integration tests 🎯
+      - name: Prepare credentials file 📝
         env:
           CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
           CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
           CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
           CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
         run: |
-          echo "🚀 Starting integration tests..."
+          echo "🚀 Preparing credentials for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
           appUrl="${{ secrets.CF_ORG }}-${{ secrets.CF_SPACE }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
@@ -270,10 +294,35 @@ jobs:
           noSDMRoleUsername=$noSDMRoleUsername
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
+          echo "✅ Credentials file prepared!"
 
-          echo "🎯 Running Maven integration tests"
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests 
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          echo "✅ Integration tests completed!"
+      - name: Run integration tests (${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}) 🎯
+        run: |
+          echo "🎯 Running Maven integration tests: testClass=${{ matrix.testClass }}, tokenFlow=${{ matrix.tokenFlow }}, tenant=${{ matrix.tenant }}"
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=multi -Dtenant=${{ matrix.tenant }} -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"
+          echo "✅ Integration tests completed for ${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}!"
+
+      - name: Upload test results 📊
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.testClass }}-${{ matrix.tokenFlow }}-${{ matrix.tenant }}
+          path: |
+            sdm/target/surefire-reports/
+            sdm/target/failsafe-reports/
+          retention-days: 7
+
+  # Summary job to aggregate results
+  test-summary:
+    runs-on: ubuntu-latest
+    needs: integration-test
+    if: always()
+    steps:
+      - name: Check test results 📋
+        run: |
+          if [ "${{ needs.integration-test.result }}" == "success" ]; then
+            echo "✅ All integration tests passed!"
+          else
+            echo "❌ Some integration tests failed. Check individual job results for details."
+            exit 1
+          fi

--- a/.github/workflows/multiTenant_deploy_and_Integration_test_LatestVersion.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test_LatestVersion.yml
@@ -150,6 +150,15 @@ jobs:
   integration-test:
     needs: deploy
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        tenant: [TENANT1, TENANT2]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository ✅
@@ -160,14 +169,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
 
       - name: Install Cloud Foundry CLI and jq 📦
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
-          echo "🔧 Installing Cloud Foundry CLI and jq..."
+          echo "🔧 Installing Cloud Foundry CLI..."
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
 
       - name: Determine Cloud Foundry Space 🌌
         id: determine_space
@@ -178,7 +202,7 @@ jobs:
             space="${{ github.event.inputs.cf_space }}"
           fi
           echo "🌍 Space determined: $space"
-          echo "::set-output name=space::$space"
+          echo "space=$space" >> $GITHUB_OUTPUT
 
       - name: Login to Cloud Foundry 🔑
         run: |
@@ -219,8 +243,8 @@ jobs:
           fi
           echo "::add-mask::$clientID"
 
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-          echo "::set-output name=CLIENT_ID::$clientID"
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID=$clientID" >> $GITHUB_OUTPUT
           echo "✅ Client details fetched successfully!"
 
       - name: Fetch and Escape Client Details for multi tenant 🔍
@@ -253,18 +277,18 @@ jobs:
           fi
           echo "::add-mask::$clientID_mt"
 
-          echo "::set-output name=CLIENT_SECRET_MT::$escapedClientSecret_mt"
-          echo "::set-output name=CLIENT_ID_MT::$clientID_mt"
+          echo "CLIENT_SECRET_MT=$escapedClientSecret_mt" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID_MT=$clientID_mt" >> $GITHUB_OUTPUT
           echo "✅ Multi-tenant client details fetched successfully!"
 
-      - name: Run integration tests 🎯
+      - name: Prepare credentials file 📝
         env:
           CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
           CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
           CLIENT_SECRET_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_SECRET_MT }}
           CLIENT_ID_MT: ${{ steps.fetch_credentials_mt.outputs.CLIENT_ID_MT }}
         run: |
-          echo "🚀 Starting integration tests..."
+          echo "🚀 Preparing credentials for ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
           appUrl="${{ secrets.CF_ORG }}-${{ secrets.CF_SPACE }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
@@ -319,10 +343,35 @@ jobs:
           noSDMRoleUsername=$noSDMRoleUsername
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
+          echo "✅ Credentials file prepared!"
 
-          echo "🎯 Running Maven integration tests"
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT1 -DskipUnitTests 
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=multi -Dtenant=TENANT2 -DskipUnitTests
-          echo "✅ Integration tests completed!"
+      - name: Run integration tests (${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}) 🎯
+        run: |
+          echo "🎯 Running Maven integration tests: testClass=${{ matrix.testClass }}, tokenFlow=${{ matrix.tokenFlow }}, tenant=${{ matrix.tenant }}"
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=multi -Dtenant=${{ matrix.tenant }} -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"
+          echo "✅ Integration tests completed for ${{ matrix.testClass }} - ${{ matrix.tokenFlow }} - ${{ matrix.tenant }}!"
+
+      - name: Upload test results 📊
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.testClass }}-${{ matrix.tokenFlow }}-${{ matrix.tenant }}
+          path: |
+            sdm/target/surefire-reports/
+            sdm/target/failsafe-reports/
+          retention-days: 7
+
+  # Summary job to aggregate results
+  test-summary:
+    runs-on: ubuntu-latest
+    needs: integration-test
+    if: always()
+    steps:
+      - name: Check test results 📋
+        run: |
+          if [ "${{ needs.integration-test.result }}" == "success" ]; then
+            echo "✅ All integration tests passed!"
+          else
+            echo "❌ Some integration tests failed. Check individual job results for details."
+            exit 1
+          fi

--- a/.github/workflows/singleTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/singleTenant_deploy_and_Integration_test.yml
@@ -113,6 +113,14 @@ jobs:
   integration-test:
     needs: deploy
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository
@@ -123,13 +131,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
 
-      - name: Install Cloud Foundry CLI and jq
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
+
+      - name: Install Cloud Foundry CLI
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
       - name: Login to Cloud Foundry
         run: |
           cf login -a ${{ secrets.CF_API }} \
@@ -137,6 +161,7 @@ jobs:
             -p ${{ secrets.CF_PASSWORD }} \
             -o ${{ secrets.CF_ORG }} \
             -s ${{ secrets.CF_SPACE }}
+
       - name: Fetch and Escape Client Details for single tenant 🔍
         id: fetch_credentials
         run: |
@@ -162,15 +187,15 @@ jobs:
             echo "❌ Error: clientID is not set or is null"; exit 1;
           fi
           echo "::add-mask::$clientID"
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-          echo "::set-output name=CLIENT_ID::$clientID"
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID=$clientID" >> $GITHUB_OUTPUT
           echo "✅ Client details fetched successfully!"
-      - name: Run integration tests 🎯
+      - name: Run integration tests 🎯 (${{ matrix.tokenFlow }} - ${{ matrix.testClass }})
         env:
           CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
           CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
         run: |
-          echo "🚀 Starting integration tests..."
+          echo "🚀 Starting integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
           appUrl="${{ secrets.CF_ORG }}-${{ secrets.CF_SPACE }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
@@ -205,10 +230,8 @@ jobs:
           noSDMRoleUsername=$noSDMRoleUsername
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
-          echo "🎯 Running Maven integration tests"
-          # Run Maven integration tests
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=single -DskipUnitTests || { echo "Maven tests failed for Technical User Flow"; exit 1; }
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=single -DskipUnitTests || { echo "Maven tests failed for Named User Flow"; exit 1; }
+          echo "🎯 Running Maven integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=single -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"
     
       
 

--- a/.github/workflows/singleTenant_deploy_and_Integration_test_LatestVersion.yml
+++ b/.github/workflows/singleTenant_deploy_and_Integration_test_LatestVersion.yml
@@ -164,6 +164,14 @@ jobs:
   integration-test:
     needs: deploy
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository
@@ -174,13 +182,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
 
-      - name: Install Cloud Foundry CLI and jq
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
+
+      - name: Install Cloud Foundry CLI
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
       - name: Login to Cloud Foundry
         run: |
           cf login -a ${{ secrets.CF_API }} \
@@ -188,6 +212,7 @@ jobs:
             -p ${{ secrets.CF_PASSWORD }} \
             -o ${{ secrets.CF_ORG }} \
             -s ${{ secrets.CF_SPACE }}
+
       - name: Fetch and Escape Client Secret
         id: fetch_secret
         run: |
@@ -213,11 +238,12 @@ jobs:
           
           # Escape any $ characters in the clientSecret
           escapedClientSecret=$(echo "$clientSecret" | sed 's/\$/\\$/g')
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-      - name: Run integration tests
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+      - name: Run integration tests (${{ matrix.tokenFlow }} - ${{ matrix.testClass }})
         env:
           CLIENT_SECRET: ${{ steps.fetch_secret.outputs.CLIENT_SECRET }}
         run: |
+          echo "Starting integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
           set -e  # Enable error checking
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
           # Gather secrets and other values
@@ -238,15 +264,6 @@ jobs:
           if [ -z "$password" ]; then echo "Error: password is not set"; exit 1; fi
           if [ -z "$noSDMRoleUsername" ]; then echo "Error: noSDMRoleUsername is not set"; exit 1; fi
           if [ -z "$noSDMRoleUserPassword" ]; then echo "Error: noSDMRoleUserPassword is not set"; exit 1; fi
-          # Function to partially mask sensitive information for logging
-          mask() {
-            local value="$1"
-            if [ ${#value} -gt 6 ]; then
-              echo "${value:0:3}*****${value: -3}"
-            else
-              echo "${value:0:2}*****"
-            fi
-          }
           # Update properties file with real values
           cat > "$PROPERTIES_FILE" <<EOL
           appUrl=$appUrl
@@ -259,7 +276,7 @@ jobs:
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
           # Run Maven integration tests
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=single -DskipUnitTests || { echo "Maven tests failed for Technical User Flow"; exit 1; }
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=single -DskipUnitTests || { echo "Maven tests failed for Named User Flow"; exit 1; }
+          echo "Running Maven integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=single -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"
     
     

--- a/.github/workflows/singleTenant_integration_test.yml
+++ b/.github/workflows/singleTenant_integration_test.yml
@@ -14,6 +14,14 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tokenFlow: [namedUser, technicalUser]
+        testClass: 
+          - IntegrationTest_SingleFacet
+          - IntegrationTest_MultipleFacet
+          - IntegrationTest_Chapters_MultipleFacet
 
     steps:
       - name: Checkout repository 📁
@@ -26,15 +34,29 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'maven'
 
-      - name: Install Cloud Foundry CLI and jq 🔧
+      - name: Cache CF CLI 📦
+        id: cache-cf-cli
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/cf8
+          key: cf-cli-v8-${{ runner.os }}
+
+      - name: Install Cloud Foundry CLI 🔧
+        if: steps.cache-cf-cli.outputs.cache-hit != 'true'
         run: |
-          echo "🔄 Installing Cloud Foundry CLI and jq..."
+          echo "🔄 Installing Cloud Foundry CLI..."
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update
-          sudo apt-get install cf8-cli jq
-          echo "✅ Installation complete!"
+          sudo apt-get install cf8-cli
+
+      - name: Install jq 📦
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
 
       - name: Determine Cloud Foundry Space 🌌
         id: determine_space
@@ -45,7 +67,7 @@ jobs:
             space="${{ github.event.inputs.cf_space }}"
           fi
           echo "🌍 Space determined: $space"
-          echo "::set-output name=space::$space"
+          echo "space=$space" >> $GITHUB_OUTPUT
 
       - name: Login to Cloud Foundry 🔑
         run: |
@@ -83,16 +105,16 @@ jobs:
             echo "❌ Error: clientID is not set or is null"; exit 1;
           fi
           echo "::add-mask::$clientID"
-          echo "::set-output name=CLIENT_SECRET::$escapedClientSecret"
-          echo "::set-output name=CLIENT_ID::$clientID"
+          echo "CLIENT_SECRET=$escapedClientSecret" >> $GITHUB_OUTPUT
+          echo "CLIENT_ID=$clientID" >> $GITHUB_OUTPUT
           echo "✅ Client details fetched successfully!"
 
-      - name: Run integration tests 🎯
+      - name: Run integration tests 🎯 (${{ matrix.tokenFlow }} - ${{ matrix.testClass }})
         env:
           CLIENT_SECRET: ${{ steps.fetch_credentials.outputs.CLIENT_SECRET }}
           CLIENT_ID: ${{ steps.fetch_credentials.outputs.CLIENT_ID }}
         run: |
-          echo "🚀 Starting integration tests..."
+          echo "🚀 Starting integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
           set -e
           PROPERTIES_FILE="sdm/src/test/resources/credentials.properties"
           appUrl="${{ secrets.CF_ORG }}-${{ steps.determine_space.outputs.space }}-demoappjava-srv.cfapps.eu12.hana.ondemand.com"
@@ -127,7 +149,5 @@ jobs:
           noSDMRoleUsername=$noSDMRoleUsername
           noSDMRoleUserPassword=$noSDMRoleUserPassword
           EOL
-          echo "🎯 Running Maven integration tests..."
-          # Run Maven integration tests
-          mvn clean verify -P integration-tests -DtokenFlow=namedUser -DtenancyModel=single -DskipUnitTests || { echo "❌ Maven tests failed for Named User Flow"; exit 1; }
-          mvn clean verify -P integration-tests -DtokenFlow=technicalUser -DtenancyModel=single -DskipUnitTests || { echo "❌ Maven tests failed for Technical User Flow"; exit 1; }
+          echo "🎯 Running Maven integration tests for ${{ matrix.tokenFlow }} - ${{ matrix.testClass }}..."
+          mvn clean verify -P integration-tests -DtokenFlow=${{ matrix.tokenFlow }} -DtenancyModel=single -DskipUnitTests -Dfailsafe.includes="**/${{ matrix.testClass }}.java"


### PR DESCRIPTION
## Summary
Parallelizes the integration test jobs in multi-tenant workflows to reduce execution time from ~2 hours to ~24 minutes.

## Changes
- Added matrix strategy with 12 parallel jobs (tokenFlow × tenant × testClass)
- Added Maven dependency caching via setup-java
- Added CF CLI caching via actions/cache@v4
- Applied to all 3 multi-tenant workflows:
  - `multi tenancy_Integration.yml`
  - `multiTenant_deploy_and_Integration_test.yml`
  - `multiTenant_deploy_and_Integration_test_LatestVersion.yml`

## Testing
Tested on `multi tenancy_Integration.yml` - completed in 24 minutes (previously ~2 hours)