### PR TITLE
Integration Test For MimeType Change Validation During Rename

### DIFF
--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
@@ -6482,4 +6482,96 @@ class IntegrationTest_Chapters_MultipleFacet {
     // Clean up
     api.deleteEntity(appUrl, bookEntityName, newBookID);
   }
+
+  @Test
+  @Order(77)
+  void testRenameChapterAttachmentWithExtensionChange_BeforeSave() throws IOException {
+    System.out.println(
+        "Test (77) : Upload chapter attachment in draft, rename changing extension before save across all facets - should return extension change warning");
+
+    for (int i = 0; i < facet.length; i++) {
+      // Step 1: Create a new book and chapter draft (do NOT save)
+      String newBookID = api.createEntityDraft(appUrl, bookEntityName, entityName2, srvpath);
+      if (newBookID.equals("Could not create entity")) {
+        fail("Could not create book for facet: " + facet[i]);
+      }
+      String newChapterID =
+          api.createEntityDraft(appUrl, chapterEntityName, entityName2, srvpath, newBookID);
+      if (newChapterID.equals("Could not create entity")) {
+        api.deleteEntityDraft(appUrl, bookEntityName, newBookID);
+        fail("Could not create chapter for facet: " + facet[i]);
+      }
+
+      // Step 2: Upload a PDF attachment to the chapter facet while book is still in draft (unsaved)
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", newChapterID);
+      postData.put("mimeType", "application/pdf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      String facetAttachmentID =
+          CreateandReturnFacetID(appUrl, serviceName, newChapterID, facet[i], postData, file);
+      if (facetAttachmentID == null) {
+        api.deleteEntityDraft(appUrl, bookEntityName, newBookID);
+        fail("Could not upload sample.pdf to chapter facet: " + facet[i]);
+      }
+
+      // Step 3: Rename the attachment changing extension from .pdf to .txt — book still not saved
+      String renameResponse =
+          api.renameAttachment(
+              appUrl,
+              chapterEntityName,
+              facet[i],
+              newChapterID,
+              facetAttachmentID,
+              "renamed_document.txt");
+      if (!"Renamed".equals(renameResponse)) {
+        api.deleteEntityDraft(appUrl, bookEntityName, newBookID);
+        fail("Could not rename chapter attachment on facet " + facet[i] + ": " + renameResponse);
+      }
+
+      // Step 4: Save the book — should receive extension change warning, not "Saved"
+      String saveWithWarningResponse =
+          api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+      assertNotNull(saveWithWarningResponse, "Response should not be null for facet: " + facet[i]);
+
+      String expectedMessage =
+          "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+      com.fasterxml.jackson.databind.JsonNode messagesNode =
+          new ObjectMapper().readTree(saveWithWarningResponse);
+      assertTrue(
+          messagesNode.isArray(),
+          "sap-messages response should be a JSON array for facet: " + facet[i]);
+
+      boolean foundExtensionError = false;
+      for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+        if (messageNode.has("message")) {
+          String message = messageNode.get("message").asText();
+          if (message.contains("Changing the file extension is not allowed")) {
+            foundExtensionError = true;
+            assertEquals(
+                expectedMessage,
+                message,
+                "Extension change error message does not match for facet: " + facet[i]);
+            break;
+          }
+        }
+      }
+
+      assertTrue(
+          foundExtensionError,
+          "Expected extension change warning not found for facet: "
+              + facet[i]
+              + ". Full response: "
+              + saveWithWarningResponse);
+
+      // Clean up
+      api.deleteEntity(appUrl, bookEntityName, newBookID);
+    }
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_Chapters_MultipleFacet.java
@@ -6363,4 +6363,123 @@ class IntegrationTest_Chapters_MultipleFacet {
     api.deleteEntity(appUrl, bookEntityName, sourceBookID);
     api.deleteEntity(appUrl, bookEntityName, targetBookID);
   }
+
+  @Test
+  @Order(76)
+  void testRenameChapterAttachmentWithExtensionChange() throws IOException {
+    System.out.println(
+        "Test (76) : Rename chapter attachment changing extension from .pdf to .txt across all facets - should return extension change warning");
+
+    // Step 1: Create a new book and chapter
+    String newBookID = api.createEntityDraft(appUrl, bookEntityName, entityName2, srvpath);
+    if (newBookID.equals("Could not create entity")) {
+      fail("Could not create book");
+    }
+    String newChapterID =
+        api.createEntityDraft(appUrl, chapterEntityName, entityName2, srvpath, newBookID);
+    if (newChapterID.equals("Could not create entity")) {
+      api.deleteEntityDraft(appUrl, bookEntityName, newBookID);
+      fail("Could not create chapter");
+    }
+    String saveResponse = api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+    if (!saveResponse.equals("Saved")) {
+      fail("Could not save book: " + saveResponse);
+    }
+
+    // Step 2: Upload a PDF attachment to each facet in the chapter
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", newChapterID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
+
+    String editResponse = api.editEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+    if (!"Entity in draft mode".equals(editResponse)) {
+      fail("Could not put book in draft mode for PDF upload");
+    }
+
+    String[] facetAttachmentIDs = new String[facet.length];
+    for (int i = 0; i < facet.length; i++) {
+      facetAttachmentIDs[i] =
+          CreateandReturnFacetID(appUrl, serviceName, newChapterID, facet[i], postData, file);
+      if (facetAttachmentIDs[i] == null) {
+        api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+        api.deleteEntity(appUrl, bookEntityName, newBookID);
+        fail("Could not upload sample.pdf to chapter facet: " + facet[i]);
+      }
+    }
+
+    // Step 3: Save the book
+    String savedAfterUpload = api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+    if (!savedAfterUpload.equals("Saved")) {
+      api.deleteEntity(appUrl, bookEntityName, newBookID);
+      fail("Could not save book after PDF upload: " + savedAfterUpload);
+    }
+
+    // Step 4 & 5: Edit the book, rename each facet's attachment changing extension .pdf -> .txt
+    for (int i = 0; i < facet.length; i++) {
+      String editDraftResponse = api.editEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+      if (!"Entity in draft mode".equals(editDraftResponse)) {
+        api.deleteEntity(appUrl, bookEntityName, newBookID);
+        fail("Could not put book in draft mode for rename on facet: " + facet[i]);
+      }
+
+      String renameResponse =
+          api.renameAttachment(
+              appUrl,
+              chapterEntityName,
+              facet[i],
+              newChapterID,
+              facetAttachmentIDs[i],
+              "renamed_document.txt");
+      if (!"Renamed".equals(renameResponse)) {
+        api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+        api.deleteEntity(appUrl, bookEntityName, newBookID);
+        fail("Could not rename chapter attachment on facet " + facet[i] + ": " + renameResponse);
+      }
+
+      // Step 6: Save and validate the extension change warning message
+      String saveWithWarningResponse =
+          api.saveEntityDraft(appUrl, bookEntityName, srvpath, newBookID);
+      assertNotNull(saveWithWarningResponse, "Response should not be null for facet: " + facet[i]);
+
+      String expectedMessage =
+          "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+      com.fasterxml.jackson.databind.JsonNode messagesNode =
+          new ObjectMapper().readTree(saveWithWarningResponse);
+      assertTrue(
+          messagesNode.isArray(),
+          "sap-messages response should be a JSON array for facet: " + facet[i]);
+
+      boolean foundExtensionError = false;
+      for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+        if (messageNode.has("message")) {
+          String message = messageNode.get("message").asText();
+          if (message.contains("Changing the file extension is not allowed")) {
+            foundExtensionError = true;
+            assertEquals(
+                expectedMessage,
+                message,
+                "Extension change error message does not match for facet: " + facet[i]);
+            break;
+          }
+        }
+      }
+
+      assertTrue(
+          foundExtensionError,
+          "Expected extension change warning not found for facet: "
+              + facet[i]
+              + ". Full response: "
+              + saveWithWarningResponse);
+    }
+
+    // Clean up
+    api.deleteEntity(appUrl, bookEntityName, newBookID);
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -6978,6 +6978,88 @@ class IntegrationTest_MultipleFacet {
     api.deleteEntity(appUrl, entityName, newEntityID);
   }
 
+  @Test
+  @Order(77)
+  void testRenameAttachmentWithExtensionChange_BeforeSave() throws IOException {
+    System.out.println(
+        "Test (77) : Upload attachment in draft, rename changing extension before save across all facets - should return extension change warning");
+
+    for (int i = 0; i < facet.length; i++) {
+      // Step 1: Create a new entity draft (do NOT save it yet)
+      String newEntityID = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+      if (newEntityID.equals("Could not create entity")) {
+        fail("Could not create entity for facet: " + facet[i]);
+      }
+
+      // Step 2: Upload a PDF attachment while entity is still in draft (unsaved)
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+      Map<String, Object> postData = new HashMap<>();
+      postData.put("up__ID", newEntityID);
+      postData.put("mimeType", "application/pdf");
+      postData.put("createdAt", new Date().toString());
+      postData.put("createdBy", "test@test.com");
+      postData.put("modifiedBy", "test@test.com");
+
+      String facetAttachmentID =
+          CreateandReturnFacetID(
+              appUrl, serviceName, entityName, facet[i], newEntityID, postData, file);
+      if (facetAttachmentID == null) {
+        api.deleteEntityDraft(appUrl, entityName, newEntityID);
+        fail("Could not upload sample.pdf to facet: " + facet[i]);
+      }
+
+      // Step 3: Rename the attachment changing extension from .pdf to .txt — entity still not saved
+      String renameResponse =
+          api.renameAttachment(
+              appUrl, entityName, facet[i], newEntityID, facetAttachmentID, "renamed_document.txt");
+      if (!"Renamed".equals(renameResponse)) {
+        api.deleteEntityDraft(appUrl, entityName, newEntityID);
+        fail("Could not rename attachment on facet " + facet[i] + ": " + renameResponse);
+      }
+
+      // Step 4: Save — should receive extension change warning, not "Saved"
+      String saveWithWarningResponse =
+          api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+      assertNotNull(saveWithWarningResponse, "Response should not be null for facet: " + facet[i]);
+
+      String expectedMessage =
+          "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+      com.fasterxml.jackson.databind.JsonNode messagesNode =
+          new ObjectMapper().readTree(saveWithWarningResponse);
+      assertTrue(
+          messagesNode.isArray(),
+          "sap-messages response should be a JSON array for facet: " + facet[i]);
+
+      boolean foundExtensionError = false;
+      for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+        if (messageNode.has("message")) {
+          String message = messageNode.get("message").asText();
+          if (message.contains("Changing the file extension is not allowed")) {
+            foundExtensionError = true;
+            assertEquals(
+                expectedMessage,
+                message,
+                "Extension change error message does not match for facet: " + facet[i]);
+            break;
+          }
+        }
+      }
+
+      assertTrue(
+          foundExtensionError,
+          "Expected extension change warning not found for facet: "
+              + facet[i]
+              + ". Full response: "
+              + saveWithWarningResponse);
+
+      // Clean up
+      api.deleteEntity(appUrl, entityName, newEntityID);
+    }
+  }
+
   // @Test
   // @Order(77)
   // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -6864,8 +6864,122 @@ class IntegrationTest_MultipleFacet {
     }
   }
 
