### PR TITLE
Add Deploy Snapshot to Maven Central Portal workflow

### DIFF
--- a/.github/actions/deploy-central-snapshot/action.yml
+++ b/.github/actions/deploy-central-snapshot/action.yml
@@ -32,11 +32,15 @@ runs:
         server-password: CENTRAL_PASSWORD
 
     - name: "Import GPG Key (if provided)"
-      if: inputs.pgp-private-key != ''
+      if: ${{ inputs.pgp-private-key != '' }}
       run: |
-        echo "${{ inputs.pgp-private-key }}" | gpg --batch --passphrase "$PASSPHRASE" --import
-      shell: bash  
+        set +x
+        echo "::add-mask::$PGP_PRIVATE_KEY"
+        echo "::add-mask::$PASSPHRASE"
+        echo "$PGP_PRIVATE_KEY" | gpg --batch --passphrase "$PASSPHRASE" --import
+      shell: bash
       env:
+        PGP_PRIVATE_KEY: ${{ inputs.pgp-private-key }}
         PASSPHRASE: ${{ inputs.pgp-passphrase }}
 
     - name: "Verify SNAPSHOT version"
@@ -53,6 +57,11 @@ runs:
 
     - name: "Deploy Snapshot to Central Portal"
       run: |
+        set +x
+        echo "::add-mask::$CENTRAL_USER"
+        echo "::add-mask::$CENTRAL_PASSWORD"
+        [ -n "$GPG_PASSPHRASE" ] && echo "::add-mask::$GPG_PASSPHRASE"
+        [ -n "$GPG_PUB_KEY" ] && echo "::add-mask::$GPG_PUB_KEY"
         echo "🚀 Deploying SNAPSHOT to Sonatype Central Portal..."
         if [ -n "$GPG_PASSPHRASE" ] && [ -n "$GPG_PUB_KEY" ]; then
           mvn -B -ntp --show-version \

--- a/.github/actions/deploy-central-snapshot/action.yml
+++ b/.github/actions/deploy-central-snapshot/action.yml
@@ -1,0 +1,77 @@
+name: Deploy Snapshot to Central Portal
+description: "Deploys a Maven SNAPSHOT package to Sonatype Central Portal Snapshots repository."
+
+inputs:
+  user:
+    description: "Sonatype Central Portal username (same as Maven Central)"
+    required: true
+  password:
+    description: "Sonatype Central Portal password (same as Maven Central)"
+    required: true
+  pgp-pub-key:
+    description: "The public pgp key ID (optional for snapshots but recommended)"
+    required: false
+  pgp-private-key:
+    description: "The private pgp key (optional for snapshots but recommended)"
+    required: false
+  pgp-passphrase:
+    description: "The passphrase for pgp (optional for snapshots but recommended)"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: "Setup Java"
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'sapmachine'
+        java-version: '21'
+        cache: maven
+        server-id: central
+        server-username: CENTRAL_USER
+        server-password: CENTRAL_PASSWORD
+
+    - name: "Import GPG Key (if provided)"
+      if: inputs.pgp-private-key != ''
+      run: |
+        echo "${{ inputs.pgp-private-key }}" | gpg --batch --passphrase "$PASSPHRASE" --import
+      shell: bash  
+      env:
+        PASSPHRASE: ${{ inputs.pgp-passphrase }}
+
+    - name: "Verify SNAPSHOT version"
+      run: |
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "Current version: $VERSION"
+        if [[ ! "$VERSION" == *-SNAPSHOT ]]; then
+          echo "Error: Version $VERSION is not a SNAPSHOT version!"
+          echo "Central Portal Snapshots repository only accepts SNAPSHOT versions."
+          exit 1
+        fi
+        echo "✅ Version $VERSION is a valid SNAPSHOT"
+      shell: bash
+
+    - name: "Deploy Snapshot to Central Portal"
+      run: |
+        echo "🚀 Deploying SNAPSHOT to Sonatype Central Portal..."
+        if [ -n "$GPG_PASSPHRASE" ] && [ -n "$GPG_PUB_KEY" ]; then
+          mvn -B -ntp --show-version \
+            -Dmaven.install.skip=true \
+            -Dmaven.test.skip=true \
+            -Dgpg.passphrase="$GPG_PASSPHRASE" \
+            -Dgpg.keyname="$GPG_PUB_KEY" \
+            clean deploy -P deploy-central-snapshot
+        else
+          mvn -B -ntp --show-version \
+            -Dmaven.install.skip=true \
+            -Dmaven.test.skip=true \
+            -Dgpg.skip=true \
+            clean deploy -P deploy-central-snapshot
+        fi
+        echo "✅ Snapshot deployed successfully!"
+      shell: bash
+      env:
+        CENTRAL_USER: ${{ inputs.user }}
+        CENTRAL_PASSWORD: ${{ inputs.password }}
+        GPG_PASSPHRASE: ${{ inputs.pgp-passphrase }}
+        GPG_PUB_KEY: ${{ inputs.pgp-pub-key }}

