### PR TITLE
Fix issue in discarding newly created entities which has multi-level of nested children

### DIFF
--- a/.github/workflows/multiTenancyDeployLocal.yml
+++ b/.github/workflows/multiTenancyDeployLocal.yml
@@ -94,6 +94,7 @@ jobs:
             echo "java version:"
             java --version
             sed -i 's|__REPOSITORY_ID__|${{ steps.set_repository_id.outputs.repository_id }}|g' mta.yaml
+            sed -i 's|__DATABASE_ID__|${{ secrets.DATABASE_ID }}|g' mta.yaml
             mbt build
             echo "✅ MBT build completed!"
 

--- a/.github/workflows/multiTenant_deploy_and_Integration_test.yml
+++ b/.github/workflows/multiTenant_deploy_and_Integration_test.yml
@@ -67,6 +67,7 @@ jobs:
             echo "java version:"
             java --version
             sed -i 's|__REPOSITORY_ID__|${{ steps.set_repository_id.outputs.repository_id }}|g' mta.yaml
+            sed -i 's|__DATABASE_ID__|${{ secrets.DATABASE_ID }}|g' mta.yaml
             mbt build
             echo "✅ MBT build completed!"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 sdm/target/
+**/target/
 .flattened-pom.xml
 node_modules/
+**/package-lock.json
+**/src/gen/
 
 # Compiled class file
 *.class
@@ -22,6 +25,12 @@ node_modules/
 *.zip
 *.tar.gz
 *.rar
+*.hdbtable
+*.hdbview
+*.xml
+*.json
+*.sql
+*.mtar
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/app/multi-tenant/central-space/cloud-cap-samples-java/db/pom.xml
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/db/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>sdm</artifactId>
-            <version>1.8.1-SNAPSHOT</version>
+            <version>1.10.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 	

--- a/app/multi-tenant/central-space/cloud-cap-samples-java/mta.yaml
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/mta.yaml
@@ -52,6 +52,8 @@ modules:
     parameters:
       memory: 256M
       disk-quota: 1024M
+    properties:
+      DATABASE_ID: __DATABASE_ID__  # Placeholder for DATABASE_ID
     build-parameters:
       builder: custom
       build-result: gen

--- a/app/multi-tenant/central-space/cloud-cap-samples-java/mtx/sidecar/server.js
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/mtx/sidecar/server.js
@@ -1,0 +1,18 @@
+const cds = require('@sap/cds');
+
+const LOG = cds.log('server');
+
+cds.once('bootstrap', async (app) => {
+  const databaseId = process.env.DATABASE_ID;
+  if (databaseId && databaseId !== 'REPLACE_WITH_YOUR_DATABASE_ID') {
+    cds.env.requires['cds.xt.DeploymentService'] ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi.create ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi.create.database_id = databaseId;
+    LOG.info(`Configured HDI database_id from environment`);
+  } else {
+    LOG.error(`DATABASE_ID environment variable is not set or is still the placeholder. HDI container creation will fail.`);
+  }
+});
+
+module.exports = cds.server;

--- a/app/multi-tenant/central-space/cloud-cap-samples-java/srv/pom.xml
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/srv/pom.xml
@@ -40,7 +40,7 @@
 <dependency>
     <groupId>com.sap.cds</groupId>
     <artifactId>sdm</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.10.1-SNAPSHOT</version>
 </dependency>
 		<dependency>
 			<groupId>com.sap.cds</groupId>

--- a/app/multi-tenant/personal-space/cloud-cap-samples-java/mta.yaml
+++ b/app/multi-tenant/personal-space/cloud-cap-samples-java/mta.yaml
@@ -52,6 +52,8 @@ modules:
     parameters:
       memory: 256M
       disk-quota: 1024M
+    properties:
+      DATABASE_ID: __DATABASE_ID__  # Placeholder for DATABASE_ID
     build-parameters:
       builder: custom
       build-result: gen