+  @Test
+  @Order(76)
+  void testRenameAttachmentWithExtensionChange() throws IOException {
+    System.out.println(
+        "Test (76) : Rename attachment changing extension from .pdf to .txt across all facets - should return extension change warning");
+
+    // Step 1: Create a new entity
+    String newEntityID = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (newEntityID.equals("Could not create entity")) {
+      fail("Could not create entity");
+    }
+    String saveResponse = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (!saveResponse.equals("Saved")) {
+      fail("Could not save new entity: " + saveResponse);
+    }
+
+    // Step 2: Upload a PDF attachment to each facet
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", newEntityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
+
+    String editResponse = api.editEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (!"Entity in draft mode".equals(editResponse)) {
+      fail("Could not put entity in draft mode for PDF upload");
+    }
+
+    String[] facetAttachmentIDs = new String[facet.length];
+    for (int i = 0; i < facet.length; i++) {
+      facetAttachmentIDs[i] =
+          CreateandReturnFacetID(
+              appUrl, serviceName, entityName, facet[i], newEntityID, postData, file);
+      if (facetAttachmentIDs[i] == null) {
+        api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+        api.deleteEntity(appUrl, entityName, newEntityID);
+        fail("Could not upload sample.pdf to facet: " + facet[i]);
+      }
+    }
+
+    // Step 3: Save the entity
+    String savedAfterUpload = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (!savedAfterUpload.equals("Saved")) {
+      api.deleteEntity(appUrl, entityName, newEntityID);
+      fail("Could not save entity after PDF upload: " + savedAfterUpload);
+    }
+
+    // Step 4 & 5: Edit the entity, rename each facet's attachment changing extension .pdf -> .txt
+    for (int i = 0; i < facet.length; i++) {
+      String editDraftResponse = api.editEntityDraft(appUrl, entityName, srvpath, newEntityID);
+      if (!"Entity in draft mode".equals(editDraftResponse)) {
+        api.deleteEntity(appUrl, entityName, newEntityID);
+        fail("Could not put entity in draft mode for rename on facet: " + facet[i]);
+      }
+
+      String renameResponse =
+          api.renameAttachment(
+              appUrl,
+              entityName,
+              facet[i],
+              newEntityID,
+              facetAttachmentIDs[i],
+              "renamed_document.txt");
+      if (!"Renamed".equals(renameResponse)) {
+        api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+        api.deleteEntity(appUrl, entityName, newEntityID);
+        fail("Could not rename attachment on facet " + facet[i] + ": " + renameResponse);
+      }
+
+      // Step 6: Save and validate the extension change warning message
+      String saveWithWarningResponse =
+          api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+      assertNotNull(saveWithWarningResponse, "Response should not be null for facet: " + facet[i]);
+
+      String expectedMessage =
+          "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+      com.fasterxml.jackson.databind.JsonNode messagesNode =
+          new ObjectMapper().readTree(saveWithWarningResponse);
+      assertTrue(
+          messagesNode.isArray(),
+          "sap-messages response should be a JSON array for facet: " + facet[i]);
+
+      boolean foundExtensionError = false;
+      for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+        if (messageNode.has("message")) {
+          String message = messageNode.get("message").asText();
+          if (message.contains("Changing the file extension is not allowed")) {
+            foundExtensionError = true;
+            assertEquals(
+                expectedMessage,
+                message,
+                "Extension change error message does not match for facet: " + facet[i]);
+            break;
+          }
+        }
+      }
+
+      assertTrue(
+          foundExtensionError,
+          "Expected extension change warning not found for facet: "
+              + facet[i]
+              + ". Full response: "
+              + saveWithWarningResponse);
+    }
+
+    // Clean up
+    api.deleteEntity(appUrl, entityName, newEntityID);
+  }
+
   // @Test
