### PR TITLE
Leading application changes for the support of download of multiple attachments

### DIFF
--- a/cap-notebook/demoapp/app/admin-books/fiori-service.cds
+++ b/cap-notebook/demoapp/app/admin-books/fiori-service.cds
@@ -48,7 +48,7 @@ annotate AdminService.Books with @(UI: {
       $Type : 'UI.ReferenceFacet',
       Label : '{i18n>Chapters}',
       ID : 'i18nChapters',
-      Target : 'chapters/@UI.LineItem#i18nChapters',
+      Target : 'cHapters/@UI.LineItem#i18nChapters',
     },
     {
       $Type : 'UI.ReferenceFacet',

--- a/cap-notebook/demoapp/app/admin-books/webapp/controller/custom.controller.js
+++ b/cap-notebook/demoapp/app/admin-books/webapp/controller/custom.controller.js
@@ -13,6 +13,14 @@ sap.ui.define(
         };
     
         return ControllerExtension.extend("books.controller.custom", {
+            isDownloadEnabled: function(oBindingContext, aSelectedContexts) {
+                if (!aSelectedContexts || aSelectedContexts.length === 0) {
+                    return false;
+                }
+                return !aSelectedContexts.some(function(oContext) {
+                    return oContext.getProperty("mimeType") === "application/internet-shortcut";
+                });
+            },
             onRowPress: function(oContext) {
                 this.base.editFlow
                 .invokeAction("AdminService.openAttachment", {
@@ -90,6 +98,43 @@ sap.ui.define(
             },
             close: function (closeBtn) {
                 closeBtn.getSource().getParent().close();
+            },
+            onDownloadPress: function(oContext, aSelectedContexts) {
+                var sIds = aSelectedContexts.map(function (oCtx) {
+                    return oCtx.getObject().ID;
+                }).join(",");
+                this.base.editFlow
+                .invokeAction("AdminService.downloadSelectedAttachments", {
+                    contexts: aSelectedContexts[0],
+                    parameterValues: [{ name: "ids", value: sIds }],
+                    skipParameterDialog: true
+                })
+                .then(function (res) {
+                    var sJsonResponse = res.getObject().value;
+                    var aEntries = JSON.parse(sJsonResponse);
+                    aEntries.forEach(function (oEntry) {
+                        if (oEntry.status === "success") {
+                            if (oEntry.linkUrl) {
+                                window.open(oEntry.linkUrl, "_blank");
+                            } else if (oEntry.content) {
+                                var byteString = atob(oEntry.content);
+                                var aBytes = new Uint8Array(byteString.length);
+                                for (var i = 0; i < byteString.length; i++) {
+                                    aBytes[i] = byteString.charCodeAt(i);
+                                }
+                                var oBlob = new Blob([aBytes], { type: oEntry.mimeType || "application/octet-stream" });
+                                var sUrl = URL.createObjectURL(oBlob);
+                                var oLink = document.createElement("a");
+                                oLink.href = sUrl;
+                                oLink.download = oEntry.fileName || "download";
+                                document.body.appendChild(oLink);
+                                oLink.click();
+                                document.body.removeChild(oLink);
+                                URL.revokeObjectURL(sUrl);
+                            }
+                        }
+                    });
+                });
             }
         });
     }

--- a/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
+++ b/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
@@ -137,7 +137,7 @@
                 "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -147,8 +147,18 @@
                       "requiresSelection": true,
                       "press": ".extension.books.controller.custom.onChangelogPress",
                       "command": "COMMON", "position": { 
-                        "anchor": "StandardAction::Create", 
-                        "placement": "After" 
+                      "anchor": "StandardAction::Create", 
+                      "placement": "After" 
+                      }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                      "press": ".extension.admin.controller.custom.onDownloadPress",
+                      "position": {
+                      "anchor": "StandardAction::Create", 
+                      "placement": "After"
                       }
                     }
                   }
@@ -156,7 +166,7 @@
                 "references/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -166,8 +176,18 @@
                       "requiresSelection": true,
                       "press": ".extension.books.controller.custom.onChangelogPress",
                       "command": "COMMON", "position": { 
-                        "anchor": "StandardAction::Create", 
-                        "placement": "After" 
+                      "anchor": "StandardAction::Create",
+                      "placement": "After"
+                      }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                      "press": ".extension.admin.controller.custom.onDownloadPress",
+                      "position": {
+                      "anchor": "StandardAction::Create", 
+                      "placement": "After"
                       }
                     }
                   }
