### PR TITLE
SDM binding and technical user customer issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.8.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.8.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -34,7 +34,7 @@
         <test-generation-folder>src/test/gen</test-generation-folder>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <attachments_version>1.4.0</attachments_version>
+        <attachments_version>1.5.0</attachments_version>
         <lombok.version>1.18.36</lombok.version>
         <jacoco.version>0.8.7</jacoco.version>
         <ehcache-version>3.10.8</ehcache-version>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -34,7 +34,7 @@
         <test-generation-folder>src/test/gen</test-generation-folder>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <attachments_version>1.3.1</attachments_version>
+        <attachments_version>1.4.0</attachments_version>
         <lombok.version>1.18.36</lombok.version>
         <jacoco.version>0.8.7</jacoco.version>
         <ehcache-version>3.10.8</ehcache-version>

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/TokenHandler.java
@@ -71,7 +71,7 @@ public class TokenHandler {
         DefaultServiceBindingAccessor.getInstance().getServiceBindings();
     ServiceBinding sdmBinding =
         allServiceBindings.stream()
-            .filter(binding -> "sdm".equalsIgnoreCase(binding.getServiceName().orElse(null)))
+            .filter(binding -> binding.getTags().contains("sdm"))
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("SDM binding not found"));
     return sdmBinding.getCredentials();

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -20,6 +20,7 @@ import com.sap.cds.sdm.service.handler.AttachmentMoveEventContext;
 import com.sap.cds.sdm.utilities.SDMUtils;
 import com.sap.cds.services.ServiceException;
 import com.sap.cds.services.persistence.PersistenceService;
+import java.time.Instant;
 import java.util.*;
 import java.util.ArrayList;
 import org.slf4j.Logger;
@@ -426,6 +427,7 @@ public class DBQuery {
     updatedFields.put("repositoryId", repositoryId);
     updatedFields.put("folderId", cmisDocument.getFolderId());
     updatedFields.put("status", "Clean");
+    updatedFields.put("scannedAt", Instant.now());
     updatedFields.put("type", "sap-icon://document");
     updatedFields.put("mimeType", cmisDocument.getMimeType());
     updatedFields.put("uploadStatus", cmisDocument.getUploadStatus());

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -181,7 +181,8 @@ public class SDMAttachmentsService extends ServiceDelegator
     return new AttachmentModificationResult(
         Boolean.TRUE.equals(createContext.getIsInternalStored()),
         createContext.getContentId(),
-        createContext.getData().getStatus());
+        createContext.getData().getStatus(),
+        null);
   }
 
   @Override

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMAttachmentsService.java
@@ -182,7 +182,7 @@ public class SDMAttachmentsService extends ServiceDelegator
         Boolean.TRUE.equals(createContext.getIsInternalStored()),
         createContext.getContentId(),
         createContext.getData().getStatus(),