-  // @Order(76)
+  // @Order(77)
   // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
   //   System.out.println(
   //       "Test (76) : Upload attachment exceeding maximum file size in references facet");

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6534,4 +6534,54 @@ class IntegrationTest_SingleFacet {
     // Clean up
     api.deleteEntity(appUrl, entityName, newEntityID);
   }
+
+  // @Test
+  // @Order(76)
+  // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
+  //   System.out.println(
+  //       "Test (76) : Upload attachment exceeding maximum file size in references facet");
+
+  //   // Create a new entity
+  //   String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+  //   if (response.equals("Could not create entity")) {
+  //     fail("Could not create entity");
+  //   }
+  //   String testEntityID = response;
+
+  //   // Load the 150MB sample file
+  //   ClassLoader classLoader = getClass().getClassLoader();
+  //   File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
+
+  //   Map<String, Object> postData = new HashMap<>();
+  //   postData.put("up__ID", testEntityID);
+  //   postData.put("mimeType", "application/pdf");
+  //   postData.put("createdAt", new Date().toString());
+  //   postData.put("createdBy", "test@test.com");
+  //   postData.put("modifiedBy", "test@test.com");
+
+  //   // Try to upload to the 'references' facet which has the 100MB limit
+  //   String referencesFacet = "references";
+  //   List<String> createResponse =
+  //       api.createAttachment(
+  //           appUrl, entityName, referencesFacet, testEntityID, srvpath, postData, file);
+  //   String check = createResponse.get(0);
+
+  //   // The upload should fail with AttachmentSizeExceeded error
+  //   if (!check.equals("Attachment created")) {
+  //     try {
+  //       JSONObject json = new JSONObject(check);
+  //       String errorCode = json.getJSONObject("error").getString("code");
+  //       String errorMessage = json.getJSONObject("error").getString("message");
+  //       assertEquals("413", errorCode);
+  //       assertEquals("File size exceeds the limit of 30MB.", errorMessage);
+  //     } catch (Exception e) {
+  //       fail("Failed to parse error response: " + e.getMessage());
+  //     }
+  //   } else {
+  //     fail("Attachment got created with file size exceeding maximum limit");
+  //   }
+
+  //   // delete the test entity draft
+  //   api.deleteEntityDraft(appUrl, entityName, testEntityID);
+  // }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6410,4 +6410,46 @@ class IntegrationTest_SingleFacet {
   //   // delete the test entity draft
   //   api.deleteEntityDraft(appUrl, entityName, testEntityID);
   // }