@@ -175,7 +195,7 @@
                 "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                   "tableSettings": {
                     "type": "ResponsiveTable",
-                    "selectionMode": "Auto",
+                    "selectionMode": "Multi",
                     "rowPress": ".extension.books.controller.custom.onRowPress"
                   },
                   "actions": {
@@ -185,8 +205,18 @@
                       "requiresSelection": true,
                       "press": ".extension.books.controller.custom.onChangelogPress",
                       "command": "COMMON", "position": { 
-                        "anchor": "StandardAction::Create", 
-                        "placement": "After" 
+                      "anchor": "StandardAction::Create", 
+                      "placement": "After" 
+                      }
+                    },
+                    "download": {
+                      "text": "Download",
+                      "requiresSelection": true,
+                      "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                      "press": ".extension.admin.controller.custom.onDownloadPress",
+                      "position": {
+                      "anchor": "StandardAction::Create", 
+                      "placement": "After"
                       }
                     }
                   }
@@ -207,7 +237,7 @@
                     "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -217,8 +247,18 @@
                           "requiresSelection": true,
                           "press": ".extension.books.controller.custom.onChangelogPress",
                           "command": "COMMON", "position": { 
-                            "anchor": "StandardAction::Create", 
-                            "placement": "After" 
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
                           }
                         }
                       }
@@ -226,7 +266,7 @@
                     "references/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -236,8 +276,18 @@
                           "requiresSelection": true,
                           "press": ".extension.books.controller.custom.onChangelogPress",
                           "command": "COMMON", "position": { 
-                            "anchor": "StandardAction::Create", 
-                            "placement": "After" 
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
                           }
                         }
                       }
@@ -245,7 +295,7 @@
                     "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -255,8 +305,18 @@
                           "requiresSelection": true,
                           "press": ".extension.books.controller.custom.onChangelogPress",
                           "command": "COMMON", "position": { 
-                            "anchor": "StandardAction::Create", 
-                            "placement": "After" 
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
                           }
                         }
                       }
@@ -278,7 +338,7 @@
                     "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -288,16 +348,26 @@
                           "requiresSelection": true,
                           "press": ".extension.books.controller.custom.onChangelogPress",
                           "command": "COMMON", "position": { 
-                            "anchor": "StandardAction::Create", 
-                            "placement": "After" 
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After" 
                           } 
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
+                          }
                         }
                       }
                     },
                     "references/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -310,13 +380,23 @@
                             "anchor": "StandardAction::Create", 
                             "placement": "After" 
                           }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
+                          }
                         }
                       }
                     },
                     "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                       "tableSettings": {
                         "type": "ResponsiveTable",
-                        "selectionMode": "Auto",
+                        "selectionMode": "Multi",
                         "rowPress": ".extension.books.controller.custom.onRowPress"
                       },
                       "actions": {
@@ -326,8 +406,18 @@
                           "requiresSelection": true,
                           "press": ".extension.books.controller.custom.onChangelogPress",
                           "command": "COMMON", "position": { 
-                            "anchor": "StandardAction::Create", 
-                            "placement": "After" 
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After" 
+                          }
+                        },
+                        "download": {
+                          "text": "Download",
+                          "requiresSelection": true,
+                          "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                          "press": ".extension.admin.controller.custom.onDownloadPress",
+                          "position": {
+                          "anchor": "StandardAction::Create", 
+                          "placement": "After"
                           }
                         }
                       }

