### PR TITLE
Update sideEffect to read boolean flag of parent entity on createLink

### DIFF
--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -28,7 +28,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -63,7 +63,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -98,7 +98,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -130,7 +130,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -161,7 +161,7 @@ service AdminService @(requires: ['admin','system-user']) {
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -194,7 +194,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -226,7 +226,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -258,7 +258,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -304,7 +304,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',


### PR DESCRIPTION
Upload button was not getting disabled when last attachment allowed was of link type. This was because SideEffect added on Custom Link button was not refreshing/reading the parent entity. Hence, the newly defined virtual Boolean flag was never read resulting in enabled Upload button.
Added @(Common.SideEffects : {TargetEntities: ['up_']},) which allows to read parent entities metadata as well, resulting in disabling Upload button.