+
+  @Test
+  @Order(76)
+  void testRename_ExtensionUpdate() throws IOException {
+    System.out.println("Test (76) : Rename single attachment while updating the file extension");
+    System.out.println("Uploading pdf");
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", entityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
+
+    String response1 = api.editEntityDraft(appUrl, entityName, srvpath, entityID);
+    List<String> createResponse =
+        api.createAttachment(appUrl, entityName, facetName, entityID, srvpath, postData, file);
+    Boolean testStatus = false;
+    String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID);
+    String name = "sample.txt";
+    if (response == "Entity in draft mode") {
+      response = api.renameAttachment(appUrl, entityName, facetName, entityID, attachmentID1, name);
+      if (response.equals("Renamed")) {
+        response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
+        System.out.println("Response is: " + response);
+        String expected =
+            "{\"error\":{\"code\":\"400\",\"message\":\"\\\"invalid/name\\\" contains unsupported characters (‘/’ or ‘\\\\’). Rename and try again.\\n\\nTable: attachments\\nPage: IntegrationTestEntity\"}}";
+        if (response.equals(expected)) {
+          api.renameAttachment(appUrl, entityName, facetName, entityID, attachmentID1, "sample123");
+          response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
+          if ("Saved".equals(response)) testStatus = true;
+        }
+      } else {
+        api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
+      }
+    }
+    if (!testStatus) {
+      fail("Attachment was renamed with unsupported characters");
+    }
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6458,4 +6458,80 @@ class IntegrationTest_SingleFacet {
     // Clean up
     api.deleteEntity(appUrl, entityName, newEntityID);
   }