--- a/.github/actions/newrelease/action.yml
+++ b/.github/actions/newrelease/action.yml
@@ -35,7 +35,7 @@ runs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git checkout -b develop
-        git add app/single-tenant/central-space/demoapp/version.txt
+        git add cap-notebook/version.txt
         git commit -am "Update version to $VERSION"
         git push --set-upstream origin develop
       shell: bash

--- a/.github/actions/newrelease/action.yml
+++ b/.github/actions/newrelease/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Update version
       run: |
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        echo $VERSION > app/single-tenant/central-space/demoapp/version.txt
+        echo $VERSION > cap-notebook/version.txt
         mvn --no-transfer-progress versions:set-property -Dproperty=revision -DnewVersion=$VERSION
         #chmod +x ensure-license.sh
         #./ensure-license.sh

--- a/.github/workflows/deploy-central-snapshot.yml
+++ b/.github/workflows/deploy-central-snapshot.yml
@@ -76,14 +76,6 @@ jobs:
           mvn clean install -P unit-tests -DskipIntegrationTests
           echo "✅ Build completed successfully!"
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: snapshot-build
-          path: .
-          include-hidden-files: true
-          retention-days: 1
-
   deploy:
     name: Deploy Snapshot to Central Portal
     runs-on: ubuntu-latest
@@ -93,11 +85,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Download artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: snapshot-build
 
       - name: Deploy Snapshot (with GPG signing)
         if: github.event.inputs.sign_artifacts != 'false'

--- a/.github/workflows/deploy-central-snapshot.yml
+++ b/.github/workflows/deploy-central-snapshot.yml
@@ -80,7 +80,7 @@ jobs:
     name: Deploy Snapshot to Central Portal
     runs-on: ubuntu-latest
     needs: [verify-snapshot, build]
-    if: needs.verify-snapshot.outputs.is_snapshot == 'true'
+    if: needs.verify-snapshot.outputs.is_snapshot == 'true' && needs.build.result == 'success'
     environment: maven-central
     steps:
       - name: Checkout
@@ -104,6 +104,7 @@ jobs:
           password: ${{ secrets.CENTRAL_REPOSITORY_PASS }}
 
       - name: Summary
+        if: success()
         run: |
           echo "## 🚀 Snapshot Deployed to Central Portal" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-central-snapshot.yml
