### PR TITLE
Separate UI and Backend Error Keys for Localization

### DIFF
--- a/.github/workflows/cfdeploy.yml
+++ b/.github/workflows/cfdeploy.yml
@@ -114,7 +114,7 @@ jobs:
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt update
-          sudo apt install cf-cli
+          sudo apt install cf8-cli
 
           cf install-plugin multiapps -f
 
@@ -249,7 +249,7 @@ jobs:
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt update
-          sudo apt install cf-cli
+          sudo apt install cf8-cli
 
           cf install-plugin multiapps -f
 

--- a/.github/workflows/multiTenancyDeployLocal.yml
+++ b/.github/workflows/multiTenancyDeployLocal.yml
@@ -105,7 +105,7 @@ jobs:
             wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
             echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt update
-            sudo apt install cf-cli
+            sudo apt install cf8-cli
             
             cf install-plugin multiapps -f
             echo "✅ Cloud Foundry CLI setup complete!"

--- a/.github/workflows/multiTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test.yml
@@ -81,7 +81,7 @@ jobs:
             wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
             echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt update
-            sudo apt install cf-cli
+            sudo apt install cf8-cli
             
             cf install-plugin multiapps -f
             echo "✅ Cloud Foundry CLI setup complete!"

--- a/.github/workflows/multiTenant_deploy_and_Integration_test_LatestVersion.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test_LatestVersion.yml
@@ -129,7 +129,7 @@ jobs:
             wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo tee /etc/apt/trusted.gpg.d/cloudfoundry.asc
             echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt update
-            sudo apt install cf-cli
+            sudo apt install cf8-cli
             
             cf install-plugin multiapps -f
             echo "✅ Cloud Foundry CLI setup complete!"

--- a/.github/workflows/singleTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/singleTenant_deploy_and_Integration_test.yml
@@ -98,7 +98,7 @@ jobs:
           echo "deb https://packages.cloudfoundry.org/debian stable main" \
           | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt update
-          sudo apt install cf-cli
+          sudo apt install cf8-cli
           
           # Install cf CLI plugin
           cf install-plugin multiapps -f

--- a/.github/workflows/singleTenant_deploy_and_Integration_test_LatestVersion.yml
+++ b/.github/workflows/singleTenant_deploy_and_Integration_test_LatestVersion.yml
@@ -149,7 +149,7 @@ jobs:
           echo "deb https://packages.cloudfoundry.org/debian stable main" \
           | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt update
-          sudo apt install cf-cli
+          sudo apt install cf8-cli
           
           # Install cf CLI plugin
           cf install-plugin multiapps -f

--- a/README.md
+++ b/README.md
@@ -1304,17 +1304,15 @@ The plugin provides two classes for error keys:
 - `SDMUIErrorKeys` - UI-facing messages that should be translated
 - `SDMErrorKeys` - Backend/internal messages (no translation needed)
 
-To translate UI messages, add entries to `messages_[languagecode].properties` in `srv/src/main/resources/`:
+To translate UI messages, add entries to `messages_[languagecode].properties` in `srv/src/main/resources/`. If the leading application does not provide translations in their language-specific properties files, these default English language messages are shown to the user.
 
+Example `messages_de.properties` for German language:
 ```properties
-# messages_de.properties
-SDM.couldNotUploadDocument=Das Dokument konnte nicht hochgeladen werden.
-SDM.couldNotDeleteDocument=Das Dokument konnte nicht gelöscht werden.
-SDM.userNotAuthorisedError=Sie haben keine Berechtigung zum Hochladen von Anhängen.
+SDM.virusRepoErrorMoreThan400MB=Sie können keine Dateien hochladen, die größer als 400 MB sind
+SDM.userNotAuthorisedError=Sie verfügen nicht über die erforderlichen Berechtigungen zum Hochladen von Anhängen
+SDM.mimetypeInvalidError=Der Dateityp ist nicht zulässig
+SDM.maxCountErrorMessage=Maximale Anzahl von Anhängen erreicht
 ```
