### PR TITLE
Support download multiple attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - Attachment Upload Status: Upload Status is the new field which displays the upload status of attachment when being uploaded.
 - Active entity attachment creation: Provides the capability to create attachments directly on active (non-draft) entities.
 - Upload button visibility control: Provides the capability to automatically show or hide the Upload button based on the configured `maxCount` limit.
+- Download attachments: Provides the capability to download multiple selected file attachments at once with smart button enablement.
 
 ## Table of Contents
 
@@ -49,6 +50,7 @@ This plugin can be consumed by the CAP application deployed on BTP to store thei
 - [Support for Attachment Upload Status](#support-for-attachment-upload-status)
 - [Support for Attachment creation in Active Entities](#support-for-attachment-creation-in-active-entities)
 - [Support for Upload Button Visibility Control](#support-for-upload-button-visibility-control)
+- [Support for Download Attachments](#support-for-download-attachments)
 - [Known Restrictions](#known-restrictions)
 - [Support, Feedback, Contributing](#support-feedback-contributing)
 - [Code of Conduct](#code-of-conduct)
@@ -1463,6 +1465,106 @@ annotate MyService.Books.references with @(
 ```
 
 > **Note:** No additional Java or configuration changes are required in the leading application. The plugin derives the field name from the facet's composition name automatically.
+
+## Support for Download Attachments
+
+This plugin provides the capability to download multiple selected file attachments at once. The Download button is automatically disabled when any link-type attachment is selected, since links are meant to be opened in the browser and not downloaded as files.
+
+### Steps to Enable Download Attachments Feature
+
+1. **Add the `downloadSelectedAttachments` action to application's service definition**
+
+   See this [example](https://github.com/cap-java/sdm/blob/develop_deploy/cap-notebook/demoapp/srv/admin-service.cds) from a sample Bookshop app.
+
+   Add this action inside the `actions { }` block of each attachment entity:
+
+   ```cds
+   action downloadSelectedAttachments(ids: String) returns String;
+   ```
+
+2. **Add a custom controller extension**
+
+   In `webapp/controller/custom.controller.js`, add the `isDownloadEnabled` and `onDownloadPress` functions.
+
+   See this [example](https://github.com/cap-java/sdm/blob/develop_deploy/cap-notebook/demoapp/app/admin-books/webapp/controller/custom.controller.js) from a sample Bookshop app.
+
+   ```js
+   isDownloadEnabled: function(oBindingContext, aSelectedContexts) {
+       if (!aSelectedContexts || aSelectedContexts.length === 0) {
+           return false;
+       }
+       return !aSelectedContexts.some(function(oContext) {
+           return oContext.getProperty("mimeType") === "application/internet-shortcut";
+       });
+   },
+   onDownloadPress: function(oContext, aSelectedContexts) {
+       var sIds = aSelectedContexts.map(function(oCtx) {
+           return oCtx.getObject().ID;
+       }).join(",");
+       this.base.editFlow
+       .invokeAction("AdminService.downloadSelectedAttachments", {
+           contexts: aSelectedContexts[0],
+           parameterValues: [{ name: "ids", value: sIds }],
+           skipParameterDialog: true
+       })
+       .then(function(res) {
+           var sJsonResponse = res.getObject().value;
+           var aEntries = JSON.parse(sJsonResponse);
+           aEntries.forEach(function(oEntry) {
+               if (oEntry.status === "success" && oEntry.content) {
+                   var byteString = atob(oEntry.content);
+                   var aBytes = new Uint8Array(byteString.length);
+                   for (var i = 0; i < byteString.length; i++) {
+                       aBytes[i] = byteString.charCodeAt(i);
+                   }
+                   var oBlob = new Blob([aBytes], { type: oEntry.mimeType || "application/octet-stream" });
+                   var sUrl = URL.createObjectURL(oBlob);
+                   var oLink = document.createElement("a");
+                   oLink.href = sUrl;
+                   oLink.download = oEntry.fileName || "download";
+                   document.body.appendChild(oLink);
+                   oLink.click();
+                   document.body.removeChild(oLink);
+                   URL.revokeObjectURL(sUrl);
+               }
+           });
+       });
+   }
+   ```
+
+   - Replace `AdminService` in `invokeAction("AdminService.downloadSelectedAttachments")` with the name of your service.
+
+3. **Add `controlConfiguration` for Download Button**
+
+   In your `sap.ui5.routing.targets` section, under the relevant Object Page, update the `controlConfiguration` for each facet by changing the `selectionMode` to `"Multi"` and adding the download action.
+
+   See this [example](https://github.com/cap-java/sdm/blob/develop_deploy/cap-notebook/demoapp/app/admin-books/webapp/manifest.json) from a sample Bookshop app.
+
+   ```json
+   "controlConfiguration": {
+       "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
+           "tableSettings": {
+               "type": "ResponsiveTable",
+               "selectionMode": "Multi",
+               "rowPress": ".extension.books.controller.custom.onRowPress"
+           },
+           "actions": {
+               "download": {
+                   "text": "Download",
+                   "requiresSelection": true,
+                   "enabled": ".extension.books.controller.custom.isDownloadEnabled",
+                   "press": ".extension.books.controller.custom.onDownloadPress",
+                   "position": {
+                       "anchor": "StandardAction::Create",
+                       "placement": "After"
+                   }
+               }
+           }
+       }
+   }
+   ```
+
+   - Replace `attachments` with your entity's facet name as needed.
 
 ## Known Restrictions
 

--- a/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentDownloadContext.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/model/AttachmentDownloadContext.java
@@ -1,0 +1,16 @@
+package com.sap.cds.sdm.model;
+
+import com.sap.cds.services.EventContext;
+import com.sap.cds.services.EventName;
+
+@EventName("downloadSelectedAttachments")
+public interface AttachmentDownloadContext extends EventContext {
+
+  static AttachmentDownloadContext create() {
+    return (AttachmentDownloadContext) EventContext.create(AttachmentDownloadContext.class, null);
+  }
+
+  void setResult(String res);
+
+  String getResult();
+}

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMService.java
@@ -81,4 +81,7 @@ public interface SDMService {
 
   public String getLinkUrl(String objectId, SDMCredentials sdmCredentials, boolean isSystemUser)
       throws IOException;
+
+  public byte[] readDocumentContent(
+      String objectId, SDMCredentials sdmCredentials, boolean isSystemUser) throws IOException;
 }

--- a/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/SDMServiceImpl.java
@@ -371,9 +371,28 @@ public class SDMServiceImpl implements SDMService {
   public void readDocument(
       String objectId, SDMCredentials sdmCredentials, AttachmentReadEventContext context) {
     logger.debug("START: readDocument for objectId: {}", objectId);
+    try {
+      byte[] content =
+          readDocumentContent(objectId, sdmCredentials, context.getUserInfo().isSystemUser());
+      try (InputStream inputStream = new ByteArrayInputStream(content)) {
+        context.getData().setContent(inputStream);
+        logger.debug("END: readDocument - content set in context");
+      }
+    } catch (ServiceException e) {
+      throw e;
+    } catch (Exception e) {
+      logger.error("Error reading document {}: {}", objectId, e.getMessage(), e);
+      throw new ServiceException("Failed to set document stream in context");
+    }
+  }
+
+  @Override
+  public byte[] readDocumentContent(
+      String objectId, SDMCredentials sdmCredentials, boolean isSystemUser) throws IOException {
+    logger.debug("START: readDocumentContent for objectId: {}", objectId);
     String repositoryId = SDMConstants.REPOSITORY_ID;
-    String grantType = context.getUserInfo().isSystemUser() ? TECHNICAL_USER_FLOW : NAMED_USER_FLOW;
-    logger.info("This is a :" + grantType + " flow");
+    String grantType = isSystemUser ? TECHNICAL_USER_FLOW : NAMED_USER_FLOW;
+    logger.info("readDocumentContent - This is a: {} flow", grantType);
     var httpClient = tokenHandler.getHttpClient(binding, connectionPool, null, grantType);
 
     String sdmUrl =
@@ -392,16 +411,19 @@ public class SDMServiceImpl implements SDMService {
         if (responseCode == 404) {
           throw new ServiceException(SDMUtils.getErrorMessage("FILE_NOT_FOUND_ERROR"));
         }
-        throw new ServiceException("Unexpected code");
+        throw new ServiceException("Unexpected code " + responseCode);
       }
       byte[] responseBody = EntityUtils.toByteArray(response.getEntity());
-      try (InputStream inputStream = new ByteArrayInputStream(responseBody)) {
-        context.getData().setContent(inputStream);
-        logger.debug("END: readDocument - content set in context");
-      }
+      logger.debug(
+          "END: readDocumentContent - {} bytes read for objectId: {}",
+          responseBody.length,
+          objectId);
+      return responseBody;
+    } catch (ServiceException e) {
+      throw e;
     } catch (Exception e) {
-      logger.error("Error reading document {}: {}", objectId, e.getMessage(), e);
-      throw new ServiceException("Failed to set document stream in context");
+      logger.error("Error reading document content {}: {}", objectId, e.getMessage(), e);
+      throw new ServiceException("Failed to read document content from repository");
     }
   }
 

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -33,11 +33,13 @@ import com.sap.cds.services.handler.annotations.ServiceName;
 import com.sap.cds.services.persistence.PersistenceService;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -433,6 +435,130 @@ public class SDMServiceGenericHandler implements EventHandler {
       context.setResult("None");
     }
     logger.debug("END: Open attachment event");
+  }
+
+  @On(event = "downloadSelectedAttachments")
+  public void downloadSelectedAttachments(AttachmentDownloadContext context) throws IOException {
+    logger.debug("START: Download selected attachments event");
+    CdsModel cdsModel = context.getModel();
+    Optional<CdsEntity> attachmentDraftEntity =
+        cdsModel.findEntity(context.getTarget().getQualifiedName() + "_drafts");
+    Optional<CdsEntity> attachmentActiveEntity =
+        cdsModel.findEntity(context.getTarget().getQualifiedName());
+
+    List<String> attachmentIds = resolveAttachmentIds(context, cdsModel);
+    logger.debug("Download requested for {} attachment(s)", attachmentIds.size());
+
+    SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
+    boolean isSystemUser = context.getUserInfo().isSystemUser();
+
+    JSONArray resultsArray = new JSONArray();
+    for (String id : attachmentIds) {
+      resultsArray.put(
+          processDownloadAttachment(
+              id, attachmentDraftEntity, attachmentActiveEntity, sdmCredentials, isSystemUser));
+    }
+
+    context.setResult(resultsArray.toString());
+    logger.info("Download completed for {} attachment(s)", attachmentIds.size());
+    logger.debug("END: Download selected attachments event");
+  }
+
+  private List<String> resolveAttachmentIds(AttachmentDownloadContext context, CdsModel cdsModel) {
+    String selectedIdsParam = context.get("ids") != null ? context.get("ids").toString() : null;
+    if (selectedIdsParam != null && !selectedIdsParam.isBlank()) {
+      return Arrays.stream(selectedIdsParam.split(",")).map(String::trim).toList();
+    }
+    CqnAnalyzer cqnAnalyzer = CqnAnalyzer.create(cdsModel);
+    Map<String, Object> targetKeys =
+        cqnAnalyzer.analyze((CqnSelect) context.get("cqn")).targetKeyValues();
+    return List.of(targetKeys.get("ID").toString());
+  }
+
+  private JSONObject processDownloadAttachment(
+      String id,
+      Optional<CdsEntity> draftEntity,
+      Optional<CdsEntity> activeEntity,
+      SDMCredentials sdmCredentials,
+      boolean isSystemUser) {
+    JSONObject result = new JSONObject();
+    result.put("id", id);
+    try {
+      CmisDocument cmisDocument = fetchAttachmentDocument(draftEntity, activeEntity, id);
+      validateDownloadStatus(cmisDocument, id);
+
+      if (SDMConstants.MIMETYPE_INTERNET_SHORTCUT.equalsIgnoreCase(cmisDocument.getMimeType())) {
+        logger.warn("Download not supported for link attachment ID: {}", id);
+        result.put("status", "error");
+        result.put("message", "Download is not supported for link attachments");
+        return result;
+      }
+
+      result.put("fileName", cmisDocument.getFileName());
+      result.put("mimeType", cmisDocument.getMimeType());
+      result.put("status", "success");
+
+      byte[] content =
+          sdmService.readDocumentContent(cmisDocument.getObjectId(), sdmCredentials, isSystemUser);
+      result.put("content", Base64.getEncoder().encodeToString(content));
+      logger.info(
+          "Content fetched for attachment: {} ({} bytes)",
+          cmisDocument.getFileName(),
+          content.length);
+    } catch (ServiceException e) {
+      logger.warn("Failed to download attachment ID {}: {}", id, e.getMessage());
+      result.put("status", "error");
+      result.put("message", e.getMessage());
+    } catch (IOException e) {
+      logger.error("IO error downloading attachment ID {}: {}", id, e.getMessage(), e);
+      result.put("status", "error");
+      result.put("message", "Failed to read attachment content");
+    }
+    return result;
+  }
+
+  private CmisDocument fetchAttachmentDocument(
+      Optional<CdsEntity> draftEntity, Optional<CdsEntity> activeEntity, String id) {
+    CmisDocument cmisDocument = null;
+    if (draftEntity.isPresent()) {
+      cmisDocument = dbQuery.getObjectIdForAttachmentID(draftEntity.get(), persistenceService, id);
+    }
+    if (cmisDocument == null
+        || cmisDocument.getFileName() == null
+        || cmisDocument.getFileName().isEmpty()) {
+      if (activeEntity.isPresent()) {
+        cmisDocument =
+            dbQuery.getObjectIdForAttachmentID(activeEntity.get(), persistenceService, id);
+      }
+    }
+    if (cmisDocument == null
+        || cmisDocument.getObjectId() == null
+        || cmisDocument.getObjectId().isEmpty()) {
+      throw new ServiceException(SDMConstants.FILE_NOT_FOUND_ERROR);
+    }
+    return cmisDocument;
+  }
+
+  private void validateDownloadStatus(CmisDocument cmisDocument, String id) {
+    if (cmisDocument.getUploadStatus() != null
+        && cmisDocument
+            .getUploadStatus()
+            .equalsIgnoreCase(SDMConstants.UPLOAD_STATUS_VIRUS_DETECTED)) {
+      logger.warn("Virus detected in attachment: {}", id);
+      throw new ServiceException(SDMUtils.getErrorMessage("VIRUS_DETECTED_FILE_ERROR"));
+    }
+    if (cmisDocument.getUploadStatus() != null
+        && cmisDocument.getUploadStatus().equalsIgnoreCase(SDMConstants.VIRUS_SCAN_INPROGRESS)) {
+      logger.warn("Virus scan is in progress for attachment: {}", id);
+      throw new ServiceException(SDMUtils.getErrorMessage("VIRUS_SCAN_IN_PROGRESS_FILE_ERROR"));
+    }
+    if (cmisDocument.getUploadStatus() != null
+        && cmisDocument
+            .getUploadStatus()
+            .equalsIgnoreCase(SDMConstants.UPLOAD_STATUS_IN_PROGRESS)) {
+      logger.warn("Upload is in progress for attachment: {}", id);
+      throw new ServiceException(SDMUtils.getErrorMessage("UPLOAD_IN_PROGRESS_FILE_ERROR"));
+    }
   }
 
   private void validateRepository(EventContext eventContext) throws ServiceException, IOException {

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -523,13 +523,11 @@ public class SDMServiceGenericHandler implements EventHandler {
     if (draftEntity.isPresent()) {
       cmisDocument = dbQuery.getObjectIdForAttachmentID(draftEntity.get(), persistenceService, id);
     }
-    if (cmisDocument == null
-        || cmisDocument.getFileName() == null
-        || cmisDocument.getFileName().isEmpty()) {
-      if (activeEntity.isPresent()) {
-        cmisDocument =
-            dbQuery.getObjectIdForAttachmentID(activeEntity.get(), persistenceService, id);
-      }
+    if ((cmisDocument == null
+            || cmisDocument.getFileName() == null
+            || cmisDocument.getFileName().isEmpty())
+        && activeEntity.isPresent()) {
+      cmisDocument = dbQuery.getObjectIdForAttachmentID(activeEntity.get(), persistenceService, id);
     }
     if (cmisDocument == null
         || cmisDocument.getObjectId() == null

--- a/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
+++ b/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
@@ -22,13 +22,14 @@ extend aspect Attachments with {
     type : String @(UI: {IsImageURL: true}) default 'sap-icon://document';
     uploadStatus : UploadStatusCode default 'uploading' @readonly ;
     uploadStatusNav : Association to one UploadScanStates on uploadStatusNav.code = uploadStatus;
-}
-
-entity UploadScanStates : CodeList {
-    key code        : UploadStatusCode @Common.Text: name  @Common.TextArrangement: #TextOnly;
-        name        : String(64) ;
-        criticality : Integer     @UI.Hidden;
-}
+   } actions {
+    action downloadSelectedAttachments(ids: String) returns String;
+   }
+     entity UploadScanStates : CodeList {
+         key code        : UploadStatusCode @Common.Text: name  @Common.TextArrangement: #TextOnly;
+             name        : String(64) ;
+             criticality : Integer     @UI.Hidden;
+     }
 
 annotate Attachments with @UI: {
 

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/SDMServiceImplTest.java
@@ -1137,8 +1137,8 @@ public class SDMServiceImplTest {
               sdmServiceImpl.readDocument(objectId, sdmCredentials, mockContext);
             });
 
-    // Check if the exception message contains the expected first part
-    String expectedMessagePart1 = "Failed to set document stream in context";
+    // Check if the exception message reflects the underlying readDocumentContent error
+    String expectedMessagePart1 = "Unexpected code 500";
     assertTrue(exception.getMessage().contains(expectedMessagePart1));
   }
 
@@ -1158,10 +1158,11 @@ public class SDMServiceImplTest {
 
     when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
     when(response.getStatusLine()).thenReturn(statusLine);
-    when(statusLine.getStatusCode()).thenReturn(500);
+    when(statusLine.getStatusCode()).thenReturn(200);
     when(response.getEntity()).thenReturn(entity);
     InputStream inputStream = new ByteArrayInputStream(expectedContent.getBytes());
     when(entity.getContent()).thenReturn(inputStream);
+    when(entity.getContentLength()).thenReturn((long) expectedContent.length());
 
     SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
 
@@ -2922,5 +2923,118 @@ public class SDMServiceImplTest {
     assertEquals(4, result.size());
     assertEquals("test.pdf", result.get("cmis:name"));
     assertNull(result.get("customProp1"));
+  }
+
+  // ========================= readDocumentContent Tests =========================
+
+  @Test
+  public void testReadDocumentContent_Success() throws IOException {
+    String objectId = "testObjectId";
+    SDMCredentials sdmCredentials = new SDMCredentials();
+
+    String grantType = "TOKEN_EXCHANGE";
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(grantType))).thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+
+    byte[] expectedContent = "Document content here".getBytes();
+    InputStream inputStream = new ByteArrayInputStream(expectedContent);
+    when(entity.getContent()).thenReturn(inputStream);
+    when(entity.getContentLength()).thenReturn((long) expectedContent.length);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    byte[] result = sdmServiceImpl.readDocumentContent(objectId, sdmCredentials, false);
+
+    assertNotNull(result);
+    assertEquals(expectedContent.length, result.length);
+    assertArrayEquals(expectedContent, result);
+  }
+
+  @Test
+  public void testReadDocumentContent_SystemUser() throws IOException {
+    String objectId = "testObjectId";
+    SDMCredentials sdmCredentials = new SDMCredentials();
+
+    String grantType = "TECHNICAL_CREDENTIALS_FLOW";
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(grantType))).thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(response.getEntity()).thenReturn(entity);
+
+    byte[] expectedContent = "System user content".getBytes();
+    InputStream inputStream = new ByteArrayInputStream(expectedContent);
+    when(entity.getContent()).thenReturn(inputStream);
+    when(entity.getContentLength()).thenReturn((long) expectedContent.length);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+    byte[] result = sdmServiceImpl.readDocumentContent(objectId, sdmCredentials, true);
+
+    assertNotNull(result);
+    assertArrayEquals(expectedContent, result);
+  }
+
+  @Test
+  public void testReadDocumentContent_NotFound() throws IOException {
+    String objectId = "testObjectId";
+    SDMCredentials sdmCredentials = new SDMCredentials();
+
+    String grantType = "TOKEN_EXCHANGE";
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(grantType))).thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(404);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream("Not found".getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    assertThrows(
+        ServiceException.class,
+        () -> sdmServiceImpl.readDocumentContent(objectId, sdmCredentials, false));
+  }
+
+  @Test
+  public void testReadDocumentContent_ServerError() throws IOException {
+    String objectId = "testObjectId";
+    SDMCredentials sdmCredentials = new SDMCredentials();
+
+    String grantType = "TOKEN_EXCHANGE";
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(grantType))).thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(500);
+    when(response.getEntity()).thenReturn(entity);
+    InputStream inputStream = new ByteArrayInputStream("Server error".getBytes());
+    when(entity.getContent()).thenReturn(inputStream);
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.readDocumentContent(objectId, sdmCredentials, false));
+    assertTrue(exception.getMessage().contains("Unexpected code"));
+  }
+
+  @Test
+  public void testReadDocumentContent_IOException() throws IOException {
+    String objectId = "testObjectId";
+    SDMCredentials sdmCredentials = new SDMCredentials();
+
+    String grantType = "TOKEN_EXCHANGE";
+    when(tokenHandler.getHttpClient(any(), any(), any(), eq(grantType))).thenReturn(httpClient);
+    when(httpClient.execute(any(HttpGet.class))).thenThrow(new IOException("Connection failed"));
+
+    SDMServiceImpl sdmServiceImpl = new SDMServiceImpl(binding, connectionPool, tokenHandler);
+
+    ServiceException exception =
+        assertThrows(
+            ServiceException.class,
+            () -> sdmServiceImpl.readDocumentContent(objectId, sdmCredentials, false));
+    assertTrue(exception.getMessage().contains("Failed to read document content"));
   }
 }

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -3820,4 +3820,445 @@ public class SDMServiceGenericHandlerTest {
         "com.example.MyService.MyEntity.attachments",
         input.targetFacet()); // Uses full qualified name
   }
+
+  // ========================= Download Selected Attachments Tests =========================
+
+  @Test
+  void testDownloadSelectedAttachments_Success_MultipleIds() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("id1,id2");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument doc1 = new CmisDocument();
+    doc1.setObjectId("obj1");
+    doc1.setFileName("file1.pdf");
+    doc1.setMimeType("application/pdf");
+    doc1.setUploadStatus("Success");
+
+    CmisDocument doc2 = new CmisDocument();
+    doc2.setObjectId("obj2");
+    doc2.setFileName("file2.txt");
+    doc2.setMimeType("text/plain");
+    doc2.setUploadStatus("Success");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "id1")).thenReturn(doc1);
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "id2")).thenReturn(doc2);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    byte[] content1 = "pdf content".getBytes();
+    byte[] content2 = "text content".getBytes();
+    when(sdmService.readDocumentContent("obj1", creds, false)).thenReturn(content1);
+    when(sdmService.readDocumentContent("obj2", creds, false)).thenReturn(content2);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    String result = resultCaptor.getValue();
+    assertNotNull(result);
+    org.json.JSONArray jsonArray = new org.json.JSONArray(result);
+    assertEquals(2, jsonArray.length());
+    assertEquals("success", jsonArray.getJSONObject(0).getString("status"));
+    assertEquals("file1.pdf", jsonArray.getJSONObject(0).getString("fileName"));
+    assertEquals("success", jsonArray.getJSONObject(1).getString("status"));
+    assertEquals("file2.txt", jsonArray.getJSONObject(1).getString("fileName"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_SingleIdFromBoundContext() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnSelect cqnSelect = mock(CqnSelect.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn(null);
+    when(context.get("cqn")).thenReturn(cqnSelect);
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(any(CqnSelect.class))).thenReturn(analysisResult);
+    when(analysisResult.targetKeyValues()).thenReturn(Map.of("ID", "single-id"));
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument doc = new CmisDocument();
+    doc.setObjectId("objSingle");
+    doc.setFileName("single.pdf");
+    doc.setMimeType("application/pdf");
+    doc.setUploadStatus("Success");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "single-id"))
+        .thenReturn(doc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    byte[] content = "single content".getBytes();
+    when(sdmService.readDocumentContent("objSingle", creds, false)).thenReturn(content);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("success", jsonArray.getJSONObject(0).getString("status"));
+    assertEquals("single.pdf", jsonArray.getJSONObject(0).getString("fileName"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_VirusDetected() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("virus-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument virusDoc = new CmisDocument();
+    virusDoc.setObjectId("virusObj");
+    virusDoc.setFileName("infected.exe");
+    virusDoc.setMimeType("application/octet-stream");
+    virusDoc.setUploadStatus("VirusDetected");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "virus-id"))
+        .thenReturn(virusDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("error", jsonArray.getJSONObject(0).getString("status"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_LinkAttachment() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("link-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument linkDoc = new CmisDocument();
+    linkDoc.setObjectId("linkObj");
+    linkDoc.setFileName("bookmark.url");
+    linkDoc.setMimeType("application/internet-shortcut");
+    linkDoc.setUrl("https://example.com");
+    linkDoc.setUploadStatus("Success");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "link-id"))
+        .thenReturn(linkDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("error", jsonArray.getJSONObject(0).getString("status"));
+    assertEquals(
+        "Download is not supported for link attachments",
+        jsonArray.getJSONObject(0).getString("message"));
+    verify(sdmService, never()).readDocumentContent(anyString(), any(), anyBoolean());
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_FallbackToActiveEntity() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity draftEntity = mock(CdsEntity.class);
+    CdsEntity activeEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(draftEntity);
+    when(draftEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("fallback-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(draftEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments"))
+        .thenReturn(Optional.of(activeEntity));
+
+    CmisDocument emptyDoc = new CmisDocument();
+    emptyDoc.setFileName("");
+    emptyDoc.setObjectId("");
+
+    CmisDocument validDoc = new CmisDocument();
+    validDoc.setObjectId("activeObj");
+    validDoc.setFileName("active.pdf");
+    validDoc.setMimeType("application/pdf");
+    validDoc.setUploadStatus("Success");
+
+    when(dbQuery.getObjectIdForAttachmentID(draftEntity, persistenceService, "fallback-id"))
+        .thenReturn(emptyDoc);
+    when(dbQuery.getObjectIdForAttachmentID(activeEntity, persistenceService, "fallback-id"))
+        .thenReturn(validDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    byte[] content = "active content".getBytes();
+    when(sdmService.readDocumentContent("activeObj", creds, false)).thenReturn(content);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("success", jsonArray.getJSONObject(0).getString("status"));
+    assertEquals("active.pdf", jsonArray.getJSONObject(0).getString("fileName"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_UploadInProgress() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("upload-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument uploadingDoc = new CmisDocument();
+    uploadingDoc.setObjectId("uploadObj");
+    uploadingDoc.setFileName("uploading.pdf");
+    uploadingDoc.setMimeType("application/pdf");
+    uploadingDoc.setUploadStatus("uploading");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "upload-id"))
+        .thenReturn(uploadingDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("error", jsonArray.getJSONObject(0).getString("status"));
+    verify(sdmService, never()).readDocumentContent(anyString(), any(), anyBoolean());
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_MixedSuccessAndError() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("good-id,virus-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument goodDoc = new CmisDocument();
+    goodDoc.setObjectId("goodObj");
+    goodDoc.setFileName("good.pdf");
+    goodDoc.setMimeType("application/pdf");
+    goodDoc.setUploadStatus("Success");
+
+    CmisDocument virusDoc = new CmisDocument();
+    virusDoc.setObjectId("virusObj");
+    virusDoc.setFileName("infected.exe");
+    virusDoc.setMimeType("application/octet-stream");
+    virusDoc.setUploadStatus("VirusDetected");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "good-id"))
+        .thenReturn(goodDoc);
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "virus-id"))
+        .thenReturn(virusDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    byte[] content = "good content".getBytes();
+    when(sdmService.readDocumentContent("goodObj", creds, false)).thenReturn(content);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(2, jsonArray.length());
+    assertEquals("success", jsonArray.getJSONObject(0).getString("status"));
+    assertEquals("good.pdf", jsonArray.getJSONObject(0).getString("fileName"));
+    assertEquals("error", jsonArray.getJSONObject(1).getString("status"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_NotFound() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("missing-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument emptyDoc = new CmisDocument();
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "missing-id"))
+        .thenReturn(emptyDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("error", jsonArray.getJSONObject(0).getString("status"));
+  }
+
+  @Test
+  void testDownloadSelectedAttachments_VirusScanInProgress() throws IOException {
+    AttachmentDownloadContext context = mock(AttachmentDownloadContext.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(userInfo.isSystemUser()).thenReturn(false);
+    when(context.getUserInfo()).thenReturn(userInfo);
+    CdsModel cdsModel = mock(CdsModel.class);
+    CdsEntity cdsEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+
+    when(context.getModel()).thenReturn(cdsModel);
+    when(context.getTarget()).thenReturn(cdsEntity);
+    when(cdsEntity.getQualifiedName()).thenReturn("MyService.MyEntity.attachments");
+    when(context.get("ids")).thenReturn("scanning-id");
+
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+
+    when(cdsModel.findEntity("MyService.MyEntity.attachments_drafts"))
+        .thenReturn(Optional.of(cdsEntity));
+    when(cdsModel.findEntity("MyService.MyEntity.attachments")).thenReturn(Optional.of(cdsEntity));
+
+    CmisDocument scanDoc = new CmisDocument();
+    scanDoc.setObjectId("scanObj");
+    scanDoc.setFileName("scanning.pdf");
+    scanDoc.setMimeType("application/pdf");
+    scanDoc.setUploadStatus("VirusScanInprogress");
+
+    when(dbQuery.getObjectIdForAttachmentID(cdsEntity, persistenceService, "scanning-id"))
+        .thenReturn(scanDoc);
+
+    SDMCredentials creds = new SDMCredentials();
+    when(tokenHandler.getSDMCredentials()).thenReturn(creds);
+
+    sdmServiceGenericHandler.downloadSelectedAttachments(context);
+
+    ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+    verify(context).setResult(resultCaptor.capture());
+
+    org.json.JSONArray jsonArray = new org.json.JSONArray(resultCaptor.getValue());
+    assertEquals(1, jsonArray.length());
+    assertEquals("error", jsonArray.getJSONObject(0).getString("status"));
+    verify(sdmService, never()).readDocumentContent(anyString(), any(), anyBoolean());
+  }
 }


### PR DESCRIPTION
## Describe your changes

Adds a new Download button to the attachments toolbar that allows users to download multiple selected file attachments at once. The button is automatically disabled when any link-type attachment is selected, since links are not downloadable files.

Users can select multiple attachments and download them all in one click
Link-type attachments are excluded from download — the button disables if any link is selected

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

MULTI TENANT 1 TECHNICAL USER
<img width="1115" height="178" alt="Screenshot 2026-04-28 at 12 54 47 PM" src="https://github.com/user-attachments/assets/b602b00c-f1e2-45e3-bceb-ac0077afe82c" />


MULTI TENNAT 1 NAMED USER
<img width="1045" height="296" alt="Screenshot 2026-04-23 at 1 30 49 PM" src="https://github.com/user-attachments/assets/ad832b8e-24fd-4a72-84c3-85b6a63a9d8a" />


MULTI TENANT 2 TECHNICAL USER
<img width="1602" height="270" alt="image" src="https://github.com/user-attachments/assets/4019beb2-07db-4ca8-9152-878e3b17164c" />


MULTI TENNAT 1 NAMED USER
<img width="743" height="136" alt="Screenshot 2026-04-28 at 3 03 00 PM" src="https://github.com/user-attachments/assets/a4d23e72-30df-4479-b9bd-99236b5ea415" />

SINGLE TENANT TECHNICAL USER
<img width="698" height="132" alt="Screenshot 2026-04-28 at 3 01 17 PM" src="https://github.com/user-attachments/assets/cd81066a-86f6-4b2e-80dd-200fbac6eadb" />


SINGLE TENANT NAMED USER

<img width="1115" height="178" alt="Screenshot 2026-04-28 at 12 54 47 PM" src="https://github.com/user-attachments/assets/5f18ea41-eaf0-4cc7-aedd-5fdbb7fe7728" />