+++ b/.github/workflows/deploy-central-snapshot.yml
@@ -1,0 +1,136 @@
+name: Deploy Snapshot to Central Portal
+
+env:
+  JAVA_VERSION: '21'
+
+on:
+  # Manual trigger - select any branch from GitHub UI
+  workflow_dispatch:
+    inputs:
+      sign_artifacts:
+        description: 'Sign artifacts with GPG'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+  # Auto-trigger on push to this feature branch
+  push:
+    branches:
+      - snapshot_maven
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  verify-snapshot:
+    runs-on: ubuntu-latest
+    outputs:
+      is_snapshot: ${{ steps.check.outputs.is_snapshot }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+
+      - name: Check version is SNAPSHOT
+        id: check
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+            echo "✅ Version $VERSION is a SNAPSHOT"
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+            echo "❌ Version $VERSION is NOT a SNAPSHOT - deployment will be skipped"
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    needs: verify-snapshot
+    if: needs.verify-snapshot.outputs.is_snapshot == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+
+      - name: Build
+        run: |
+          echo "🔨 Building SNAPSHOT version: ${{ needs.verify-snapshot.outputs.version }}"
+          mvn clean install -P unit-tests -DskipIntegrationTests
+          echo "✅ Build completed successfully!"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: snapshot-build
+          path: .
+          include-hidden-files: true
+          retention-days: 1
+
+  deploy:
+    name: Deploy Snapshot to Central Portal
+    runs-on: ubuntu-latest
+    needs: [verify-snapshot, build]
+    if: needs.verify-snapshot.outputs.is_snapshot == 'true'
+    environment: maven-central
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: snapshot-build
+
+      - name: Deploy Snapshot (with GPG signing)
+        if: github.event.inputs.sign_artifacts != 'false'
+        uses: ./.github/actions/deploy-central-snapshot
+        with:
+          user: ${{ secrets.CENTRAL_REPOSITORY_USER }}
+          password: ${{ secrets.CENTRAL_REPOSITORY_PASS }}
+          pgp-pub-key: ${{ secrets.PGP_PUB_KEY }}
+          pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
+          pgp-passphrase: ${{ secrets.PGP_PASSPHRASE }}
+
+      - name: Deploy Snapshot (without GPG signing)
+        if: github.event.inputs.sign_artifacts == 'false'
+        uses: ./.github/actions/deploy-central-snapshot
+        with:
+          user: ${{ secrets.CENTRAL_REPOSITORY_USER }}
+          password: ${{ secrets.CENTRAL_REPOSITORY_PASS }}
+
+      - name: Summary
+        run: |
+          echo "## 🚀 Snapshot Deployed to Central Portal" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ needs.verify-snapshot.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository:** https://central.sonatype.com/repository/maven-snapshots/" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Usage" >> $GITHUB_STEP_SUMMARY
+          echo '```xml' >> $GITHUB_STEP_SUMMARY
+          echo '<repositories>' >> $GITHUB_STEP_SUMMARY
+          echo '  <repository>' >> $GITHUB_STEP_SUMMARY
+          echo '    <id>central-snapshots</id>' >> $GITHUB_STEP_SUMMARY
+          echo '    <url>https://central.sonatype.com/repository/maven-snapshots/</url>' >> $GITHUB_STEP_SUMMARY
+          echo '    <snapshots><enabled>true</enabled></snapshots>' >> $GITHUB_STEP_SUMMARY
+          echo '  </repository>' >> $GITHUB_STEP_SUMMARY
+          echo '</repositories>' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-central-snapshot.yml
+++ b/.github/workflows/deploy-central-snapshot.yml
@@ -16,10 +16,6 @@ on:
           - 'true'
           - 'false'
 
-  # Auto-trigger on push to this feature branch
-  push:
-    branches:
-      - snapshot_maven
 
 permissions:
   contents: read

--- a/.github/workflows/main-build-and-deploy-oss.yml
+++ b/.github/workflows/main-build-and-deploy-oss.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
 
   update-version:
-    environment: maven-central
+    #environment: maven-central
     runs-on: ubuntu-latest
     #needs: blackduck
     steps:
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version
         uses: ./.github/actions/newrelease

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.10.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
@@ -341,6 +341,35 @@
                         <artifactId>central-publishing-maven-plugin</artifactId>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>deploy-central-snapshot</id>
+            <!-- Override distributionManagement to use Central Portal snapshots -->
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>central</id>
+                    <name>Sonatype Central Portal Snapshots</name>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                </snapshotRepository>
+                <!-- Intentionally empty to prevent accidental release deployment -->
+                <repository>
+                    <id>disabled-release</id>
+                    <url>file:///dev/null</url>
+                </repository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <deploymentType>USER_MANAGED</deploymentType>
+                            <skipExistingDeployments>true</skipExistingDeployments>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -367,9 +367,7 @@
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
                         <configuration>
-                            <publishingServerId>central</publishingServerId>
-                            <deploymentType>USER_MANAGED</deploymentType>
-                            <skipExistingDeployments>true</skipExistingDeployments>
+                            <skipPublishing>true</skipPublishing>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>false</extensions>
                         <configuration>
                             <skipPublishing>true</skipPublishing>
                         </configuration>

--- a/sdm/pom.xml
+++ b/sdm/pom.xml
@@ -98,6 +98,20 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>deploy-central-snapshot</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>central</id>
+                    <name>Sonatype Central Portal Snapshots</name>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                </snapshotRepository>
+                <repository>
+                    <id>disabled-release</id>
+                    <url>file:///dev/null</url>
+                </repository>
+            </distributionManagement>
+        </profile>
     </profiles>
 
     <dependencies>


### PR DESCRIPTION
## Describe your changes

This PR introduces a new CI workflow to deploy SNAPSHOT artifacts directly to Sonatype Central Portal Snapshots repository, enabling teams to test pre-release versions before an official release.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I follow [Java Development Guidelines for SAP](https://help.sap.com/docs/SAP_COMMERCE/531a7d44feed44f99866946a4958b679/2e2d35a17d0e4ab8a0282d660d2531c1.html?locale=en-US&version=2205)
- [ ] I have tested the functionality on my cloud environment.
- [ ] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description
