### PR TITLE
Leading application changes for the download of multiple attachments

### DIFF
--- a/cap-notebook/demoapp/app/admin-books/webapp/controller/custom.controller.js
+++ b/cap-notebook/demoapp/app/admin-books/webapp/controller/custom.controller.js
@@ -13,6 +13,14 @@ sap.ui.define(
         };
     
         return ControllerExtension.extend("books.controller.custom", {
+            isDownloadEnabled: function(oBindingContext, aSelectedContexts) {
+                if (!aSelectedContexts || aSelectedContexts.length === 0) {
+                    return false;
+                }
+                return !aSelectedContexts.some(function(oContext) {
+                    return oContext.getProperty("mimeType") === "application/internet-shortcut";
+                });
+            },
             onRowPress: function(oContext) {
                 this.base.editFlow
                 .invokeAction("AdminService.openAttachment", {
@@ -90,6 +98,43 @@ sap.ui.define(
             },
             close: function (closeBtn) {
                 closeBtn.getSource().getParent().close();
+            },
+            onDownloadPress: function(oContext, aSelectedContexts) {
+                var sIds = aSelectedContexts.map(function(oCtx) {
+                    return oCtx.getObject().ID;
+                }).join(",");
+                this.base.editFlow
+                .invokeAction("AdminService.downloadSelectedAttachments", {
+                    contexts: aSelectedContexts[0],
+                    parameterValues: [{ name: "ids", value: sIds }],
+                    skipParameterDialog: true
+                })
+                .then(function (res) {
+                    var sJsonResponse = res.getObject().value;
+                    var aEntries = JSON.parse(sJsonResponse);
+                    aEntries.forEach(function (oEntry) {
+                        if (oEntry.status === "success") {
+                            if (oEntry.linkUrl) {
+                                window.open(oEntry.linkUrl, "_blank");
+                            } else if (oEntry.content) {
+                                var byteString = atob(oEntry.content);
+                                var aBytes = new Uint8Array(byteString.length);
+                                for (var i = 0; i < byteString.length; i++) {
+                                    aBytes[i] = byteString.charCodeAt(i);
+                                }
+                                var oBlob = new Blob([aBytes], { type: oEntry.mimeType || "application/octet-stream" });
+                                var sUrl = URL.createObjectURL(oBlob);
+                                var oLink = document.createElement("a");
+                                oLink.href = sUrl;
+                                oLink.download = oEntry.fileName || "download";
+                                document.body.appendChild(oLink);
+                                oLink.click();
+                                document.body.removeChild(oLink);
+                                URL.revokeObjectURL(sUrl);
+                            }
+                        }
+                    });
+                });
             }
         });
     }

--- a/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
+++ b/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
@@ -137,7 +137,7 @@
                 "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -148,7 +148,17 @@
                       "press": ".extension.books.controller.custom.onChangelogPress",
                       "command": "COMMON", "position": { 
                         "anchor": "StandardAction::Create", 
-                        "placement": "After" 
+                        "placement": "After"
+                      }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                      "press": ".extension.books.controller.custom.onDownloadPress",
+                      "position": {
+                        "anchor": "StandardAction::Create", 
+                        "placement": "After"
                       }
                     }
                   }
@@ -156,7 +166,7 @@
                 "references/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -169,13 +179,23 @@
                         "anchor": "StandardAction::Create", 
                         "placement": "After" 
                       }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                      "press": ".extension.books.controller.custom.onDownloadPress",
+                      "position": {
+                        "anchor": "StandardAction::Create",
+                        "placement": "After"
+                      }
                     }
                   }
                 },
                 "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -187,6 +207,16 @@
                       "command": "COMMON", "position": { 
                         "anchor": "StandardAction::Create", 
                         "placement": "After" 
+                      }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                      "press": ".extension.books.controller.custom.onDownloadPress",
+                      "position": {
+                        "anchor": "StandardAction::Create",
+                        "placement": "After"
                       }
                     }
                   }
@@ -207,7 +237,7 @@
                     "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -219,6 +249,16 @@
                           "command": "COMMON", "position": { 
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
                           }
                         }
                       }
@@ -226,7 +266,7 @@
                     "references/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -239,13 +279,23 @@
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
                           }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
+                          }
                         }
                       }
                     },
                     "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -257,6 +307,16 @@
                           "command": "COMMON", "position": { 
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
                           }
                         }
                       }
@@ -278,7 +338,7 @@
                     "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -291,13 +351,23 @@
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
                           } 
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
+                          }
                         }
                       }
                     },
                     "references/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -310,13 +380,23 @@
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
                           }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
+                          }
                         }
                       }
                     },
                     "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -328,6 +408,16 @@
                           "command": "COMMON", "position": { 
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                          "press": ".extension.books.controller.custom.onDownloadPress",
+                          "position": {
+                            "anchor": "StandardAction::Create",
+                            "placement": "After"
                           }
                         }
                       }

--- a/cap-notebook/demoapp/app/index.html
+++ b/cap-notebook/demoapp/app/index.html
@@ -14,7 +14,7 @@
 		};
 	</script>
 
-	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
     <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/resources/sap-ui-core.js"
       data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
       data-sap-ui-compatVersion="edge"

--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -41,6 +41,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
   annotate AdminService.Books.attachments with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isAttachmentsUploadable}}
@@ -75,6 +76,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
   annotate AdminService.Books.references with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isReferencesUploadable}}
@@ -109,6 +111,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Pages.attachments as projection on my.Pages.attachments
@@ -140,6 +143,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Pages.references as projection on my.Pages.references
@@ -170,6 +174,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Chapters projections
@@ -202,6 +207,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.references as projection on my.Chapters.references
@@ -233,6 +239,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.footnotes as projection on my.Chapters.footnotes
@@ -264,6 +271,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Pages footnotes projection
@@ -296,5 +304,6 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 }


### PR DESCRIPTION
## Describe your changes

Users can now select multiple attachments and download them all at once using a single Download button. The button intelligently disables itself when link-type entries are selected. This applies to all attachment sections across Books, Chapters and Pages