--- a/app/multi-tenant/personal-space/cloud-cap-samples-java/mtx/sidecar/server.js
+++ b/app/multi-tenant/personal-space/cloud-cap-samples-java/mtx/sidecar/server.js
@@ -1,0 +1,18 @@
+const cds = require('@sap/cds');
+
+const LOG = cds.log('server');
+
+cds.once('bootstrap', async (app) => {
+  const databaseId = process.env.DATABASE_ID;
+  if (databaseId && databaseId !== 'REPLACE_WITH_YOUR_DATABASE_ID') {
+    cds.env.requires['cds.xt.DeploymentService'] ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi.create ??= {};
+    cds.env.requires['cds.xt.DeploymentService'].hdi.create.database_id = databaseId;
+    LOG.info(`Configured HDI database_id from environment`);
+  } else {
+    LOG.error(`DATABASE_ID environment variable is not set or is still the placeholder. HDI container creation will fail.`);
+  }
+});
+
+module.exports = cds.server;

--- a/app/single-tenant/central-space/demoapp/db/pom.xml
+++ b/app/single-tenant/central-space/demoapp/db/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.sap.cds</groupId>
             <artifactId>sdm</artifactId>
-            <version>1.8.1-SNAPSHOT</version>
+            <version>1.10.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 	

--- a/app/single-tenant/central-space/demoapp/srv/pom.xml
+++ b/app/single-tenant/central-space/demoapp/srv/pom.xml
@@ -18,7 +18,7 @@
          <dependency>
           <groupId>com.sap.cds</groupId>
            <artifactId>sdm</artifactId>
-          <version>1.8.1-SNAPSHOT</version>
+          <version>1.10.1-SNAPSHOT</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.8.1-SNAPSHOT</revision>
+        <revision>1.10.1-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.8.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.8.1-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/helper/AttachmentsHandlerUtils.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/handler/applicationservice/helper/AttachmentsHandlerUtils.java
@@ -62,20 +62,30 @@ public class AttachmentsHandlerUtils {
   }
 
   /**
-   * Creates a mapping of attachment entity paths to their corresponding actual paths within the CDS
-   * model.
+   * Creates a mapping of direct attachment entity paths for the given CDS entity.
    *
-   * <p>This method analyzes both direct and nested attachment compositions within the given entity.
-   * It processes direct attachments that are immediate compositions of the entity, and also
-   * traverses nested compositions to find attachments in related entities. The resulting mapping
-   * provides a translation between logical attachment paths and their actual implementation paths.
+   * <p>This method processes only direct attachment compositions (immediate compositions of the
+   * entity that target sap.attachments.Attachments). Nested compositions are not traversed.
    *
-   * @param model the CDS model containing entity definitions and relationships
-   * @param entity the target CDS entity to analyze for attachment path mappings
-   * @param persistenceService the persistence service used for data access operations
-   * @return a map where keys are attachment entity paths and values are the corresponding actual
-   *     paths, or an empty map if no attachments are found or if an error occurs during processing
+   * @param entity the target CDS entity to analyze for direct attachment path mappings
+   * @return a map where keys and values are the direct attachment entity paths, or an empty map if
+   *     no direct attachments are found
    */
