### PR TITLE
Fix BlackDuck security risks

### DIFF
--- a/app/multi-tenant/central-space/cloud-cap-samples-java/pom.xml
+++ b/app/multi-tenant/central-space/cloud-cap-samples-java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.5.16</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -70,6 +70,27 @@
 				<groupId>com.sap.cloud.servicesdk.xbem</groupId>
 				<artifactId>emjapi-extension-sap-cp-jms</artifactId>
 				<version>4.0.0</version>
+			</dependency>
+
+			<!-- Security: fix Netty CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.2.15.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Bouncy Castle CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
 			</dependency>
 
 		</dependencies>

--- a/app/multi-tenant/personal-space/cloud-cap-samples-java/pom.xml
+++ b/app/multi-tenant/personal-space/cloud-cap-samples-java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.5.16</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -70,6 +70,27 @@
 				<groupId>com.sap.cloud.servicesdk.xbem</groupId>
 				<artifactId>emjapi-extension-sap-cp-jms</artifactId>
 				<version>4.0.0</version>
+			</dependency>
+
+			<!-- Security: fix Netty CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.2.15.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Bouncy Castle CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
 			</dependency>
 
 		</dependencies>

--- a/app/single-tenant/central-space/demoapp/pom.xml
+++ b/app/single-tenant/central-space/demoapp/pom.xml
@@ -18,7 +18,7 @@
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>21</jdk.version>
 		<cds.services.version>4.1.1</cds.services.version>
-		<spring.boot.version>3.3.1</spring.boot.version>
+		<spring.boot.version>3.5.16</spring.boot.version>
 		<cds.install-cdsdk.version>8.0.2</cds.install-cdsdk.version>
 
 		<cds.install-node.downloadUrl>https://nodejs.org/dist/</cds.install-node.downloadUrl>
@@ -47,6 +47,27 @@
 				<version>${spring.boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Netty CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.2.15.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Bouncy Castle CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/app/single-tenant/personal-space/demoapp/pom.xml
+++ b/app/single-tenant/personal-space/demoapp/pom.xml
@@ -18,7 +18,7 @@
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>21</jdk.version>
 		<cds.services.version>4.1.1</cds.services.version>
-		<spring.boot.version>3.3.1</spring.boot.version>
+		<spring.boot.version>3.5.16</spring.boot.version>
 		<cds.install-cdsdk.version>8.0.2</cds.install-cdsdk.version>
 
 		<cds.install-node.downloadUrl>https://nodejs.org/dist/</cds.install-node.downloadUrl>
@@ -47,6 +47,27 @@
 				<version>${spring.boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Netty CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.2.15.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<!-- Security: fix Bouncy Castle CVEs (BlackDuck) -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
- Upgrade spring-boot-starter-parent from 3.2.6 to 3.5.16 in multi-tenant apps (resolves transitive CVEs in Tomcat 10.1.x, Spring Framework 6.1.x, Spring Security 6.2/6.3, jackson-databind 2.15/2.17)
- Upgrade spring.boot.version from 3.3.1 to 3.5.16 in single-tenant apps (resolves Spring Boot 3.3.1 CVEs and above transitive dependencies)
- Add dependencyManagement overrides for Netty 4.2.15.Final (was 4.1.110.Final)
- Add dependencyManagement overrides for Bouncy Castle 1.84 (was 1.78.1)

## Type of change

Please delete options that are not relevant.

- [x] Blackduck Scan fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [ ] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description