--- a/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
+++ b/cap-notebook/demoapp/app/admin-books/webapp/manifest.json
@@ -85,7 +85,7 @@
           "target": "AuthorsDetails"
         },
         {
-          "pattern": "Books({key})/chapters({key2}):?query:",
+          "pattern": "Books({key})/cHapters({key2}):?query:",
           "name": "chaptersObjectPage",
           "target": "ChaptersObjectPage"
         },

--- a/cap-notebook/demoapp/app/common.cds
+++ b/cap-notebook/demoapp/app/common.cds
@@ -64,6 +64,14 @@ annotate my.Books.attachments with @UI: {
     TypeNamePlural: '{i18n>Attachments}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -150,7 +158,15 @@ annotate my.Books.references with @UI: {
     TypeNamePlural: '{i18n>Attachments}',
   },
   LineItem  : [
-     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
+    {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
     {Value: createdAt, @HTML5.CssDefaults: {width: '15%'}},
@@ -231,6 +247,14 @@ annotate my.Books.footnotes with @UI: {
     TypeNamePlural: '{i18n>Attachments}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -312,6 +336,14 @@ annotate my.Chapters.attachments with @UI: {
     TypeNamePlural: '{i18n>Attachments}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -393,6 +425,14 @@ annotate my.Chapters.references with @UI: {
     TypeNamePlural: '{i18n>References}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
      {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -474,6 +514,14 @@ annotate my.Chapters.footnotes with @UI: {
     TypeNamePlural: '{i18n>Footnotes}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -555,6 +603,14 @@ annotate my.Pages.attachments with @UI: {
     TypeNamePlural: '{i18n>Attachments}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -636,6 +692,14 @@ annotate my.Pages.references with @UI: {
     TypeNamePlural: '{i18n>References}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},
@@ -717,6 +781,14 @@ annotate my.Pages.footnotes with @UI: {
     TypeNamePlural: '{i18n>Footnotes}',
   },
   LineItem  : [
+    {
+      $Type : 'UI.DataFieldForAction',
+      Action: 'AdminService.createAttachmentInActive',
+      Label : 'Create Attachment',
+      Inline: false,
+      RequiresSelection: false,
+      ![@UI.Hidden]: {$edmJson: {$Ne: [ {$Path: 'IsActiveEntity'}, true ]}}
+    },
     {Value: type, @HTML5.CssDefaults: {width: '10%'}},
     {Value: fileName, @HTML5.CssDefaults: {width: '20%'}},
     {Value: content, @HTML5.CssDefaults: {width: '0%'}},

--- a/cap-notebook/demoapp/app/index.html
+++ b/cap-notebook/demoapp/app/index.html
@@ -15,7 +15,7 @@
 	</script>
 
 	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-    <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.138.1/resources/sap-ui-core.js"
+    <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/resources/sap-ui-core.js"
       data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
       data-sap-ui-compatVersion="edge"
       data-sap-ui-async="true"

--- a/cap-notebook/demoapp/app/index.html
+++ b/cap-notebook/demoapp/app/index.html
@@ -14,7 +14,7 @@
 		};
 	</script>
 
-	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
     <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.140.0/resources/sap-ui-core.js"
       data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
       data-sap-ui-compatVersion="edge"

--- a/cap-notebook/demoapp/db/pom.xml
+++ b/cap-notebook/demoapp/db/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>sdm</artifactId>
-            <version>1.7.1-SNAPSHOT</version>
+            <version>1.8.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 	

--- a/cap-notebook/demoapp/db/schema.cds
+++ b/cap-notebook/demoapp/db/schema.cds
@@ -18,7 +18,7 @@ currency : Currency;
 image : LargeBinary @Core.MediaType: 'image/png';
 
 // top-level chapters composition (root of the nested hierarchy)
-chapters : Composition of many Chapters on chapters.book = $self;
+cHapters : Composition of many Chapters on cHapters.book = $self;
 
 // top-level pages composition (same pattern as chapters)
 pages : Composition of many Pages on pages.book = $self;

--- a/cap-notebook/demoapp/db/schema.cds
+++ b/cap-notebook/demoapp/db/schema.cds
@@ -16,6 +16,8 @@ stock : Integer;
 price : Decimal;
 currency : Currency;
 image : LargeBinary @Core.MediaType: 'image/png';
+isAttachmentsUploadable : Boolean default true;
+isReferencesUploadable  : Boolean default true;
 
 // top-level chapters composition (root of the nested hierarchy)
 cHapters : Composition of many Chapters on cHapters.book = $self;
@@ -73,6 +75,7 @@ entity Notebooks : managed, cuid {
   price             : Decimal;
   currency          : Currency;
   image             : LargeBinary @Core.MediaType: 'image/png';
+  isAttachmentsUploadable : Boolean default true;
 }
 
 entity Pages : cuid, managed {

--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -22,6 +22,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -50,6 +51,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -78,6 +80,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -106,6 +109,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -134,6 +138,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
     @(Common.SideEffects : {TargetEntities: ['']},)
@@ -162,6 +167,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -190,6 +196,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -218,6 +225,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
@@ -247,6 +255,7 @@ service AdminService @(requires: ['admin','system-user']) {
         up__ID: String, 
         sourceFolderId: String,
         objectIds: String,
+        targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 

--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -41,6 +41,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
   annotate AdminService.Books.attachments with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isAttachmentsUploadable}}
@@ -75,6 +76,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
   annotate AdminService.Books.references with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isReferencesUploadable}}
@@ -109,6 +111,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Pages.attachments as projection on my.Pages.attachments
@@ -140,6 +143,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Pages.references as projection on my.Pages.references
@@ -170,6 +174,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Chapters projections
@@ -202,6 +207,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.references as projection on my.Chapters.references
@@ -233,6 +239,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.footnotes as projection on my.Chapters.footnotes
@@ -264,6 +271,7 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Pages footnotes projection
@@ -296,5 +304,6 @@ service AdminService @(requires: ['admin','system-user']) {
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 }

--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -42,6 +42,9 @@ service AdminService @(requires: ['admin','system-user']) {
     action openAttachment() returns String;
     action changelog() returns String;
   };
+  annotate AdminService.Books.attachments with @(
+    Capabilities: {InsertRestrictions: {Insertable: up_.isAttachmentsUploadable}}
+  );
 
   entity Books.references as projection on my.Books.references
     actions {
@@ -73,6 +76,9 @@ service AdminService @(requires: ['admin','system-user']) {
     action openAttachment() returns String;
     action changelog() returns String;
   };
+  annotate AdminService.Books.references with @(
+    Capabilities: {InsertRestrictions: {Insertable: up_.isReferencesUploadable}}
+  );
 
   entity Books.footnotes as projection on my.Books.footnotes
     actions {

--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -1,3 +1,4 @@
+
 using { sap.capire.bookshop as my } from '../db/schema';
 service AdminService @(requires: ['admin','system-user']) {
 
@@ -13,6 +14,8 @@ service AdminService @(requires: ['admin','system-user']) {
 
   entity Books.attachments as projection on my.Books.attachments
     actions {
+    @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
     @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
@@ -43,6 +46,8 @@ service AdminService @(requires: ['admin','system-user']) {
   entity Books.references as projection on my.Books.references
     actions {
     @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
+    @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
     @(Common.SideEffects : {TargetEntities: ['']})
@@ -71,6 +76,8 @@ service AdminService @(requires: ['admin','system-user']) {
 
   entity Books.footnotes as projection on my.Books.footnotes
     actions {
+    @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
     @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
@@ -101,6 +108,8 @@ service AdminService @(requires: ['admin','system-user']) {
   entity Pages.attachments as projection on my.Pages.attachments
     actions {
     @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
+    @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
     @(Common.SideEffects : {TargetEntities: ['']})
@@ -129,6 +138,8 @@ service AdminService @(requires: ['admin','system-user']) {
 
   entity Pages.references as projection on my.Pages.references
     actions {
+    @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
     @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
@@ -159,6 +170,8 @@ service AdminService @(requires: ['admin','system-user']) {
   entity Chapters.attachments as projection on my.Chapters.attachments
     actions {
     @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
+    @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
     @(Common.SideEffects : {TargetEntities: ['']})
@@ -187,6 +200,8 @@ service AdminService @(requires: ['admin','system-user']) {
 
   entity Chapters.references as projection on my.Chapters.references
     actions {
+    @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
     @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
@@ -217,6 +232,8 @@ service AdminService @(requires: ['admin','system-user']) {
   entity Chapters.footnotes as projection on my.Chapters.footnotes
     actions {
     @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
+    @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature
     @(Common.SideEffects : {TargetEntities: ['']})
@@ -246,6 +263,8 @@ service AdminService @(requires: ['admin','system-user']) {
   // Pages footnotes projection
   entity Pages.footnotes as projection on my.Pages.footnotes
     actions {
+    @(Common.SideEffects : {TargetEntities: ['']},)
+    action createAttachmentInActive(in:many $self);
     @(Common.SideEffects : {TargetEntities: ['']},)
     action copyAttachments(in:many $self, up__ID:String, objectIds:String);
     // moveAttachments action signature

--- a/cap-notebook/demoapp/srv/attachment-extension.cds
+++ b/cap-notebook/demoapp/srv/attachment-extension.cds
@@ -50,7 +50,7 @@ annotate Books.attachments with {
 
 
 annotate Books.references with {
-  content @Validation.Maximum : '100MB';
+  content @Validation.Maximum : '30MB';
   status @(
     Common.Text: {
       $value: ![statusText.text],

--- a/cap-notebook/demoapp/srv/attachment-extension.cds
+++ b/cap-notebook/demoapp/srv/attachment-extension.cds
@@ -50,6 +50,7 @@ annotate Books.attachments with {
 
 
 annotate Books.references with {
+  content @Validation.Maximum : '100MB';
   status @(
     Common.Text: {
       $value: ![statusText.text],

--- a/cap-notebook/demoapp/srv/pom.xml
+++ b/cap-notebook/demoapp/srv/pom.xml
@@ -18,7 +18,7 @@
          <dependency>
           <groupId>com.sap.cds</groupId>
            <artifactId>sdm</artifactId>
-          <version>1.7.1-SNAPSHOT</version>
+          <version>1.8.1-SNAPSHOT</version>
         </dependency>
 
 

--- a/cap-notebook/demoapp/srv/src/main/java/customer/demoapp/handlers/AdminServiceHandler.java
+++ b/cap-notebook/demoapp/srv/src/main/java/customer/demoapp/handlers/AdminServiceHandler.java
@@ -1,0 +1,230 @@
+package customer.demoapp.handlers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.sap.cds.ql.Insert;
+import com.sap.cds.ql.cqn.CqnAnalyzer;
+import com.sap.cds.ql.cqn.CqnComparisonPredicate;
+import com.sap.cds.ql.cqn.CqnConnectivePredicate;
+import com.sap.cds.ql.cqn.CqnElementRef;
+import com.sap.cds.ql.cqn.CqnLiteral;
+import com.sap.cds.ql.cqn.CqnPredicate;
+import com.sap.cds.ql.cqn.CqnReference;
+import com.sap.cds.ql.cqn.CqnSelect;
+import com.sap.cds.ql.cqn.CqnStructuredTypeRef;
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.cds.ApplicationService;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.On;
+import com.sap.cds.services.handler.annotations.ServiceName;
+
+import java.util.List;
+
+import cds.gen.adminservice.AdminService_;
+import cds.gen.adminservice.BooksAttachments_;
+
+/**
+ * Handler for AdminService operations including creating attachments in active entity state.
+ */
+@Component
+@ServiceName(AdminService_.CDS_NAME)
+public class AdminServiceHandler implements EventHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdminServiceHandler.class);
+
+    @Autowired
+    @Qualifier("AdminService")
+    private ApplicationService adminService;
+
+    /**
+     * Handler for createAttachmentInActive action.
+     */
+    @On(event = "createAttachmentInActive")
+    public void createAttachmentInActive(EventContext context) {
+        String targetEntity = context.getTarget().getQualifiedName();
+        logger.info("=== createAttachmentInActive triggered for entity: {} ===", targetEntity);
+        
+        // Guard: When CAP invokes this during draft activation (edit+save),
+        // the "in" parameter contains existing attachment rows.
+        // A user-initiated button click sends "in" as null/empty (RequiresSelection: false).
+        // Skip execution if "in" has items — that means it's a framework save, not a user click.
+        Object inParam = context.get("in");
+        if (inParam instanceof List && !((List<?>) inParam).isEmpty()) {
+            logger.info("Skipping createAttachmentInActive — triggered by framework save (in has {} items), not user click", ((List<?>) inParam).size());
+            context.setCompleted();
+            return;
+        }
+        
+        try {
+            // Extract the parent entity ID from CQN
+            CqnSelect cqn = (CqnSelect) context.get("cqn");
+            CqnAnalyzer analyzer = CqnAnalyzer.create(context.getModel());
+            Map<String, Object> rootKeys = analyzer.analyze(cqn).rootKeys();
+            logger.info("Root keys: {}", rootKeys);
+            
+            // Extract the immediate parent ID.
+            // For non-nested entities (e.g., Books.attachments), rootKeys has {up__ID: bookID}.
+            // For nested entities (e.g., Chapters.attachments via composition path
+            //   Books(bookID)/chapters(chapterID)/attachments), rootKeys only has {ID: bookID}
+            //   and the Chapter ID is in the penultimate CQN path segment's filter.
+            String parentId = extractParentId(cqn, rootKeys);
+            
+            if (parentId == null || parentId.isEmpty()) {
+                logger.error("Could not extract parent ID from CQN. Root keys: {}", rootKeys);
+                context.setCompleted();
+                throw new RuntimeException("Parent entity ID is required to create attachment.");
+            }
+            
+            logger.info("Creating attachment for parent ID: {} in facet: {}", parentId, targetEntity);
+            
+            // Create attachment with unique filename (timestamp prevents any duplicate issues)
+            String attachmentId = createAttachmentWithContent(parentId, targetEntity);
+            logger.info("Attachment created successfully with ID: {}", attachmentId);
+            
+            context.setCompleted();
+            
+        } catch (Exception e) {
+            logger.error("Failed to create attachment: {}", e.getMessage(), e);
+            context.setCompleted();
+            throw new RuntimeException("Failed to create attachment: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Creates an attachment record with content in the active entity state.
+     * Uses a timestamp-based unique filename to prevent duplicate issues.
+     */
+    private String createAttachmentWithContent(String parentId, String targetEntity) throws IOException {
+        String attachmentId = UUID.randomUUID().toString();
+        
+        // Use timestamp in filename to guarantee uniqueness
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS")
+            .withZone(ZoneId.systemDefault())
+            .format(Instant.now());
+        String fileName = "attachment-" + timestamp + ".txt";
+        
+        String sampleContent = "Sample Attachment\n" +
+                               "Created: " + Instant.now() + "\n" +
+                               "Parent ID: " + parentId + "\n" +
+                               "Facet: " + targetEntity + "\n" +
+                               "Attachment ID: " + attachmentId;
+        
+        InputStream contentStream = new ByteArrayInputStream(sampleContent.getBytes(StandardCharsets.UTF_8));
+        
+        Map<String, Object> attachmentData = new HashMap<>();
+        attachmentData.put("ID", attachmentId);
+        attachmentData.put("up__ID", parentId);
+        attachmentData.put("fileName", fileName);
+        attachmentData.put("mimeType", "text/plain");
+        attachmentData.put("note", "Created programmatically in active entity");
+        attachmentData.put("content", contentStream);
+        
+        // Determine which entity to insert into based on the target
+        // The target will be like "AdminService.Books.attachments" or "AdminService.Chapters.attachments" etc.
+        String insertTarget = targetEntity;
+        logger.info("Inserting attachment into: {}", insertTarget);
+        
+        Insert insert = Insert.into(insertTarget).entry(attachmentData);
+        adminService.run(insert);
+        
+        return attachmentId;
+    }
+
+    /**
+     * Extracts the immediate parent entity's ID from the CQN.
+     * 
+     * For non-nested entities (e.g., Books.attachments):
+     *   CQN: SELECT from AdminService.Books.attachments WHERE up__ID = 'bookID'
+     *   rootKeys = {up__ID: bookID} → up__ID found directly.
+     * 
+     * For nested entities (e.g., Chapters.attachments via composition path):
+     *   CQN: SELECT from AdminService.Books[ID='bookID'].chapters[ID='chapterID'].attachments
+     *   rootKeys = {ID: bookID} → up__ID NOT found.
+     *   Fix: traverse CQN path segments and extract ID from the penultimate segment
+     *   (which represents the immediate parent entity, e.g., chapters[ID='chapterID']).
+     */
+    private String extractParentId(CqnSelect cqn, Map<String, Object> rootKeys) {
+        // Case 1: Direct entity set — rootKeys has up__ID
+        Object upId = rootKeys.get("up__ID");
+        if (upId != null) {
+            logger.info("Found up__ID in rootKeys: {}", upId);
+            return upId.toString();
+        }
+
+        // Case 2: Nested composition path — traverse CQN ref segments
+        try {
+            if (cqn.from().isRef()) {
+                CqnStructuredTypeRef ref = cqn.from().asRef();
+                List<? extends CqnReference.Segment> segments = ref.segments();
+                logger.info("CQN path has {} segments", segments.size());
+
+                if (segments.size() >= 2) {
+                    // Penultimate segment is the immediate parent (e.g., "chapters")
+                    CqnReference.Segment parentSegment = segments.get(segments.size() - 2);
+                    logger.info("Parent segment: {}, has filter: {}",
+                            parentSegment.id(), parentSegment.filter().isPresent());
+
+                    if (parentSegment.filter().isPresent()) {
+                        String parentId = extractIdFromPredicate(parentSegment.filter().get());
+                        if (parentId != null) {
+                            logger.info("Extracted parent ID from CQN segment '{}': {}",
+                                    parentSegment.id(), parentId);
+                            return parentId;
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not extract parent ID from CQN path segments: {}", e.getMessage());
+        }
+
+        // Fallback: use ID from rootKeys (correct for non-nested, wrong for nested)
+        Object id = rootKeys.get("ID");
+        if (id != null) {
+            logger.warn("Using fallback ID from rootKeys (may be wrong for nested entities): {}", id);
+            return id.toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Recursively extracts the "ID" value from a CQN predicate.
+     * Handles simple comparisons (ID = 'value') and conjunctions (ID = 'value' AND IsActiveEntity = true).
+     */
+    private String extractIdFromPredicate(CqnPredicate predicate) {
+        if (predicate instanceof CqnComparisonPredicate) {
+            CqnComparisonPredicate comp = (CqnComparisonPredicate) predicate;
+            if (comp.left() instanceof CqnElementRef && comp.right() instanceof CqnLiteral) {
+                String fieldName = ((CqnElementRef) comp.left()).lastSegment();
+                if ("ID".equals(fieldName)) {
+                    return ((CqnLiteral<?>) comp.right()).value().toString();
+                }
+            }
+        } else if (predicate instanceof CqnConnectivePredicate) {
+            // Conjunction (AND) or disjunction (OR) — check each child
+            for (CqnPredicate child : ((CqnConnectivePredicate) predicate).predicates()) {
+                String id = extractIdFromPredicate(child);
+                if (id != null) {
+                    return id;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Describe your changes

Users can now select multiple attachments and download them all at once using a single Download button. The button intelligently disables itself when link-type entries are selected. This applies to all attachment sections across Books, Chapters and Pages