+  public static Map<String, String> getDirectAttachmentPathMapping(CdsEntity entity) {
+    logger.debug(
+        "Getting direct attachment path mapping for entity: {}", entity.getQualifiedName());
+    Map<String, String> pathMapping = new HashMap<>();
+    entity
+        .compositions()
+        .forEach(
+            composition -> processDirectAttachmentComposition(entity, pathMapping, composition));
+    logger.debug(
+        "Found {} direct attachment path mappings for entity: {}",
+        pathMapping.size(),
+        entity.getQualifiedName());
+    return pathMapping;
+  }
+
   public static Map<String, String> getAttachmentPathMapping(
       CdsModel model, CdsEntity entity, PersistenceService persistenceService) {
     logger.debug("Getting attachment path mapping for entity: {}", entity.getQualifiedName());

--- a/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/persistence/DBQuery.java
@@ -568,37 +568,41 @@ public class DBQuery {
       String objectId,
       AttachmentReadEventContext context) {
     logger.debug("Fetching uploadStatus for objectId: {} from entity: {}", objectId, entity);
-    Optional<CdsEntity> attachmentEntity = context.getModel().findEntity(entity + "_drafts");
-    CqnSelect q =
-        Select.from(attachmentEntity.get())
-            .columns("uploadStatus")
-            .where(doc -> doc.get("objectId").eq(objectId));
-    Result result = persistenceService.run(q);
     CmisDocument cmisDocument = new CmisDocument();
     boolean isAttachmentFound = false;
-    for (Row row : result.list()) {
-      cmisDocument.setUploadStatus(
-          row.get("uploadStatus") != null
-              ? row.get("uploadStatus").toString()
-              : SDMConstants.UPLOAD_STATUS_IN_PROGRESS);
-      isAttachmentFound = true;
+    Optional<CdsEntity> draftEntityOpt = context.getModel().findEntity(entity + "_drafts");
+    if (draftEntityOpt.isPresent()) {
+      CqnSelect q =
+          Select.from(draftEntityOpt.get())
+              .columns("uploadStatus")
+              .where(doc -> doc.get("objectId").eq(objectId));
+      Result result = persistenceService.run(q);
+      for (Row row : result.list()) {
+        cmisDocument.setUploadStatus(
+            row.get("uploadStatus") != null
+                ? row.get("uploadStatus").toString()
+                : SDMConstants.UPLOAD_STATUS_IN_PROGRESS);
+        isAttachmentFound = true;
+      }
     }
     if (!isAttachmentFound) {
       logger.debug(
           "Attachment not found in draft table for objectId: {}, checking active entity: {}",
           objectId,
           entity);
-      attachmentEntity = context.getModel().findEntity(entity);
-      q =
-          Select.from(attachmentEntity.get())
-              .columns("uploadStatus")
-              .where(doc -> doc.get("objectId").eq(objectId));
-      result = persistenceService.run(q);
-      for (Row row : result.list()) {
-        cmisDocument.setUploadStatus(
-            row.get("uploadStatus") != null
-                ? row.get("uploadStatus").toString()
-                : SDMConstants.UPLOAD_STATUS_IN_PROGRESS);
+      Optional<CdsEntity> activeEntityOpt = context.getModel().findEntity(entity);
+      if (activeEntityOpt.isPresent()) {
+        CqnSelect q =
+            Select.from(activeEntityOpt.get())
+                .columns("uploadStatus")
+                .where(doc -> doc.get("objectId").eq(objectId));
+        Result result = persistenceService.run(q);
+        for (Row row : result.list()) {
+          cmisDocument.setUploadStatus(
+              row.get("uploadStatus") != null
+                  ? row.get("uploadStatus").toString()
+                  : SDMConstants.UPLOAD_STATUS_IN_PROGRESS);
+        }
       }
     }
     logger.debug(

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -187,18 +187,13 @@ public class SDMServiceGenericHandler implements EventHandler {
     logger.debug("Processing draft cancel for entity: {}", parentEntityName);
 
     Optional<CdsEntity> parentActiveEntityOpt = context.getModel().findEntity(parentEntityName);
-    Map<String, String> compositionPathMapping =
-        parentActiveEntityOpt
-            .map(
-                cdsEntity ->
-                    AttachmentsHandlerUtils.getAttachmentPathMapping(
-                        context.getModel(), cdsEntity, persistenceService))
-            .orElse(new HashMap<>());
-
-    logger.debug("Found {} composition paths to process", compositionPathMapping.size());
-    for (Map.Entry<String, String> entry : compositionPathMapping.entrySet()) {
-      String attachmentCompositionDefinition = entry.getKey();
-      revertLinksForComposition(context, parentKeys, attachmentCompositionDefinition);
+    if (parentActiveEntityOpt.isPresent()) {
+      Map<String, String> compositionPathMapping =
+          AttachmentsHandlerUtils.getDirectAttachmentPathMapping(parentActiveEntityOpt.get());
+      logger.debug("Found {} composition paths to process", compositionPathMapping.size());
+      for (Map.Entry<String, String> entry : compositionPathMapping.entrySet()) {
+        revertLinksForComposition(context, parentKeys, entry.getKey());
+      }
     }
     revertNestedEntityLinks(context);
     logger.debug("END: Handle draft discard for links");
@@ -697,7 +692,13 @@ public class SDMServiceGenericHandler implements EventHandler {
       throws ServiceException {
     logger.debug("Checking attachment constraints for upID: {}", upID);
     CdsModel cdsModel = context.getModel();
-    CdsEntity attachmentEntity = cdsModel.findEntity(context.getTarget().getQualifiedName()).get();
+    CdsEntity attachmentEntity =
+        cdsModel
+            .findEntity(context.getTarget().getQualifiedName())
+            .orElseThrow(
+                () ->
+                    new ServiceException(
+                        "Entity not found in model: " + context.getTarget().getQualifiedName()));
 
     // Fetch the row count for current repository
     Result result =

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -1798,6 +1798,211 @@ public class SDMServiceGenericHandlerTest {
   }
 
   @Test
+  void testHandleDraftDiscardForLinks_OnlyDirectAttachmentsProcessedViaPathMapping()
+      throws IOException {
+    // Verifies that handleDraftDiscardForLinks uses getDirectAttachmentPathMapping (not
+    // getAttachmentPathMapping) on the root entity — i.e. only direct attachments on the root
+    // are processed via Path 1. Nested attachments are handled exclusively by
+    // revertNestedEntityLinks.
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+
+      attachmentUtilsMock
+          .when(
+              () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(eq(parentActiveEntity)))
+          .thenReturn(new HashMap<>());
+
+      sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext);
+
+      // getDirectAttachmentPathMapping must be called on the root entity
+      attachmentUtilsMock.verify(
+          () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(eq(parentActiveEntity)),
+          times(1));
+
+      // getAttachmentPathMapping must NOT be called on the root entity
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(cdsModel), eq(parentActiveEntity), any()),
+          never());
+    }
+  }
+
+  @Test
+  void testHandleDraftDiscardForLinks_DirectAttachmentOnRootIsReverted() throws IOException {
+    // Verifies that when the root entity has a direct attachment composition,
+    // revertLinksForComposition is called for it via Path 1 (getDirectAttachmentPathMapping).
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsEntity attachmentDraftEntity = mock(CdsEntity.class);
+    CdsEntity attachmentActiveEntity = mock(CdsEntity.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+    when(parentActiveEntity.compositions()).thenReturn(Stream.empty());
+
+    // Direct attachment on root
+    Map<String, String> directMapping = new HashMap<>();
+    directMapping.put("AdminService.Books.attachments", "AdminService.Books.attachments");
+
+    when(cdsModel.findEntity("AdminService.Books.attachments_drafts"))
+        .thenReturn(Optional.of(attachmentDraftEntity));
+    when(cdsModel.findEntity("AdminService.Books.attachments"))
+        .thenReturn(Optional.of(attachmentActiveEntity));
+
+    CdsElement upElement = mock(CdsElement.class);
+    when(attachmentDraftEntity.elements()).thenReturn(Stream.of(upElement));
+    when(upElement.getName()).thenReturn("up__ID");
+    sdmUtilsMock.when(() -> SDMUtils.getUpIdKey(attachmentDraftEntity)).thenReturn("up__ID");
+
+    Result emptyResult = mock(Result.class);
+    when(emptyResult.iterator()).thenReturn(Collections.emptyIterator());
+    when(persistenceService.run(any(CqnSelect.class))).thenReturn(emptyResult);
+
+    SDMCredentials sdmCredentials = mock(SDMCredentials.class);
+    UserInfo userInfo = mock(UserInfo.class);
+    when(tokenHandler.getSDMCredentials()).thenReturn(sdmCredentials);
+    when(draftContext.getUserInfo()).thenReturn(userInfo);
+    when(userInfo.isSystemUser()).thenReturn(false);
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+      attachmentUtilsMock
+          .when(
+              () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(eq(parentActiveEntity)))
+          .thenReturn(directMapping);
+
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
+
+      // persistence was called — confirming revertLinksForComposition was entered for the direct
+      // attachment
+      verify(persistenceService, atLeastOnce()).run(any(CqnSelect.class));
+    }
+  }
+
+  @Test
+  void testHandleDraftDiscardForLinks_GrandchildAttachmentDoesNotCrash() throws IOException {
+    // Regression test for the bug: root → Chapters (no attachments) → Sections (has attachments).
+    // With the old code, getAttachmentPathMapping on root would construct a wrong entity name
+    // "AdminService.Chapters.attachments" causing NoSuchElementException.
+    // With the fix, getDirectAttachmentPathMapping returns empty for root (no direct attachments),
+    // and revertNestedEntityLinks correctly handles Sections via Chapters.
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+    CdsEntity parentActiveEntity = mock(CdsEntity.class);
+    CdsElement chaptersComposition = mock(CdsElement.class);
+    CdsAssociationType chaptersAssocType = mock(CdsAssociationType.class);
+    CdsEntity chaptersEntity = mock(CdsEntity.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.of(parentActiveEntity));
+
+    // Root has one composition: Chapters (no direct attachments)
+    when(parentActiveEntity.compositions()).thenReturn(Stream.of(chaptersComposition));
+    when(chaptersComposition.getType()).thenReturn(chaptersAssocType);
+    when(chaptersAssocType.getTarget()).thenReturn(chaptersEntity);
+    when(chaptersEntity.getQualifiedName()).thenReturn("AdminService.Chapters");
+
+    // Chapters_drafts does not exist (simulates non-draft-enabled or grandchild scenario)
+    when(cdsModel.findEntity("AdminService.Chapters_drafts")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+
+      // Root has NO direct attachments
+      attachmentUtilsMock
+          .when(
+              () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(eq(parentActiveEntity)))
+          .thenReturn(new HashMap<>());
+
+      // Must not throw NoSuchElementException
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
+
+      // getDirectAttachmentPathMapping called on root — not getAttachmentPathMapping
+      attachmentUtilsMock.verify(
+          () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(eq(parentActiveEntity)),
+          times(1));
+      attachmentUtilsMock.verify(
+          () ->
+              AttachmentsHandlerUtils.getAttachmentPathMapping(
+                  eq(cdsModel), eq(parentActiveEntity), any()),
+          never());
+    }
+  }
+
+  @Test
+  void testHandleDraftDiscardForLinks_ActiveEntityNotFound_SkipsDirectAttachments()
+      throws IOException {
+    // When the active entity is not found in the model, no attachment processing should occur.
+    DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);
+    CdsEntity parentDraftEntity = mock(CdsEntity.class);
+    CqnAnalyzer analyzer = mock(CqnAnalyzer.class);
+    AnalysisResult analysisResult = mock(AnalysisResult.class);
+    CqnDelete cqnDelete = mock(CqnDelete.class);
+
+    when(draftContext.getTarget()).thenReturn(parentDraftEntity);
+    when(parentDraftEntity.getQualifiedName()).thenReturn("AdminService.Books_drafts");
+    when(draftContext.getModel()).thenReturn(cdsModel);
+    when(draftContext.getCqn()).thenReturn(cqnDelete);
+    cqnAnalyzerMock.when(() -> CqnAnalyzer.create(cdsModel)).thenReturn(analyzer);
+    when(analyzer.analyze(cqnDelete)).thenReturn(analysisResult);
+    when(analysisResult.rootKeys()).thenReturn(Map.of("ID", "book123"));
+    when(cdsModel.findEntity("AdminService.Books")).thenReturn(Optional.empty());
+
+    try (var attachmentUtilsMock =
+        mockStatic(
+            com.sap.cds.sdm.handler.applicationservice.helper.AttachmentsHandlerUtils.class)) {
+
+      assertDoesNotThrow(() -> sdmServiceGenericHandler.handleDraftDiscardForLinks(draftContext));
+
+      // Neither method should be called since active entity is absent
+      attachmentUtilsMock.verify(
+          () -> AttachmentsHandlerUtils.getDirectAttachmentPathMapping(any()), never());
+      attachmentUtilsMock.verify(
+          () -> AttachmentsHandlerUtils.getAttachmentPathMapping(any(), any(), any()), never());
+    }
+  }
+
+  @Test
   void testRevertNestedEntityLinks_WithNullParentId() throws IOException {
 
     DraftCancelEventContext draftContext = mock(DraftCancelEventContext.class);


### PR DESCRIPTION

## Issue 1: NoSuchElementException during draft discard when attachments exist on a grandchild composition entity

Root Cause:
handleDraftDiscardForLinks was calling getAttachmentPathMapping on the root entity being discarded. This method traverses nested compositions to find attachment entities, but buildEntityPath always used the direct child entity as the namespace when constructing the map key — regardless of how deep the actual attachment entity lived.

For example, given the structure:
SourcingEventsServiceEntity
  └── TeamAddinsServiceEntity    (direct child, no attachments)
        └── TeamsServiceEntity
              └── attachments    (grandchild)
buildEntityPath produced SourcingEventService.TeamAddinsServiceEntity.attachments instead of SourcingEventService.TeamsServiceEntity.attachments. When revertLinksForComposition appended _drafts and called model.findEntity(...), the entity was not found, causing NoSuchElementException.

Fix:
Added getDirectAttachmentPathMapping in AttachmentsHandlerUtils that only processes direct sap.attachments.Attachments compositions on the root entity — no nested traversal.
Updated handleDraftDiscardForLinks to use getDirectAttachmentPathMapping for Path 1 (root entity direct attachments).
Nested attachment handling is already correctly implemented in the existing revertNestedEntityLinks → processNestedEntityComposition path (Path 2), which calls getAttachmentPathMapping on each direct child individually — meaning targetEntity always equals the entity where the attachment actually lives.
Additionally fixed unsafe Optional.get() calls without isPresent() checks in DBQuery.getuploadStatusForAttachment.

## Issue 2: Multi-tenant application Subscription failure

Root Cause:
A second HANA Cloud database (adms-hana) was added to the provider subaccount. With multiple HANA instances present, Service Manager requires an explicit database_id parameter to know which database to provision HDI containers on — without it, every subscription attempt fails with a broker error.

Fix:
Added DATABASE_ID as a CF environment property on the MTX sidecar module in mta.yaml, injected at deploy time from a GitHub environment secret. A server.js bootstrap hook reads this value at runtime and sets it on cds.env.requires['cds.xt.DeploymentService'].hdi.create.database_id, since CDS does not auto-resolve environment variables in nested hdi.create configuration. This ensures Service Manager always targets the correct HANA instance (9e43eb96) regardless of how many databases exist in the subaccount.


#### Any documentation
The issue only manifests when attachments are defined on a grandchild or deeper composition of the draft-cancelled entity. Applications where attachments are directly on the first-level child (like the standard demo app) are unaffected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/28505618401
Multi-tenant Integration tests: https://github.com/cap-java/sdm/actions/runs/28516956119

Tested the customer scenario by creating a entity structure similar to customer application and reproducing the issue and then validated the same scenario with the fix branch

Tested Subscription and Unsubscription of multi-tenant application