+
+  @Test
+  @Order(77)
+  void testRenameAttachmentWithExtensionChange_WhileUpload() throws IOException {
+    System.out.println(
+        "Test (77) : Upload attachment in draft, rename changing extension before save - should return extension change warning");
+
+    // Step 1: Create a new entity draft (do NOT save it yet)
+    String newEntityID = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (newEntityID.equals("Could not create entity")) {
+      fail("Could not create entity");
+    }
+
+    // Step 2: Upload a PDF attachment while entity is still in draft (unsaved)
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("sample.pdf").getFile());
+
+    Map<String, Object> postData = new HashMap<>();
+    postData.put("up__ID", newEntityID);
+    postData.put("mimeType", "application/pdf");
+    postData.put("createdAt", new Date().toString());
+    postData.put("createdBy", "test@test.com");
+    postData.put("modifiedBy", "test@test.com");
+
+    List<String> createResponse =
+        api.createAttachment(appUrl, entityName, facetName, newEntityID, srvpath, postData, file);
+    String check = createResponse.get(0);
+    if (!check.equals("Attachment created")) {
+      api.deleteEntityDraft(appUrl, entityName, newEntityID);
+      fail("Could not upload sample.pdf: " + check);
+    }
+    String newAttachmentID = createResponse.get(1);
+
+    // Step 3: Rename the attachment changing extension from .pdf to .txt — entity still not saved
+    String renameResponse =
+        api.renameAttachment(
+            appUrl, entityName, facetName, newEntityID, newAttachmentID, "renamed_document.txt");
+    if (!renameResponse.equals("Renamed")) {
+      api.deleteEntityDraft(appUrl, entityName, newEntityID);
+      fail("Could not rename attachment: " + renameResponse);
+    }
+
+    // Step 4: Save — should receive extension change warning, not "Saved"
+    String saveWithWarningResponse = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    assertNotNull(saveWithWarningResponse, "Response should not be null");
+
+    String expectedMessage =
+        "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+    com.fasterxml.jackson.databind.JsonNode messagesNode =
+        new ObjectMapper().readTree(saveWithWarningResponse);
+    assertTrue(messagesNode.isArray(), "sap-messages response should be a JSON array");
+
+    boolean foundExtensionError = false;
+    for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+      if (messageNode.has("message")) {
+        String message = messageNode.get("message").asText();
+        if (message.contains("Changing the file extension is not allowed")) {
+          foundExtensionError = true;
+          assertEquals(
+              expectedMessage,
+              message,
+              "Extension change error message does not match expected value");
+          break;
+        }
+      }
+    }
+
+    assertTrue(
+        foundExtensionError,
+        "Expected extension change warning not found in response. Full response: "
+            + saveWithWarningResponse);
+
+    // Clean up
+    api.deleteEntity(appUrl, entityName, newEntityID);
+  }
 }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -6361,95 +6361,101 @@ class IntegrationTest_SingleFacet {
     api.deleteEntity(appUrl, entityName, moveSourceEntity);
   }
 
