### PR TITLE
user defined error msg for maximum upload of attachments

### DIFF
--- a/app/multi-tenant/central-space/cloud-cap-samples-java/srv/src/main/resources/messages.properties
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/srv/src/main/resources/messages.properties
@@ -11,4 +11,4 @@ order.exceeds.stock = {0} exceeds stock for book
 review.add.forbidden=User not allowed to add more than one review for a given book
 book.import.failed = Import of books failed
 book.import.invalid.csv = Invalid CSV structure found - Please check its content
-SDM.Attachments.maxCountError = Maximum number of attachments reached in English
+SDM.maxCountErrorMessage = Maximum number of attachments reached in English

--- a/app/multi-tenant/personal-space/cloud-cap-samples-java/srv/src/main/resources/messages.properties
+++ b/app/multi-tenant/personal-space/cloud-cap-samples-java/srv/src/main/resources/messages.properties
@@ -11,4 +11,4 @@ order.exceeds.stock = {0} exceeds stock for book
 review.add.forbidden=User not allowed to add more than one review for a given book
 book.import.failed = Import of books failed
 book.import.invalid.csv = Invalid CSV structure found - Please check its content
-SDM.Attachments.maxCountError = Maximum number of attachments reached in English
+SDM.maxCountErrorMessage = Maximum number of attachments reached in English

--- a/app/single-tenant/central-space/demoapp/srv/src/main/resources/messages.properties
+++ b/app/single-tenant/central-space/demoapp/srv/src/main/resources/messages.properties
@@ -1,1 +1,1 @@
-SDM.Attachments.maxCountError = Maximum number of attachments reached in English
+SDM.maxCountErrorMessage = Maximum number of attachments reached in English

