### PR TITLE
 Restrict file extension change during attachment rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.8.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.8.1-SNAPSHOT</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorMessages.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMErrorMessages.java
@@ -147,6 +147,8 @@ public class SDMErrorMessages {
       "Failed to access SDM error key fields";
   public static final String FAILED_TO_ACCESS_ERROR_MESSAGES_FIELDS =
       "Failed to access SDM error messages fields";
+  public static final String FILE_EXTENSION_CHANGE_NOT_ALLOWED =
+      "Changing the file extension is not allowed. The file \"%s\" must retain its original extension \"%s\".";
 
   // Helper Methods to create error/warning messages
   public static String buildErrorMessage(

--- a/sdm/src/main/java/com/sap/cds/sdm/constants/SDMUIErrorKeys.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/constants/SDMUIErrorKeys.java
@@ -68,6 +68,8 @@ public final class SDMUIErrorKeys {
       "SDM.multipleDuplicateFilenamesPrefix";
   public static final String MULTIPLE_DUPLICATE_FILENAMES_SUFFIX_KEY =
       "SDM.multipleDuplicateFilenamesSuffix";
+  public static final String FILE_EXTENSION_CHANGE_NOT_ALLOWED_KEY =
+      "SDM.fileExtensionChangeNotAllowed";
 
   // Update Operation Errors
   public static final String FILE_NOT_FOUND_PREFIX_KEY = "SDM.fileNotFoundPrefix";

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMCreateAttachmentsHandler.java
@@ -482,8 +482,22 @@ public class SDMCreateAttachmentsHandler implements EventHandler {
         AttachmentsHandlerUtils.prepareCmisDocument(
             filenameInRequest, descriptionInRequest, objectId);
 
+    List<String> extensionChangedFiles = new ArrayList<>();
     AttachmentsHandlerUtils.updateFilenameProperty(
-        fileNameInDB, filenameInRequest, fileNameInSDM, updatedSecondaryProperties);
+        fileNameInDB,
+        filenameInRequest,
+        fileNameInSDM,
+        updatedSecondaryProperties,
+        extensionChangedFiles);
+
+    // If extension change was detected, revert filename to original and warn
+    if (!extensionChangedFiles.isEmpty()) {
+      attachment.put("fileName", fileNameInSDM);
+      for (String warningMessage : extensionChangedFiles) {
+        context.getMessages().warn(warningMessage);
+      }
+    }
+
     AttachmentsHandlerUtils.updateDescriptionProperty(
         descriptionInSDM,
         descriptionInRequest,

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandler.java
@@ -197,6 +197,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
     List<String> fileNameWithRestrictedCharacters = new ArrayList<>();
     List<String> filesNotFound = new ArrayList<>();
     List<String> filesWithUnsupportedProperties = new ArrayList<>();
+    List<String> extensionChangedFiles = new ArrayList<>();
     Map<String, String> badRequest = new HashMap<>();
     Map<String, String> propertyTitles = new HashMap<>();
     List<String> noSDMRoles = new ArrayList<>();
@@ -229,7 +230,8 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
             filesWithUnsupportedProperties,
             badRequest,
             secondaryPropertiesWithInvalidDefinitions,
-            noSDMRoles);
+            noSDMRoles,
+            extensionChangedFiles);
       }
     }
     handleWarnings(
@@ -241,6 +243,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
         badRequest,
         propertyTitles,
         noSDMRoles,
+        extensionChangedFiles,
         contextInfo);
   }
 
@@ -254,7 +257,8 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
       List<String> filesWithUnsupportedProperties,
       Map<String, String> badRequest,
       Map<String, String> secondaryPropertiesWithInvalidDefinitions,
-      List<String> noSDMRoles)
+      List<String> noSDMRoles,
+      List<String> extensionChangedFiles)
       throws IOException {
     logger.debug("Processing {} attachments for update", attachments.size());
     List<String> scanFailedFiles = new ArrayList<>();
@@ -275,7 +279,8 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
           secondaryPropertiesWithInvalidDefinitions,
           noSDMRoles,
           scanFailedFiles,
-          uploadInProgressFiles);
+          uploadInProgressFiles,
+          extensionChangedFiles);
     }
 
     // Throw exception if any files failed scan or upload in progress
@@ -319,7 +324,8 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
       Map<String, String> secondaryPropertiesWithInvalidDefinitions,
       List<String> noSDMRoles,
       List<String> scanFailedFiles,