-  // @Test
-  // @Order(76)
-  // void testUploadAttachmentExceedingMaximumFileSize() throws IOException {
-  //   System.out.println(
-  //       "Test (76) : Upload attachment exceeding maximum file size in references facet");
-
-  //   // Create a new entity
-  //   String response = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
-  //   if (response.equals("Could not create entity")) {
-  //     fail("Could not create entity");
-  //   }
-  //   String testEntityID = response;
-
-  //   // Load the 150MB sample file
-  //   ClassLoader classLoader = getClass().getClassLoader();
-  //   File file = new File(classLoader.getResource("sample32mb.pdf").getFile());
-
-  //   Map<String, Object> postData = new HashMap<>();
-  //   postData.put("up__ID", testEntityID);
-  //   postData.put("mimeType", "application/pdf");
-  //   postData.put("createdAt", new Date().toString());
-  //   postData.put("createdBy", "test@test.com");
-  //   postData.put("modifiedBy", "test@test.com");
-
-  //   // Try to upload to the 'references' facet which has the 100MB limit
-  //   String referencesFacet = "references";
-  //   List<String> createResponse =
-  //       api.createAttachment(
-  //           appUrl, entityName, referencesFacet, testEntityID, srvpath, postData, file);
-  //   String check = createResponse.get(0);
-
-  //   // The upload should fail with AttachmentSizeExceeded error
-  //   if (!check.equals("Attachment created")) {
-  //     try {
-  //       JSONObject json = new JSONObject(check);
-  //       String errorCode = json.getJSONObject("error").getString("code");
-  //       String errorMessage = json.getJSONObject("error").getString("message");
-  //       assertEquals("413", errorCode);
-  //       assertEquals("File size exceeds the limit of 30MB.", errorMessage);
-  //     } catch (Exception e) {
-  //       fail("Failed to parse error response: " + e.getMessage());
-  //     }
-  //   } else {
-  //     fail("Attachment got created with file size exceeding maximum limit");
-  //   }
-
-  //   // delete the test entity draft
-  //   api.deleteEntityDraft(appUrl, entityName, testEntityID);
-  // }
-
   @Test
   @Order(76)