-
-Default English messages are defined in `SDMErrorMessages`.
-
 
 ## Support for Attachment Upload Status
 

--- a/README.md
+++ b/README.md
@@ -1299,17 +1299,21 @@ type=Type
 
 ### Error Messages Localization
 
-The plugin provides error message keys in the `SDMErrorKeys` [class](https://github.com/cap-java/sdm/blob/develop/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorKeys.java). You can override these messages by adding translations to `messages_[languagecode].properties` files in your leading application under `srv/src/main/resources`.
+The plugin provides two classes for error keys:
 
-Default messages are present in `SDMErrorMessages` [class](https://github.com/cap-java/sdm/blob/develop/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorMessages.java). If the leading application does not provide translations in their language-specific properties files, these default English language messages are shown to the user.
+- `SDMUIErrorKeys` - UI-facing messages that should be translated
+- `SDMErrorKeys` - Backend/internal messages (no translation needed)
 
-Example `messages_de.properties` for German language:
+To translate UI messages, add entries to `messages_[languagecode].properties` in `srv/src/main/resources/`:
+
 ```properties
-SDM.virusRepoErrorMoreThan400MB=Sie können keine Dateien hochladen, die größer als 400 MB sind
-SDM.userNotAuthorisedError=Sie verfügen nicht über die erforderlichen Berechtigungen zum Hochladen von Anhängen
-SDM.mimetypeInvalidError=Der Dateityp ist nicht zulässig
-SDM.maxCountErrorMessage=Maximale Anzahl von Anhängen erreicht
+# messages_de.properties
+SDM.couldNotUploadDocument=Das Dokument konnte nicht hochgeladen werden.
+SDM.couldNotDeleteDocument=Das Dokument konnte nicht gelöscht werden.
+SDM.userNotAuthorisedError=Sie haben keine Berechtigung zum Hochladen von Anhängen.
 ```
+
+Default English messages are defined in `SDMErrorMessages`.
 
 
 ## Support for Attachment Upload Status

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.8.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.8.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorKeys.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorKeys.java
@@ -8,35 +8,21 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+// Backend/Internal Error Keys
 public class SDMErrorKeys {
-  private SDMErrorKeys() {
-    // Doesn't do anything
-  }
+  private SDMErrorKeys() {}
 
-  public static final String COULD_NOT_UPDATE_THE_ATTACHMENT_KEY =
-      "SDM.couldNotUpdateTheAttachment";
-  public static final String ATTACHMENT_NOT_FOUND_KEY = "SDM.attachmentNotFound";
-  public static final String GENERIC_ERROR_KEY = "SDM.genericError";
-  public static final String EVENT_UPLOAD_KEY = "SDM.eventUpload";
-  public static final String VERSIONED_REPO_ERROR_KEY = "SDM.Repository.versionedRepoError";
-  public static final String VIRUS_REPO_ERROR_MORE_THAN_400MB_KEY =
-      "SDM.virusRepoErrorMoreThan400MB";
-  public static final String VIRUS_ERROR_KEY = "SDM.virusError";
-  public static final String REPOSITORY_ERROR_KEY = "SDM.repositoryError";
-  public static final String SDM_MISSING_ROLES_EXCEPTION_KEY = "SDM.sdmMissingRolesException";
-  public static final String SDM_SERVER_ERROR_KEY = "SDM.sdmServerError";
   public static final String ENTITY_PROCESSING_ERROR_LINK_KEY = "SDM.entityProcessingErrorLink";
-  public static final String USER_NOT_AUTHORISED_ERROR_KEY = "SDM.userNotAuthorisedError";
-  public static final String MIMETYPE_INVALID_ERROR_KEY = "SDM.mimetypeInvalidError";
-  public static final String USER_NOT_AUTHORISED_ERROR_LINK_KEY = "SDM.userNotAuthorisedErrorLink";
-  public static final String FILE_NOT_FOUND_ERROR_KEY = "SDM.fileNotFoundError";
+  public static final String FAILED_TO_EDIT_LINK_KEY = "SDM.failedToEditLink";
   public static final String ONBOARD_REPO_MESSAGE_KEY = "SDM.onboardRepoMessage";
   public static final String REPOSITORY_ALREADY_EXIST_KEY = "SDM.repositoryAlreadyExist";
   public static final String ONBOARD_REPO_ERROR_MESSAGE_KEY = "SDM.onboardRepoErrorMessage";
-  public static final String UPDATE_ATTACHMENT_ERROR_KEY = "SDM.updateAttachmentError";
+  public static final String FAILED_TO_OFFBOARD_REPOSITORY_KEY = "SDM.failedToOffboardRepository";
+  public static final String ERROR_WHILE_OFFBOARDING_REPOSITORY_KEY =
+      "SDM.errorWhileOffboardingRepository";
+  public static final String UNEXPECTED_ERROR_WHILE_OFFBOARDING_REPOSITORY_KEY =
+      "SDM.unexpectedErrorWhileOffboardingRepository";
   public static final String DRAFT_NOT_FOUND_KEY = "SDM.draftNotFound";
-  public static final String UNSUPPORTED_PROPERTIES_KEY = "SDM.unsupportedProperties";
-  public static final String FAILED_TO_COPY_ATTACHMENT_KEY = "SDM.failedToCopyAttachment";
   public static final String PARENT_ENTITY_NOT_FOUND_ERROR_KEY = "SDM.parentEntityNotFoundError";
   public static final String COMPOSITION_NOT_FOUND_ERROR_KEY = "SDM.compositionNotFoundError";
   public static final String TARGET_ATTACHMENT_ENTITY_NOT_FOUND_ERROR_KEY =
@@ -44,12 +30,17 @@ public class SDMErrorKeys {
   public static final String INVALID_FACET_FORMAT_ERROR_KEY = "SDM.invalidFacetFormatError";
   public static final String FETCH_ATTACHMENT_COMPOSITION_ERROR_KEY =
       "SDM.fetchAttachmentCompositionError";
-  public static final String FAILED_TO_EDIT_LINK_KEY = "SDM.failedToEditLink";
   public static final String ERROR_IN_SETTING_TIMEOUT_KEY = "SDM.errorInSettingTimeout";
   public static final String SDM_CREDENTIALS_MISSING_OR_INVALID_KEY =
       "SDM.sdmCredentialsMissingOrInvalid";
   public static final String FAILED_TO_RETRIEVE_SDM_CREDENTIALS_KEY =
       "SDM.failedToRetrieveSdmCredentials";
+  public static final String CLIENT_CREDENTIALS_MISSING_OR_INVALID_KEY =
+      "SDM.clientCredentialsMissingOrInvalid";
+  public static final String FAILED_TO_CREATE_CLIENT_CREDENTIALS_KEY =
+      "SDM.failedToCreateClientCredentials";
+  public static final String FAILED_TO_REPLACE_SUBDOMAIN_IN_BASE_TOKEN_URL_KEY =
+      "SDM.failedToReplaceSubdomainInBaseTokenUrl";
   public static final String FAILED_TO_CREATE_HTTP_CLIENT_KEY = "SDM.failedToCreateHttpClient";
   public static final String ERROR_WHILE_CREATING_HTTP_CLIENT_KEY =
       "SDM.errorWhileCreatingHttpClient";
@@ -58,67 +49,17 @@ public class SDMErrorKeys {
   public static final String FAILED_TO_SERIALIZE_REPOSITORY_OBJECT_TO_JSON_KEY =
       "SDM.failedToSerializeRepositoryObjectToJson";
   public static final String FAILED_TO_CREATE_STRING_ENTITY_KEY = "SDM.failedToCreateStringEntity";
-  public static final String CLIENT_CREDENTIALS_MISSING_OR_INVALID_KEY =
-      "SDM.clientCredentialsMissingOrInvalid";
-  public static final String FAILED_TO_CREATE_CLIENT_CREDENTIALS_KEY =
-      "SDM.failedToCreateClientCredentials";
-  public static final String FAILED_TO_REPLACE_SUBDOMAIN_IN_BASE_TOKEN_URL_KEY =
-      "SDM.failedToReplaceSubdomainInBaseTokenUrl";
   public static final String ERROR_WHILE_FETCHING_REPOSITORY_ID_KEY =
-      "SDM.errowWhileFetchingRepositoryId";
+      "SDM.errorWhileFetchingRepositoryId";
   public static final String UNEXPECTED_ERROR_WHILE_FETCHING_REPOSITORY_ID_KEY =
       "SDM.unexpectedErrorWhileFetchingRepositoryId";
-  public static final String FAILED_TO_OFFBOARD_REPOSITORY_KEY = "SDM.failedToOffboardRepository";
-  public static final String ERROR_WHILE_OFFBOARDING_REPOSITORY_KEY =
-      "SDM.errorWhileOffboardingRepository";
-  public static final String UNEXPECTED_ERROR_WHILE_OFFBOARDING_REPOSITORY_KEY =
-      "SDM.unexpectedErrorWhileOffboardingRepository";
   public static final String FAILED_TO_PARSE_REPOSITORY_RESPONSE_KEY =
       "SDM.failedToParseRepositoryResponse";
   public static final String FAILED_TO_CREATE_FOLDER_KEY = "SDM.failedToCreateFolder";
-  public static final String FILENAME_WHITESPACE_ERROR_MESSAGE_KEY =
-      "SDM.filenameWhitespaceErrorMessage";
-  public static final String SINGLE_RESTRICTED_CHARACTER_IN_FILE_KEY =
-      "SDM.singleRestrictedCharacterInFile";
-  public static final String SINGLE_DUPLICATE_FILENAME_KEY = "SDM.singleDuplicateFilename";
-  public static final String VIRUS_DETECTED_FILE_ERROR_KEY = "SDM.virusDetectedFileError";
-  public static final String VIRUS_SCAN_IN_PROGRESS_FILE_ERROR_KEY =
-      "SDM.virusScanInProgressFileError";
-
-  public static final String UPLOAD_IN_PROGRESS_FILE_ERROR_KEY = "SDM.uploadInProgressFileError";
-  public static final String VIRUS_DETECTED_FILES_PREFIX_KEY = "SDM.virusDetectedFilesPrefix";
-  public static final String VIRUS_DETECTED_FILES_SUFFIX_KEY = "SDM.virusDetectedFilesSuffix";
-  public static final String VIRUS_SCAN_IN_PROGRESS_FILES_PREFIX_KEY =
-      "SDM.virusScanInProgressFilesPrefix";
-  public static final String VIRUS_SCAN_IN_PROGRESS_FILES_SUFFIX_KEY =
-      "SDM.virusScanInProgressFilesSuffix";
-  public static final String SCAN_FAILED_FILES_PREFIX_KEY = "SDM.scanFailedFilesPrefix";
-  public static final String SCAN_FAILED_FILES_SUFFIX_KEY = "SDM.scanFailedFilesSuffix";
-  public static final String RESTRICTED_CHARACTERS_IN_MULTIPLE_FILES_KEY =
-      "SDM.restrictedCharactersInMultipleFiles";
-  public static final String MULTIPLE_DUPLICATE_FILENAMES_PREFIX_KEY =
-      "SDM.multipleDuplicateFilenamesPrefix";
-  public static final String MULTIPLE_DUPLICATE_FILENAMES_SUFFIX_KEY =
-      "SDM.multipleDuplicateFilenamesSuffix";
-  public static final String FILE_NOT_FOUND_PREFIX_KEY = "SDM.fileNotFoundPrefix";
-  public static final String FILE_NOT_FOUND_SUFFIX_KEY = "SDM.fileNotFoundSuffix";
-  public static final String BAD_REQUEST_PREFIX_KEY = "SDM.badRequestPrefix";
-  public static final String BAD_REQUEST_SUFFIX_KEY = "SDM.badRequestSuffix";
-  public static final String EVENT_CREATE_KEY = "SDM.eventCreate";
-  public static final String EVENT_UPDATE_KEY = "SDM.eventUpdate";
-  public static final String NO_SDM_ROLES_PREFIX_KEY = "SDM.noSdmRolesPrefix";
   public static final String CONTEXT_INFO_TABLE = "SDM.contextInfoTable";
   public static final String CONTEXT_INFO_PAGE = "SDM.contextInfoPage";
-  public static final String UNSUPPORTED_PROPERTIES_PREFIX_KEY = "SDM.unsupportedPropertiesPrefix";
-  public static final String UNSUPPORTED_PROPERTIES_SUFFIX_KEY = "SDM.unsupportedPropertiesSuffix";
-  public static final String MAX_COUNT_ERROR_MESSAGE_KEY = "SDM.maxCountErrorMessage";
-  public static final String FETCH_CHANGELOG_ERROR_KEY = "SDM.fetchChangelogError";
-  public static final String FAILED_TO_MOVE_ATTACHMENT_KEY = "SDM.failedToMoveAttachment";
-  public static final String INVALID_SECONDARY_PROPERTIES_FOR_MOVE_PREFIX_KEY =
-      "SDM.invalidSecondaryPropertiesForMovePrefix";
-  public static final String INVALID_SECONDARY_PROPERTIES_FOR_MOVE_SUFFIX_KEY =
-      "SDM.invalidSecondaryPropertiesForMoveSuffix";
-  public static final String SDM_MOVE_OPERATION_FAILED_KEY = "SDM.sdmMoveOperationFailed";
+  public static final String EVENT_CREATE_KEY = "SDM.eventCreate";
+  public static final String EVENT_UPDATE_KEY = "SDM.eventUpdate";
   public static final String FAILED_TO_ACCESS_ERROR_KEY_FIELDS_KEY =
       "SDM.failedToAccessErrorKeyFields";
   public static final String FAILED_TO_ACCESS_ERROR_MESSAGES_FIELDS_KEY =

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorMessages.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorMessages.java
@@ -19,9 +19,8 @@ public class SDMErrorMessages {
 
   public static final String COULD_NOT_UPDATE_THE_ATTACHMENT = "Could not update the attachment";
   public static final String ATTACHMENT_NOT_FOUND = "Attachment not found";
-  public static final String GENERIC_ERROR = "Could not %s the document.";
-  public static final String EVENT_UPLOAD = "upload";
-  public static final String EVENT_DELETE = "delete";
+  public static final String COULD_NOT_UPLOAD_DOCUMENT = "Could not upload the document.";
+  public static final String COULD_NOT_DELETE_DOCUMENT = "Could not delete the document.";
   public static final String VERSIONED_REPO_ERROR =
       "Upload not supported for versioned repositories.";
   public static final String VIRUS_REPO_ERROR_MORE_THAN_400MB =
@@ -263,8 +262,12 @@ public class SDMErrorMessages {
     return duplicateFilenameFormat(filenames);
   }
 
-  public static String getGenericError(String event) {
-    return String.format(SDMUtils.getErrorMessage("GENERIC_ERROR"), event);
+  public static String getCouldNotUploadDocument() {
+    return SDMUtils.getErrorMessage("COULD_NOT_UPLOAD_DOCUMENT");
+  }
+
+  public static String getCouldNotDeleteDocument() {
+    return SDMUtils.getErrorMessage("COULD_NOT_DELETE_DOCUMENT");
   }
 
   public static String getVirusFilesError(String filename) {

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMUIErrorKeys.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMUIErrorKeys.java
@@ -1,0 +1,105 @@
+package com.sap.cds.sdm.constants;
+
+import com.sap.cds.sdm.utilities.SDMUtils;
+import com.sap.cds.services.ServiceException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** UI-Facing Error Keys for Localization. */
+public final class SDMUIErrorKeys {
+  private SDMUIErrorKeys() {}
+
+  // Document Operations
+  public static final String COULD_NOT_UPLOAD_DOCUMENT_KEY = "SDM.couldNotUploadDocument";
+  public static final String COULD_NOT_DELETE_DOCUMENT_KEY = "SDM.couldNotDeleteDocument";
+  public static final String COULD_NOT_UPDATE_THE_ATTACHMENT_KEY =
+      "SDM.couldNotUpdateTheAttachment";
+  public static final String ATTACHMENT_NOT_FOUND_KEY = "SDM.attachmentNotFound";
+  public static final String UPDATE_ATTACHMENT_ERROR_KEY = "SDM.updateAttachmentError";
+  public static final String FAILED_TO_COPY_ATTACHMENT_KEY = "SDM.failedToCopyAttachment";
+  public static final String FAILED_TO_MOVE_ATTACHMENT_KEY = "SDM.failedToMoveAttachment";
+  public static final String SDM_MOVE_OPERATION_FAILED_KEY = "SDM.sdmMoveOperationFailed";
+  public static final String FETCH_CHANGELOG_ERROR_KEY = "SDM.fetchChangelogError";
+
+  // Repository Errors
+  public static final String VERSIONED_REPO_ERROR_KEY = "SDM.Repository.versionedRepoError";
+  public static final String VIRUS_REPO_ERROR_MORE_THAN_400MB_KEY =
+      "SDM.virusRepoErrorMoreThan400MB";
+  public static final String REPOSITORY_ERROR_KEY = "SDM.repositoryError";
+  public static final String FILE_NOT_FOUND_ERROR_KEY = "SDM.fileNotFoundError";
+
+  // Authorization Errors
+  public static final String SDM_MISSING_ROLES_EXCEPTION_KEY = "SDM.sdmMissingRolesException";
+  public static final String USER_NOT_AUTHORISED_ERROR_KEY = "SDM.userNotAuthorisedError";
+  public static final String USER_NOT_AUTHORISED_ERROR_LINK_KEY = "SDM.userNotAuthorisedErrorLink";
+  public static final String MIMETYPE_INVALID_ERROR_KEY = "SDM.mimetypeInvalidError";
+
+  // Virus Scanning Errors
+  public static final String VIRUS_ERROR_KEY = "SDM.virusError";
+  public static final String VIRUS_DETECTED_FILE_ERROR_KEY = "SDM.virusDetectedFileError";
+  public static final String VIRUS_SCAN_IN_PROGRESS_FILE_ERROR_KEY =
+      "SDM.virusScanInProgressFileError";
+  public static final String UPLOAD_IN_PROGRESS_FILE_ERROR_KEY = "SDM.uploadInProgressFileError";
+  public static final String VIRUS_DETECTED_FILES_PREFIX_KEY = "SDM.virusDetectedFilesPrefix";
+  public static final String VIRUS_DETECTED_FILES_SUFFIX_KEY = "SDM.virusDetectedFilesSuffix";
+  public static final String VIRUS_SCAN_IN_PROGRESS_FILES_PREFIX_KEY =
+      "SDM.virusScanInProgressFilesPrefix";
+  public static final String VIRUS_SCAN_IN_PROGRESS_FILES_SUFFIX_KEY =
+      "SDM.virusScanInProgressFilesSuffix";
+  public static final String SCAN_FAILED_FILES_PREFIX_KEY = "SDM.scanFailedFilesPrefix";
+  public static final String SCAN_FAILED_FILES_SUFFIX_KEY = "SDM.scanFailedFilesSuffix";
+  public static final String UPLOAD_IN_PROGRESS_FILES_PREFIX_KEY =
+      "SDM.uploadInProgressFilesPrefix";
+  public static final String UPLOAD_IN_PROGRESS_FILES_SUFFIX_KEY =
+      "SDM.uploadInProgressFilesSuffix";
+
+  // File Validation Errors
+  public static final String FILENAME_WHITESPACE_ERROR_MESSAGE_KEY =
+      "SDM.filenameWhitespaceErrorMessage";
+  public static final String SINGLE_RESTRICTED_CHARACTER_IN_FILE_KEY =
+      "SDM.singleRestrictedCharacterInFile";
+  public static final String RESTRICTED_CHARACTERS_IN_MULTIPLE_FILES_KEY =
+      "SDM.restrictedCharactersInMultipleFiles";
+  public static final String SINGLE_DUPLICATE_FILENAME_KEY = "SDM.singleDuplicateFilename";
+  public static final String MULTIPLE_DUPLICATE_FILENAMES_PREFIX_KEY =
+      "SDM.multipleDuplicateFilenamesPrefix";
+  public static final String MULTIPLE_DUPLICATE_FILENAMES_SUFFIX_KEY =
+      "SDM.multipleDuplicateFilenamesSuffix";
+
+  // Update Operation Errors
+  public static final String FILE_NOT_FOUND_PREFIX_KEY = "SDM.fileNotFoundPrefix";
+  public static final String FILE_NOT_FOUND_SUFFIX_KEY = "SDM.fileNotFoundSuffix";
+  public static final String BAD_REQUEST_PREFIX_KEY = "SDM.badRequestPrefix";
+  public static final String BAD_REQUEST_SUFFIX_KEY = "SDM.badRequestSuffix";
+  public static final String NO_SDM_ROLES_PREFIX_KEY = "SDM.noSdmRolesPrefix";
+
+  // Server/Other Errors
+  public static final String SDM_SERVER_ERROR_KEY = "SDM.sdmServerError";
+  public static final String UNSUPPORTED_PROPERTIES_KEY = "SDM.unsupportedProperties";
+  public static final String UNSUPPORTED_PROPERTIES_PREFIX_KEY = "SDM.unsupportedPropertiesPrefix";
+  public static final String UNSUPPORTED_PROPERTIES_SUFFIX_KEY = "SDM.unsupportedPropertiesSuffix";
+  public static final String INVALID_SECONDARY_PROPERTIES_FOR_MOVE_PREFIX_KEY =
+      "SDM.invalidSecondaryPropertiesForMovePrefix";
+  public static final String INVALID_SECONDARY_PROPERTIES_FOR_MOVE_SUFFIX_KEY =
+      "SDM.invalidSecondaryPropertiesForMoveSuffix";
+  public static final String MAX_COUNT_ERROR_MESSAGE_KEY = "SDM.maxCountErrorMessage";
+
+  public static Map<String, Object> getAllUIErrorKeys() {
+    Map<String, Object> out = new LinkedHashMap<>();
+    for (Field f : SDMUIErrorKeys.class.getDeclaredFields()) {
+      int m = f.getModifiers();
+      if (Modifier.isPublic(m) && Modifier.isStatic(m) && Modifier.isFinal(m)) {
+        try {
+          out.put(f.getName(), f.get(null));
+        } catch (IllegalAccessException ignored) {
+          throw new ServiceException(
+              SDMUtils.getErrorMessage("FAILED_TO_ACCESS_ERROR_KEY_FIELDS"), ignored);
+        }
+      }
+    }
+    return Collections.unmodifiableMap(out);
+  }
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMReadAttachmentsHandler.java
@@ -11,8 +11,8 @@ import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.sdm.caching.CacheConfig;
 import com.sap.cds.sdm.caching.ErrorMessageKey;
 import com.sap.cds.sdm.constants.SDMConstants;
-import com.sap.cds.sdm.constants.SDMErrorKeys;
 import com.sap.cds.sdm.constants.SDMErrorMessages;
+import com.sap.cds.sdm.constants.SDMUIErrorKeys;
 import com.sap.cds.sdm.handler.TokenHandler;
 import com.sap.cds.sdm.handler.applicationservice.helper.SDMBeforeReadItemsModifier;
 import com.sap.cds.sdm.handler.common.SDMApplicationHandlerHelper;
@@ -88,7 +88,7 @@ public class SDMReadAttachmentsHandler implements EventHandler {
     }
 
     Map<String, Object> errorMessages = SDMErrorMessages.getAllErrorMessages();
-    Map<String, Object> errorKeys = SDMErrorKeys.getAllErrorKeys();
+    Map<String, Object> errorKeys = SDMUIErrorKeys.getAllUIErrorKeys();
     logger.debug("Caching {} error messages", errorMessages.size());
     String localizedMessage;
     String localizedErrorMessageKey;

--- a/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/DocumentUploadService.java
@@ -470,8 +470,7 @@ public class DocumentUploadService {
       logger.debug("END: formResponse - status: {} for file: {}", status, name);
     } catch (IOException e) {
       logger.error("Error forming response: {}", e.getMessage(), e);
-      throw new ServiceException(
-          SDMErrorMessages.getGenericError(SDMUtils.getErrorMessage("EVENT_UPLOAD")), e);
+      throw new ServiceException(SDMErrorMessages.getCouldNotUploadDocument(), e);
     }
   }
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -530,8 +530,7 @@ public class SDMServiceImpl implements SDMService {
       logger.debug("END: getFolderIdByPath - folderId: {}", folderId);
       return folderId;
     } catch (IOException e) {
-      throw new ServiceException(
-          SDMErrorMessages.getGenericError(SDMUtils.getErrorMessage("EVENT_UPLOAD")));
+      throw new ServiceException(SDMErrorMessages.getCouldNotUploadDocument());
     }
   }
 
@@ -692,8 +691,7 @@ public class SDMServiceImpl implements SDMService {
       return statusCode;
     } catch (IOException e) {
       logger.error("Error deleting document {}: {}", objectId, e.getMessage(), e);
-      throw new ServiceException(
-          SDMErrorMessages.getGenericError(SDMUtils.getErrorMessage("EVENT_DELETE")));
+      throw new ServiceException(SDMErrorMessages.getCouldNotDeleteDocument());
     }
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -363,8 +363,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
           createResult != null ? createResult.toString() : "null");
     } catch (Exception e) {
       logger.error("Error creating document in SDM service: {}", e.getMessage(), e);
-      throw new ServiceException(
-          SDMErrorMessages.getGenericError(AttachmentService.EVENT_CREATE_ATTACHMENT), e);
+      throw new ServiceException(SDMErrorMessages.getCouldNotUploadDocument(), e);
     }
 
     logger.info(

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -544,10 +544,7 @@ public class SDMServiceImplTest {
                 sdmServiceImpl.getFolderIdByPath(
                     "parentId", "repositoryId", mockSdmCredentials, false));
 
-    assertTrue(
-        exception
-            .getMessage()
-            .contains(SDMErrorMessages.getGenericError(SDMUtils.getErrorMessage("EVENT_UPLOAD"))));
+    assertTrue(exception.getMessage().contains(SDMErrorMessages.getCouldNotUploadDocument()));
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

Separates error keys into SDMUIErrrorKeys (UI messages - need translation) and SDMErrrorKeys (backend - no translation needed).
Also adds couldNotUploadDocument and couldNotDeleteDocument keys to replace variable-based genericError 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single tenant Integration test
https://github.com/cap-java/sdm/actions/runs/23642925702

Multi tenant Integration test
https://github.com/cap-java/sdm/actions/runs/23659995046