-        null);
+        Instant.now());
   }
 
   @Override

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -33,7 +33,8 @@ public interface SDMService {
 
   public JSONObject getRepositoryInfo(SDMCredentials sdmCredentials) throws IOException;
 
-  public int deleteDocument(String cmisaction, String objectId, String user) throws IOException;
+  public int deleteDocument(String cmisaction, String objectId, String user, Boolean isSystemUser)
+      throws IOException;
 
   public void readDocument(
       String objectId, SDMCredentials sdmCredentials, AttachmentReadEventContext context)

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -660,13 +660,17 @@ public class SDMServiceImpl implements SDMService {
   }
 
   @Override
-  public int deleteDocument(String cmisaction, String objectId, String user) {
+  public int deleteDocument(String cmisaction, String objectId, String user, Boolean isSytemUser) {
     logger.info(
-        "Deleting document - action: {}, objectId: {}, user: {}", cmisaction, objectId, user);
+        "Deleting document - action: {}, objectId: {}, user: {},isSystemUser :{}",
+        cmisaction,
+        objectId,
+        user,
+        isSytemUser);
     long startTime = System.currentTimeMillis();
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
     HttpClient httpClient;
-    if (user.equals(SDMConstants.SYSTEM_USER)) {
+    if (isSytemUser) {
       logger.debug("Using TECHNICAL_USER_FLOW for deletion");
       httpClient = tokenHandler.getHttpClient(binding, connectionPool, null, TECHNICAL_USER_FLOW);
     } else {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -25,6 +25,7 @@ import com.sap.cds.services.persistence.PersistenceService;
 import com.sap.cds.services.utils.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.json.JSONObject;
@@ -524,6 +525,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
               eventContext.setContentId(
                   existing.getObjectId() + ":" + existing.getFolderId() + ":" + activeEntityName);
               eventContext.getData().setStatus("Clean");
+              eventContext.getData().setScannedAt(Instant.now());
               eventContext.getData().setContent(null);
               eventContext.setCompleted();
               return;
@@ -628,6 +630,7 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
             + ":"
             + eventContext.getAttachmentEntity().getQualifiedName());
     eventContext.getData().setStatus("Clean");
+    eventContext.getData().setScannedAt(Instant.now());
     eventContext.getData().setContent(null);
     eventContext.setCompleted();
     logger.debug("Attachment context finalized and marked as completed");

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandler.java
@@ -107,12 +107,20 @@ public class SDMAttachmentsServiceHandler implements EventHandler {
       if (cmisDocuments.isEmpty()) {
         // deleteFolder API
         logger.info("Deleting folder: {} for entity: {}", folderId, entity);
-        sdmService.deleteDocument("deleteTree", folderId, context.getDeletionUserInfo().getName());
+        sdmService.deleteDocument(
+            "deleteTree",
+            folderId,
+            context.getDeletionUserInfo().getName(),
+            context.getDeletionUserInfo().getIsSystemUser());
         logger.info("Folder deleted successfully: {}", folderId);
       } else {
         if (!isObjectIdPresent(cmisDocuments, objectId)) {
           logger.info("Deleting document: {} from repository", objectId);
-          sdmService.deleteDocument("delete", objectId, context.getDeletionUserInfo().getName());
+          sdmService.deleteDocument(
+              "delete",
+              objectId,
+              context.getDeletionUserInfo().getName(),
+              context.getDeletionUserInfo().getIsSystemUser());
           logger.info("Document deleted successfully: {}", objectId);
         } else {
           logger.debug("ObjectId {} is still referenced, not deleting", objectId);

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMCustomServiceHandler.java
@@ -1525,13 +1525,20 @@ public class SDMCustomServiceHandler {
     logger.error("Copy failure detected, initiating cleanup. Error: {}", e.getMessage());
     if (!folderExists) {
       logger.debug("Deleting newly created folder: {}", folderId);
-      sdmService.deleteDocument("deleteTree", folderId, context.getUserInfo().getName());
+      sdmService.deleteDocument(
+          "deleteTree",
+          folderId,
+          context.getUserInfo().getName(),
+          context.getUserInfo().isSystemUser());
     } else {
       logger.debug(
           "Deleting {} copied attachments from existing folder", attachmentsMetadata.size());
       for (Map<String, String> attachmentMetadata : attachmentsMetadata) {
         sdmService.deleteDocument(
-            "delete", attachmentMetadata.get("cmis:objectId"), context.getUserInfo().getName());
+            "delete",
+            attachmentMetadata.get("cmis:objectId"),
+            context.getUserInfo().getName(),
+            context.getUserInfo().isSystemUser());
       }
     }
     throw new ServiceException(e.getMessage());

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/TokenHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/TokenHandlerTest.java
@@ -140,7 +140,7 @@ public class TokenHandlerTest {
       mockCredentials.put("uaa", mockUaa);
       mockCredentials.put("uri", "https://mock.service.url");
 
-      Mockito.when(mockServiceBinding.getServiceName()).thenReturn(Optional.of("sdm"));
+      Mockito.when(mockServiceBinding.getTags()).thenReturn(Collections.singletonList("sdm"));
       Mockito.when(mockServiceBinding.getCredentials()).thenReturn(mockCredentials);
 
       List<ServiceBinding> mockServiceBindings = Collections.singletonList(mockServiceBinding);
@@ -202,7 +202,7 @@ public class TokenHandlerTest {
       mockCredentials.put("uaa", mockUaa);
       mockCredentials.put("uri", "https://mock.service.url");
 
-      Mockito.when(mockServiceBinding.getServiceName()).thenReturn(Optional.of("sdm"));
+      Mockito.when(mockServiceBinding.getTags()).thenReturn(Collections.singletonList("sdm"));
       Mockito.when(mockServiceBinding.getCredentials()).thenReturn(mockCredentials);
 
       List<ServiceBinding> mockServiceBindings = Collections.singletonList(mockServiceBinding);

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -809,10 +809,14 @@ public class SDMServiceImplTest {
       when(response.getEntity()).thenReturn(entity);
       when(mockContext.getDeletionUserInfo()).thenReturn(deletionUserInfo);
       when(deletionUserInfo.getName()).thenReturn("system-internal");
+      when(deletionUserInfo.getIsSystemUser()).thenReturn(true);
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
       int actualResponse =
           sdmServiceImpl.deleteDocument(
-              "deleteTree", "objectId", mockContext.getDeletionUserInfo().getName());
+              "deleteTree",
+              "objectId",
+              mockContext.getDeletionUserInfo().getName(),
+              mockContext.getDeletionUserInfo().getIsSystemUser());
       assertEquals(200, actualResponse);
     } finally {
       mockWebServer.shutdown();
@@ -841,7 +845,10 @@ public class SDMServiceImplTest {
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
       int actualResponse =
           sdmServiceImpl.deleteDocument(
-              "deleteTree", "objectId", mockContext.getDeletionUserInfo().getName());
+              "deleteTree",
+              "objectId",
+              mockContext.getDeletionUserInfo().getName(),
+              mockContext.getDeletionUserInfo().getIsSystemUser());
       assertEquals(200, actualResponse);
     } finally {
       mockWebServer.shutdown();
@@ -903,10 +910,14 @@ public class SDMServiceImplTest {
       when(tokenHandler.getSDMCredentials()).thenReturn(mockSdmCredentials);
       when(mockContext.getDeletionUserInfo()).thenReturn(deletionUserInfo);
       when(deletionUserInfo.getName()).thenReturn("system-internal");
+      when(deletionUserInfo.getIsSystemUser()).thenReturn(true);
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
       int actualResponse =
           sdmServiceImpl.deleteDocument(
-              "delete", "objectId", mockContext.getDeletionUserInfo().getName());
+              "delete",
+              "objectId",
+              mockContext.getDeletionUserInfo().getName(),
+              mockContext.getDeletionUserInfo().getIsSystemUser());
       assertEquals(200, actualResponse);
     } finally {
       mockWebServer.shutdown();
@@ -934,7 +945,10 @@ public class SDMServiceImplTest {
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
       int actualResponse =
           sdmServiceImpl.deleteDocument(
-              "delete", "objectId", mockContext.getDeletionUserInfo().getName());
+              "delete",
+              "objectId",
+              mockContext.getDeletionUserInfo().getName(),
+              mockContext.getDeletionUserInfo().getIsSystemUser());
       assertEquals(200, actualResponse);
     } finally {
       mockWebServer.shutdown();
@@ -961,10 +975,14 @@ public class SDMServiceImplTest {
       when(tokenHandler.getSDMCredentials()).thenReturn(mockSdmCredentials);
       when(mockContext.getDeletionUserInfo()).thenReturn(deletionUserInfo);
       when(deletionUserInfo.getName()).thenReturn("system-internal");
+      when(deletionUserInfo.getIsSystemUser()).thenReturn(true);
       SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
       int actualResponse =
           sdmServiceImpl.deleteDocument(
-              "delete", "ewdwe", mockContext.getDeletionUserInfo().getName());
+              "delete",
+              "ewdwe",
+              mockContext.getDeletionUserInfo().getName(),
+              mockContext.getDeletionUserInfo().getIsSystemUser());
       assertEquals(404, actualResponse);
     } finally {
       mockWebServer.shutdown();
@@ -1296,12 +1314,16 @@ public class SDMServiceImplTest {
     SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
     when(mockContext.getDeletionUserInfo()).thenReturn(deletionUserInfo);
     when(deletionUserInfo.getName()).thenReturn("system-internal");
+    when(deletionUserInfo.getIsSystemUser()).thenReturn(true);
     // Ensure ServiceException is thrown
     assertThrows(
         ServiceException.class,
         () ->
             sdmServiceImpl.deleteDocument(
-                "delete", "123", mockContext.getDeletionUserInfo().getName()));
+                "delete",
+                "123",
+                mockContext.getDeletionUserInfo().getName(),
+                mockContext.getDeletionUserInfo().getIsSystemUser()));
   }
 
   @Test

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMAttachmentsServiceHandlerTest.java
@@ -1425,7 +1425,8 @@ public class SDMAttachmentsServiceHandlerTest {
         .deleteDocument(
             "delete",
             objectId,
-            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getName());
+            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getName(),
+            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getIsSystemUser());
   }
 
   @Test
@@ -1461,7 +1462,8 @@ public class SDMAttachmentsServiceHandlerTest {
         .deleteDocument(
             "deleteTree",
             folderId,
-            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getName());
+            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getName(),
+            attachmentMarkAsDeletedEventContext.getDeletionUserInfo().getIsSystemUser());
   }
 
   @Test
@@ -2054,7 +2056,7 @@ public class SDMAttachmentsServiceHandlerTest {
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
     verify(deleteContext).setCompleted();
-    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString());
+    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString(), anyBoolean());
   }
 
   @Test
@@ -2068,7 +2070,7 @@ public class SDMAttachmentsServiceHandlerTest {
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
     verify(deleteContext).setCompleted();
-    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString());
+    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString(), anyBoolean());
   }
 
   @Test
