### PR TITLE
Update sideEffect to read boolean flag of parent entity on createLink

### DIFF
--- a/cap-notebook/demoapp/srv/admin-service.cds
+++ b/cap-notebook/demoapp/srv/admin-service.cds
@@ -29,7 +29,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -64,7 +64,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -99,7 +99,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -131,7 +131,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -162,7 +162,7 @@ service AdminService @(requires: ['admin','system-user']) {
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -195,7 +195,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -227,7 +227,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -259,7 +259,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -305,7 +305,7 @@ service AdminService @(requires: ['admin','system-user']) {
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
 
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',


### PR DESCRIPTION
Upload button was not getting disabled when last attachment allowed was of link type. This was because SideEffect added on Custom Link button was not refreshing/reading the parent entity. Hence, the newly defined virtual Boolean flag was never read resulting in enabled Upload button.
Added @(Common.SideEffects : {TargetEntities: ['up_']},) which allows to read parent entities metadata as well, resulting in disabling Upload button.