-  void testRename_ExtensionUpdate() throws IOException {
-    System.out.println("Test (76) : Rename single attachment while updating the file extension");
-    System.out.println("Uploading pdf");
+  void testRenameAttachmentWithExtensionChange() throws IOException {
+    System.out.println(
+        "Test (76) : Rename attachment changing extension from .pdf to .txt - should return extension change warning");
+
+    // Step 1: Create a new entity
+    String newEntityID = api.createEntityDraft(appUrl, entityName, entityName2, srvpath);
+    if (newEntityID.equals("Could not create entity")) {
+      fail("Could not create entity");
+    }
+    String saveResponse = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (!saveResponse.equals("Saved")) {
+      fail("Could not save new entity: " + saveResponse);
+    }
+
+    // Step 2: Upload a PDF attachment
     ClassLoader classLoader = getClass().getClassLoader();
     File file = new File(classLoader.getResource("sample.pdf").getFile());
 
     Map<String, Object> postData = new HashMap<>();
-    postData.put("up__ID", entityID);
+    postData.put("up__ID", newEntityID);
     postData.put("mimeType", "application/pdf");
     postData.put("createdAt", new Date().toString());
     postData.put("createdBy", "test@test.com");
     postData.put("modifiedBy", "test@test.com");
 
-    String response1 = api.editEntityDraft(appUrl, entityName, srvpath, entityID);
+    String editResponse = api.editEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (editResponse != "Entity in draft mode") {
+      fail("Could not put entity in draft mode for PDF upload");
+    }
+
     List<String> createResponse =
-        api.createAttachment(appUrl, entityName, facetName, entityID, srvpath, postData, file);
-    Boolean testStatus = false;
-    String response = api.editEntityDraft(appUrl, entityName, srvpath, entityID);
-    String name = "sample.txt";
-    if (response == "Entity in draft mode") {
-      response = api.renameAttachment(appUrl, entityName, facetName, entityID, attachmentID1, name);
-      if (response.equals("Renamed")) {
-        response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
-        System.out.println("Response is: " + response);
-        String expected =
-            "{\"error\":{\"code\":\"400\",\"message\":\"\\\"invalid/name\\\" contains unsupported characters (‘/’ or ‘\\\\’). Rename and try again.\\n\\nTable: attachments\\nPage: IntegrationTestEntity\"}}";
-        if (response.equals(expected)) {
-          api.renameAttachment(appUrl, entityName, facetName, entityID, attachmentID1, "sample123");
-          response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
-          if ("Saved".equals(response)) testStatus = true;
+        api.createAttachment(appUrl, entityName, facetName, newEntityID, srvpath, postData, file);
+    String check = createResponse.get(0);
+    if (!check.equals("Attachment created")) {
+      fail("Could not upload sample.pdf: " + check);
+    }
+    String newAttachmentID = createResponse.get(1);
+
+    // Step 3: Save the entity
+    String savedAfterUpload = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (!savedAfterUpload.equals("Saved")) {
+      fail("Could not save entity after PDF upload: " + savedAfterUpload);
+    }
+
+    // Step 4: Edit the entity
+    String editDraftResponse = api.editEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    if (editDraftResponse != "Entity in draft mode") {
+      api.deleteEntity(appUrl, entityName, newEntityID);
+      fail("Could not put entity in draft mode for rename");
+    }
+
+    // Step 5: Rename the attachment changing the extension from .pdf to .txt
+    String renameResponse =
+        api.renameAttachment(
+            appUrl, entityName, facetName, newEntityID, newAttachmentID, "renamed_document.txt");
+    if (!renameResponse.equals("Renamed")) {
+      api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+      api.deleteEntity(appUrl, entityName, newEntityID);
+      fail("Could not rename attachment: " + renameResponse);
+    }
+
+    // Step 6: Save and validate the extension change error message
+    String saveWithWarningResponse = api.saveEntityDraft(appUrl, entityName, srvpath, newEntityID);
+    assertNotNull(saveWithWarningResponse, "Response should not be null");
+
+    String expectedMessage =
+        "Changing the file extension is not allowed. The file \"renamed_document.txt\" must retain its original extension \".pdf\".";
+
+    com.fasterxml.jackson.databind.JsonNode messagesNode =
+        new ObjectMapper().readTree(saveWithWarningResponse);
+    assertTrue(messagesNode.isArray(), "sap-messages response should be a JSON array");
+
+    boolean foundExtensionError = false;
+    for (com.fasterxml.jackson.databind.JsonNode messageNode : messagesNode) {
+      if (messageNode.has("message")) {
+        String message = messageNode.get("message").asText();
+        if (message.contains("Changing the file extension is not allowed")) {
+          foundExtensionError = true;
+          assertEquals(
+              expectedMessage,
+              message,
+              "Extension change error message does not match expected value");
+          break;
         }
-      } else {
-        api.saveEntityDraft(appUrl, entityName, srvpath, entityID);
       }
     }
-    if (!testStatus) {
-      fail("Attachment was renamed with unsupported characters");
-    }
+
+    assertTrue(
+        foundExtensionError,
+        "Expected extension change warning not found in response. Full response: "
+            + saveWithWarningResponse);
+
+    // Clean up
+    api.deleteEntity(appUrl, entityName, newEntityID);
   }
 }


### PR DESCRIPTION
## Describe your changes

We have recently implemented a validation check on rename of file names, where user should not be able to update the extension/mimetype of a file while rename. 

This PR will add integration tests for this scenario.

#### Any documentation

<img width="2444" height="1162" alt="image" src="https://github.com/user-attachments/assets/5a7b2a35-058e-4cf3-850c-a1db80494567" />


## Type of change

Please delete options that are not relevant.

- [x] Integration Test

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description