@@ -2083,7 +2085,7 @@ public class SDMAttachmentsServiceHandlerTest {
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
     verify(deleteContext).setCompleted();
-    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString());
+    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString(), anyBoolean());
   }
 
   @Test
@@ -2103,7 +2105,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
-    verify(sdmService).deleteDocument("deleteTree", "folderId", "testUser");
+    verify(sdmService).deleteDocument("deleteTree", "folderId", "testUser", false);
     verify(deleteContext).setCompleted();
   }
 
@@ -2127,7 +2129,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
-    verify(sdmService).deleteDocument("delete", "objectId", "testUser");
+    verify(sdmService).deleteDocument("delete", "objectId", "testUser", false);
     verify(deleteContext).setCompleted();
   }
 
@@ -2151,7 +2153,7 @@ public class SDMAttachmentsServiceHandlerTest {
 
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
-    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString());
+    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString(), anyBoolean());
     verify(deleteContext).setCompleted();
   }
 
@@ -2416,7 +2418,7 @@ public class SDMAttachmentsServiceHandlerTest {
     handlerSpy.markAttachmentAsDeleted(deleteContext);
 
     // Should not call delete on either document since target is present
-    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString());
+    verify(sdmService, never()).deleteDocument(anyString(), anyString(), anyString(), anyBoolean());
     verify(deleteContext).setCompleted();
   }
 

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMCustomServiceHandlerTest.java
@@ -242,7 +242,8 @@ public class SDMCustomServiceHandlerTest {
             });
 
     // Verify that deleteDocument was called for cleanup of the first successful attachment
