### PR TITLE
Fix: NoSuchElementException on Discard Draft

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.10.1-SNAPSHOT</revision>
+        <revision>1.0.0-RC1</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <revision>1.0.0-RC1</revision>
+        <revision>1.10.1-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
+++ b/sdm/src/main/java/com/sap/cds/sdm/service/handler/SDMServiceGenericHandler.java
@@ -277,8 +277,15 @@ public class SDMServiceGenericHandler implements EventHandler {
 
     CdsModel model = context.getModel();
     String draftEntityName = attachmentCompositionDefinition + "_drafts";
-    CdsEntity draftEntity = model.findEntity(draftEntityName).get();
-    CdsEntity activeEntity = model.findEntity(attachmentCompositionDefinition).get();
+    Optional<CdsEntity> draftEntityOpt = model.findEntity(draftEntityName);
+    Optional<CdsEntity> activeEntityOpt = model.findEntity(attachmentCompositionDefinition);
+    if (!draftEntityOpt.isPresent() || !activeEntityOpt.isPresent()) {
+      logger.debug(
+          "Entity not found in model, skipping revert for: {}", attachmentCompositionDefinition);
+      return;
+    }
+    CdsEntity draftEntity = draftEntityOpt.get();
+    CdsEntity activeEntity = activeEntityOpt.get();
 
     final String upIdKey = SDMUtils.getUpIdKey(draftEntity);
     if (upIdKey == null || upIdKey.isEmpty()) {
@@ -299,6 +306,9 @@ public class SDMServiceGenericHandler implements EventHandler {
 
     Result draftLinks = persistenceService.run(selectDraftLinks);
     logger.debug("Found {} draft links to process", draftLinks.rowCount());
+    if (draftLinks.rowCount() == 0) {
+      return;
+    }
     SDMCredentials sdmCredentials = tokenHandler.getSDMCredentials();
     Boolean isSystemUser = context.getUserInfo().isSystemUser();
 

--- a/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
+++ b/sdm/src/main/resources/cds/com.sap.cds/sdm/attachments.cds
@@ -22,8 +22,6 @@ extend aspect Attachments with {
     type : String @(UI: {IsImageURL: true}) default 'sap-icon://document';
     uploadStatus : UploadStatusCode default 'uploading' @readonly ;
     uploadStatusNav : Association to one UploadScanStates on uploadStatusNav.code = uploadStatus;
-   } actions {
-    action downloadSelectedAttachments(ids: String) returns String;
    }
      entity UploadScanStates : CodeList {
          key code        : UploadStatusCode @Common.Text: name  @Common.TextArrangement: #TextOnly;

--- a/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
+++ b/sdm/src/test/java/unit/com/sap/cds/sdm/service/handler/SDMServiceGenericHandlerTest.java
@@ -2149,6 +2149,7 @@ public class SDMServiceGenericHandlerTest {
 
     Result draftLinksResult = mock(Result.class);
     Row draftLinkRow = mock(Row.class);
+    when(draftLinksResult.rowCount()).thenReturn(1L);
     when(draftLinksResult.iterator()).thenReturn(Arrays.asList(draftLinkRow).iterator());
     when(persistenceService.run(any(CqnSelect.class))).thenReturn(draftLinksResult);
 
@@ -2244,8 +2245,8 @@ public class SDMServiceGenericHandlerTest {
         });
 
     verify(persistenceService, times(1)).run(any(CqnSelect.class));
-    verify(tokenHandler, times(1)).getSDMCredentials();
-    verify(context, times(1)).getUserInfo();
+    verify(tokenHandler, never()).getSDMCredentials();
+    verify(context, never()).getUserInfo();
   }
 
   @Test
@@ -2266,6 +2267,7 @@ public class SDMServiceGenericHandlerTest {
 
     Result draftLinksResult = mock(Result.class);
     Row draftLinkRow = mock(Row.class);
+    when(draftLinksResult.rowCount()).thenReturn(1L);
     when(draftLinksResult.iterator()).thenReturn(Arrays.asList(draftLinkRow).iterator());
 
     when(draftLinkRow.get("ID")).thenReturn("attachment123");


### PR DESCRIPTION
## Describe your changes

1. When users discarded a draft in applications using the SDM plugin, they encountered a NoSuchElementException crash. The error originated in SDMServiceGenericHandler.java in the discard-draft revert logic, where two Optional.get() calls were made without first checking whether the Optional was present:

// Before fix — throws NoSuchElementException if entity not found in model
CdsEntity draftEntity = model.findEntity(draftEntityName).get();
CdsEntity activeEntity = model.findEntity(attachmentCompositionDefinition).get();

This happened in scenarios where the attachment composition entity (or its _drafts counterpart) was not registered in the CDS model at the time of the discard — for example in sourcing applications where the entity definition is not always available in the model. An unchecked .get() on an empty Optional throws NoSuchElementException, causing the entire discard operation to fail.

2. There was another issue which was observed , that SDM was been called on discard draft button even when there were no links present. This PR will also add a validation check for this.

3. By adding downloadSelectedAttachments to attachments.cds file we have made this feature as mandatory for all customers, so the ones who do not define leading app changes for this will face compilation issue. This PR will also fix this issue and make downloadSelectedAttachment feature as optional. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [ ] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [ ] I have tested the functionality on my cloud environment.
- [ ] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description