--- a/app/single-tenant/personal-space/demoapp/srv/src/main/resources/messages.properties
+++ b/app/single-tenant/personal-space/demoapp/srv/src/main/resources/messages.properties
@@ -1,1 +1,1 @@
-SDM.Attachments.maxCountError = Maximum number of attachments reached in English
+SDM.maxCountErrorMessage = Maximum number of attachments reached in English

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -3979,7 +3979,7 @@ class IntegrationTest_MultipleFacet {
         String errorMessage = json.getJSONObject("error").getString("message");
         assertEquals("500", errorCode);
         if (facetName.equals("references")) {
-          assertEquals("Cannot upload more than 5 attachments.", errorMessage);
+          assertEquals("Maximum number of attachments reached in English", errorMessage);
         } else if (facetName.equals("attachments")) {
           assertEquals("Maximum number of attachments reached in English", errorMessage);
         }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_MultipleFacet.java
@@ -2510,7 +2510,7 @@ class IntegrationTest_MultipleFacet {
         response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID4);
         if (response.equals("Saved")) {
           String expectedJson =
-              "{\"error\":{\"code\":\"500\",\"message\":\"Cannot upload more than 4 attachments.\"}}";
+              "{\"error\":{\"code\":\"500\",\"message\":\"Maximum number of attachments reached in English\"}}";
           ObjectMapper objectMapper = new ObjectMapper();
           JsonNode actualJsonNode = objectMapper.readTree(check);
           JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
@@ -2558,7 +2558,7 @@ class IntegrationTest_MultipleFacet {
         System.out.println("Result message for attachment " + i + ": " + resultMessage);
 
         String expectedResponse =
-            "{\"error\":{\"code\":\"500\",\"message\":\"Cannot upload more than 4 attachments.\"}}";
+            "{\"error\":{\"code\":\"500\",\"message\":\"Maximum number of attachments reached in English\"}}";
         if (resultMessage.equals(expectedResponse)) {
           ObjectMapper objectMapper = new ObjectMapper();
           JsonNode actualJsonNode = objectMapper.readTree(resultMessage);
@@ -3981,7 +3981,7 @@ class IntegrationTest_MultipleFacet {
         if (facetName.equals("references")) {
           assertEquals("Cannot upload more than 5 attachments.", errorMessage);
         } else if (facetName.equals("attachments")) {
-          assertEquals("Cannot upload more than 4 attachments.", errorMessage);
+          assertEquals("Maximum number of attachments reached in English", errorMessage);
         }
       }
     }

--- a/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
+++ b/sdm/src/test/java/integration/com/sap/cds/sdm/IntegrationTest_SingleFacet.java
@@ -2367,7 +2367,7 @@ class IntegrationTest_SingleFacet {
         response = api.saveEntityDraft(appUrl, entityName, srvpath, entityID4);
         if (response.equals("Saved")) {
           String expectedJson =
-              "{\"error\":{\"code\":\"500\",\"message\":\"Cannot upload more than 4 attachments.\"}}";
+              "{\"error\":{\"code\":\"500\",\"message\":\"Maximum number of attachments reached in English\"}}";
           ObjectMapper objectMapper = new ObjectMapper();
           JsonNode actualJsonNode = objectMapper.readTree(check);
           JsonNode expectedJsonNode = objectMapper.readTree(expectedJson);
@@ -2415,7 +2415,7 @@ class IntegrationTest_SingleFacet {
         System.out.println("Result message for attachment " + i + ": " + resultMessage);
 
         String expectedResponse =
-            "{\"error\":{\"code\":\"500\",\"message\":\"Cannot upload more than 4 attachments.\"}}";
+            "{\"error\":{\"code\":\"500\",\"message\":\"Maximum number of attachments reached in English\"}}";
         if (resultMessage.equals(expectedResponse)) {
           ObjectMapper objectMapper = new ObjectMapper();
           JsonNode actualJsonNode = objectMapper.readTree(resultMessage);
@@ -3504,7 +3504,7 @@ class IntegrationTest_SingleFacet {
         String errorCode = json.getJSONObject("error").getString("code");
         String errorMessage = json.getJSONObject("error").getString("message");
         assertEquals("500", errorCode);
-        assertEquals("Cannot upload more than 4 attachments.", errorMessage);
+        assertEquals("Maximum number of attachments reached in English", errorMessage);
       }
       String response = api.saveEntityDraft(appUrl, entityName, srvpath, createLinkEntity);
       if (!response.equals("Saved")) {


### PR DESCRIPTION
## Describe your changes

->  **Problem**

When users configured a custom error message for the maximum attachment upload limit, the application always displayed the default message:

"Cannot upload more than X attachments."

instead of the user-defined custom message.

-> **Root Cause**

The leading application was using an incorrect configuration key mapping:

Incorrect: SDM.Attachments.maxCountError
Correct: SDM.maxCountError

As a result, the custom error message configuration was not being picked up.

-> **Fix**

Updated the key mapping in the leading application from SDM.Attachments.maxCountError to SDM.maxCountError to correctly resolve and display the user-configured error message when the maximum upload limit is exceeded.

-> **Validation**

Verified that the custom error message is displayed correctly when the attachment upload count exceeds the configured maximum limit.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Before fix

<img width="660" height="458" alt="Screenshot 2026-06-19 at 10 54 03 AM" src="https://github.com/user-attachments/assets/05bed5da-e906-4254-aa45-c9d3af77373a" />


After fix 

<img width="641" height="375" alt="Screenshot 2026-06-19 at 10 46 56 AM" src="https://github.com/user-attachments/assets/257fc80c-ebf1-4216-b12d-84ffcc6fb2f2" />

Single tenant Integration tests

https://github.com/cap-java/sdm/actions/runs/27815453016
<img width="1708" height="438" alt="Screenshot 2026-06-22 at 11 26 26 PM" src="https://github.com/user-attachments/assets/dd6ce7b2-ecb5-4ea0-8ab5-afbd858876f2" />

Multi tenant Integration tests

https://github.com/cap-java/sdm/actions/runs/27814115842
<img width="1699" height="535" alt="Screenshot 2026-06-23 at 1 15 04 PM" src="https://github.com/user-attachments/assets/a9fe5239-c8bc-4c26-ad93-cf6f5bff0126" />