-      List<String> uploadInProgressFiles)
+      List<String> uploadInProgressFiles,
+      List<String> extensionChangedFiles)
       throws IOException {
     String id = (String) attachment.get("ID");
     String filenameInRequest = (String) attachment.get("fileName");
@@ -354,6 +360,7 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
         dbQuery.getPropertiesForID(
             attachmentEntity.get(), persistenceService, id, secondaryTypeProperties);
 
+    int extensionWarningsBefore = extensionChangedFiles.size();
     Map<String, String> updatedSecondaryProperties =
         prepareUpdatedProperties(
             attachmentEntity,
@@ -363,7 +370,13 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
             details.fileNameInDB,
             details.descriptionInDB,
             secondaryTypeProperties,
-            propertiesInDB);
+            propertiesInDB,
+            extensionChangedFiles);
+
+    // If extension change was detected, revert filename to original
+    if (extensionChangedFiles.size() > extensionWarningsBefore) {
+      attachment.put("fileName", details.fileNameInDB);
+    }
 
     if (updatedSecondaryProperties.isEmpty()) {
       logger.debug("No changes detected for attachment ID: {}, skipping SDM update", id);
@@ -459,7 +472,8 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
       String fileNameInDB,
       String descriptionInDB,
       Map<String, String> secondaryTypeProperties,
-      Map<String, String> propertiesInDB) {
+      Map<String, String> propertiesInDB,
+      List<String> extensionChangedFiles) {
     Map<String, String> updatedSecondaryProperties =
         SDMUtils.getUpdatedSecondaryProperties(
             attachmentEntity,
@@ -469,7 +483,11 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
             propertiesInDB);
 
     AttachmentsHandlerUtils.updateFilenameProperty(
-        fileNameInDB, filenameInRequest, fileNameInDB, updatedSecondaryProperties);
+        fileNameInDB,
+        filenameInRequest,
+        fileNameInDB,
+        updatedSecondaryProperties,
+        extensionChangedFiles);
 
     AttachmentsHandlerUtils.updateDescriptionProperty(
         null, descriptionInRequest, descriptionInDB, updatedSecondaryProperties, true);