-    verify(sdmService, times(1)).deleteDocument(eq("delete"), eq(OBJECT_ID), eq("testUser"));
+    verify(sdmService, times(1))
+        .deleteDocument(eq("delete"), eq(OBJECT_ID), eq("testUser"), eq(false));
     assertTrue(exception.getMessage().contains("Copy failed"));
   }
 
@@ -279,7 +280,7 @@ public class SDMCustomServiceHandlerTest {
             });
 
     // Should attempt to delete the folder
-    verify(sdmService, times(1)).deleteDocument(eq("deleteTree"), eq(FOLDER_ID), any());
+    verify(sdmService, times(1)).deleteDocument(eq("deleteTree"), eq(FOLDER_ID), any(), any());
     assertTrue(ex.getMessage().contains("Copy failed"));
   }
 
@@ -320,7 +321,7 @@ public class SDMCustomServiceHandlerTest {
             });
 
     // Should attempt to delete the copied attachment
-    verify(sdmService, times(1)).deleteDocument(eq("delete"), eq(OBJECT_ID), any());
+    verify(sdmService, times(1)).deleteDocument(eq("delete"), eq(OBJECT_ID), any(), any());
     assertTrue(ex.getMessage().contains("Copy failed"));
   }
 


### PR DESCRIPTION
## Describe your changes
In com.sap.cds.sdm.service.SDMServiceImpl in most cases a boolean variable is passed boolean isSystemUser and depending on its value either technical/non technical flow is used.
This variable is determined like this:
Boolean isSystemUser = eventContext.getUserInfo().isSystemUser();

However upon deletion the following check is done:

if (user.equals(SDMConstants.SYSTEM_USER)) {

where SYSTEM_USER = "system-internal"

Enhancement sdm service binding lookup by tags for supporting User-Provided scenario
#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="815" height="206" alt="Screenshot 2026-04-14 at 12 22 45 PM" src="https://github.com/user-attachments/assets/0c88da9f-ba92-42af-a254-f6b956640c27" />

<img width="1715" height="900" alt="Screenshot 2026-04-14 at 12 00 44 PM" src="https://github.com/user-attachments/assets/7ff2d90d-d0a3-40ad-af1f-4e39164b1bb3" />