@@ -563,7 +581,14 @@ public class SDMUpdateAttachmentsHandler implements EventHandler {
       Map<String, String> badRequest,
       Map<String, String> propertyTitles,
       List<String> noSDMRoles,
+      List<String> extensionChangedFiles,
       String contextInfo) {
+    if (!extensionChangedFiles.isEmpty()) {
+      logger.warn("File extension change attempted for files: {}", extensionChangedFiles);
+      for (String warningMessage : extensionChangedFiles) {
+        context.getMessages().warn(warningMessage);
+      }
+    }
     if (!fileNameWithRestrictedCharacters.isEmpty()) {
       logger.warn(
           "Files with restricted characters in filename: {}", fileNameWithRestrictedCharacters);

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/helper/AttachmentsHandlerUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/helper/AttachmentsHandlerUtils.java
@@ -664,14 +664,17 @@ public class AttachmentsHandlerUtils {
    *
    * @param fileNameInDB the filename currently in the database
    * @param filenameInRequest the filename from the request
+   * @param fileNameInSDM the filename in SDM
    * @param updatedSecondaryProperties the map to update
+   * @param extensionChangedFiles list to collect filenames where extension change was attempted
    * @throws ServiceException if filename validation fails
    */
   public static void updateFilenameProperty(
       String fileNameInDB,
       String filenameInRequest,
       String fileNameInSDM,
-      Map<String, String> updatedSecondaryProperties)
+      Map<String, String> updatedSecondaryProperties,
+      List<String> extensionChangedFiles)
       throws ServiceException {
     logger.debug(
         "Updating filename property - DB: {}, Request: {}, SDM: {}",
@@ -681,6 +684,9 @@ public class AttachmentsHandlerUtils {
     if (fileNameInDB == null) {
       if (filenameInRequest != null) {
         if (!filenameInRequest.equals(fileNameInSDM)) {
+          if (isFileExtensionChanged(fileNameInSDM, filenameInRequest, extensionChangedFiles)) {
+            return;
+          }
           logger.debug(
               "Filename updated from SDM value: {} to request value: {}",
               fileNameInSDM,
@@ -696,6 +702,9 @@ public class AttachmentsHandlerUtils {
         logger.warn("Filename validation failed: filename cannot be empty");
         throw new ServiceException("Filename cannot be empty");
       } else if (!fileNameInDB.equals(filenameInRequest)) {
+        if (isFileExtensionChanged(fileNameInDB, filenameInRequest, extensionChangedFiles)) {
+          return;
+        }
         logger.debug(
             "Filename updated from DB value: {} to request value: {}",
             fileNameInDB,
@@ -703,6 +712,30 @@ public class AttachmentsHandlerUtils {
         updatedSecondaryProperties.put("filename", filenameInRequest);
       }
     }
+  }
+
+  /**
+   * Checks if the file extension has changed. If so, adds a warning message to the list and returns
+   * true, indicating the rename should be skipped and the filename reverted.
+   *
+   * @param originalFileName the original filename (from DB or SDM)
+   * @param newFileName the new filename from the request
+   * @param extensionChangedFiles list to collect warning messages
+   * @return true if extension changed (rename should be skipped), false otherwise
+   */
+  private static boolean isFileExtensionChanged(
+      String originalFileName, String newFileName, List<String> extensionChangedFiles) {
+    if (SDMUtils.hasFileExtensionChanged(originalFileName, newFileName)) {
+      String originalExtension = SDMUtils.getFileExtension(originalFileName);
+      logger.warn("File extension change attempted: {} -> {}", originalFileName, newFileName);
+      extensionChangedFiles.add(
+          String.format(
+              SDMUtils.getErrorMessage("FILE_EXTENSION_CHANGE_NOT_ALLOWED"),
+              newFileName,
+              originalExtension));
+      return true;
+    }
+    return false;
   }
 
   public static void updateDescriptionProperty(

--- a/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
@@ -134,6 +134,39 @@ public class SDMUtils {
     return matcher.find();
   }
 
+  /**
+   * Extracts the file extension from a filename (lowercase, including the dot).
+   *
+   * @param fileName the filename to extract the extension from
+   * @return the file extension (e.g. ".pdf"), or empty string if no valid extension exists
+   */
+  public static String getFileExtension(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return "";
+    }
+    int lastDotIndex = fileName.lastIndexOf('.');
+    if (lastDotIndex <= 0 || lastDotIndex == fileName.length() - 1) {
+      return "";
+    }
+    return fileName.substring(lastDotIndex).toLowerCase();
+  }
+
+  /**
+   * Checks whether the file extension has changed between the original and new filename.
+   *
+   * @param originalFileName the original filename
+   * @param newFileName the new filename
+   * @return true if the extension has changed, false otherwise
+   */
+  public static boolean hasFileExtensionChanged(String originalFileName, String newFileName) {
+    if (originalFileName == null || newFileName == null) {
+      return false;
+    }
+    String originalExtension = getFileExtension(originalFileName);
+    String newExtension = getFileExtension(newFileName);
+    return !originalExtension.equals(newExtension);
+  }
+
   public static void prepareSecondaryProperties(
       Map<String, String> requestBody,
       Map<String, String> secondaryProperties,

--- a/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/utilities/SDMUtils.java
@@ -164,6 +164,9 @@ public class SDMUtils {
     }
     String originalExtension = getFileExtension(originalFileName);
     String newExtension = getFileExtension(newFileName);
+    if (originalExtension.isEmpty() || newExtension.isEmpty()) {
+      return false;
+    }
     return !originalExtension.equals(newExtension);
   }
 

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
@@ -583,7 +583,7 @@ class IntegrationTest_Chapters_MultipleFacet {
 
       for (int i = 0; i < facet.length; i++) {
         api.renameAttachment(
-            appUrl, chapterEntityName, facet[i], chapterID, ID2[i], "sample123.pdf");
+            appUrl, chapterEntityName, facet[i], chapterID, ID2[i], "sample123.txt");
       }
 
       response = api.saveEntityDraft(appUrl, bookEntityName, srvpath, bookID);

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
@@ -552,7 +552,7 @@ class IntegrationTest_Chapters_MultipleFacet {
         return;
       }
 
-      String restrictedName = "a/\\bc.pdf"; // \b becomes BACKSPACE
+      String restrictedName = "a/\\bc.txt"; // \b becomes BACKSPACE
       response =
           api.renameAttachment(
               appUrl, chapterEntityName, facet[i], chapterID, ID2[i], restrictedName);
@@ -575,7 +575,7 @@ class IntegrationTest_Chapters_MultipleFacet {
 
     // ---------------- EXPECTED MESSAGE (EXACT) ----------------
     String expectedMessage =
-        "\"a/\\bc.pdf\" contains unsupported characters ('/' or '\\'). Rename and try again.\n\n"
+        "\"a/\\bc.txt\" contains unsupported characters ('/' or '\\'). Rename and try again.\n\n"
             + "Table: attachments\n"
             + "Page: IntegrationTestEntity";
 
@@ -610,11 +610,11 @@ class IntegrationTest_Chapters_MultipleFacet {
 
     if ("Entity in draft mode".equals(response)) {
       // To create a duplicate within the same facet, we need to rename ID2[i] to
-      // the same name as an existing file in that facet. The existing files are:
-      // sample.pdf (ID[0]), sample.txt (ID[1]), sample.exe (ID[2]) - these are the first uploads
-      // We rename ID2[i] (sample123.pdf from test 8) to "sample.pdf" which already exists
-      String[] duplicateNames = {"sample.pdf", "sample.txt", "sample.exe"};
-      String[] validNames = {"unique_sample1.pdf", "unique_sample2.txt", "unique_sample3.exe"};
+      // the same name as an existing file in that facet. After test 7, the existing files are:
+      // sample123 (ID[0]), reference123 (ID[1]), footnote123 (ID[2])
+      // We rename ID2[i] (sample123.txt from test 8) to these names which already exist
+      String[] duplicateNames = {"sample123", "reference123", "footnote123"};
+      String[] validNames = {"unique_sample1.txt", "unique_sample2.txt", "unique_sample3.txt"};
 
       // Try to rename to duplicate file names (names that already exist in each facet)
       for (int i = 0; i < facet.length; i++) {

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/handler/applicationservice/SDMUpdateAttachmentsHandlerTest.java
@@ -406,7 +406,7 @@ public class SDMUpdateAttachmentsHandlerTest {
           .when(
               () ->
                   AttachmentsHandlerUtils.updateFilenameProperty(
-                      anyString(), anyString(), anyString(), any(Map.class)))
+                      anyString(), anyString(), anyString(), any(Map.class), any(List.class)))
           .thenAnswer(invocation -> null);
 
       attachmentsMockStatic

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -151,6 +151,14 @@ public class SDMUtilsTest {
   }
 
   @Test
+  public void testHasFileExtensionChanged() {
+    assertTrue(SDMUtils.hasFileExtensionChanged("sample.pdf", "sample.dmg"));
+    assertFalse(SDMUtils.hasFileExtensionChanged("sample.pdf", "renamed.pdf"));
+    assertFalse(SDMUtils.hasFileExtensionChanged(null, "file.txt"));
+    assertFalse(SDMUtils.hasFileExtensionChanged("file.txt", null));
+  }
+
+  @Test
   public void prepareSecondaryPropertiesTest_withFilenameKey() {
     Map<String, String> requestBody = new HashMap<>();
     Map<String, String> secondaryProperties = new HashMap<>();

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/utilities/SDMUtilsTest.java
@@ -156,6 +156,8 @@ public class SDMUtilsTest {
     assertFalse(SDMUtils.hasFileExtensionChanged("sample.pdf", "renamed.pdf"));
     assertFalse(SDMUtils.hasFileExtensionChanged(null, "file.txt"));
     assertFalse(SDMUtils.hasFileExtensionChanged("file.txt", null));
+    assertFalse(SDMUtils.hasFileExtensionChanged("sample.pdf", "sample123"));
+    assertFalse(SDMUtils.hasFileExtensionChanged("sample", "sample123"));
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes
When renaming an attachment, users could change the file extension (e.g., sample.pdf → sample.dmg), corrupting the document type and making downloaded files unopenable.

Changes:

-> Added getFileExtension() and hasFileExtensionChanged() utilities in SDMUtils
-> Added extension validation in updateFilenameProperty() — if extension changes, the rename is skipped, the filename is reverted to the original, and a warning is shown to the user
-> Applied to both Update and Create handler flows

Behavior:

sample.pdf → report.pdf  Allowed
sample.pdf → sample.dmg  Warning shown, filename will be reverted

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="813" height="296" alt="Screenshot 2026-04-30 at 2 03 11 PM" src="https://github.com/user-attachments/assets/b774067c-8e9b-446a-a1c6-2bcad93600a2" />


SINGLE TENANT INTEGRATION TEST

https://github.com/cap-java/sdm/actions/runs/25163159892
<img width="1313" height="585" alt="Screenshot 2026-05-04 at 9 18 07 AM" src="https://github.com/user-attachments/assets/4b43a540-3489-4fd2-9eb7-2cbbc4310026" />


MULTI TENANT INTEGRATION TEST

https://github.com/cap-java/sdm/actions/runs/25163208769

<img width="1484" height="539" alt="Screenshot 2026-05-04 at 9 19 12 AM" src="https://github.com/user-attachments/assets/4396f880-8045-48d9-ab52-6533f765e9ee" />
